### PR TITLE
feat: zod バリデーション基盤を追加（Issue #6 PR 1/6）

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "express": "^5.2.1",
         "form-data": "^4.0.5",
         "multer": "^2.0.2",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -2142,6 +2143,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "express": "^5.2.1",
     "form-data": "^4.0.5",
     "multer": "^2.0.2",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,18 +1,86 @@
 import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
 import { ApiError } from '../types';
+import { ERROR_CODES, ErrorCode } from '../schemas/errorCodes';
 
-export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+/**
+ * Express のエラーハンドラ。
+ *
+ * 対応するエラー:
+ * - ZodError: validate ミドルウェアから来る検証失敗。
+ *   path / code から適切な ErrorCode にマッピングして 400 で返す。
+ * - { status, code, message } 形式のオブジェクト: service 層で throw される業務エラー。
+ *   status / code をそのまま使う。
+ * - その他: 500 server_error として返す。
+ *
+ * どのケースでも Notion 仕様書「API 設計書」の統一エラーフォーマット
+ * （`status` / `error` / `message`）で応答する。
+ */
+export const errorHandler = (
+    err: unknown,
+    _req: Request,
+    res: Response,
+    _next: NextFunction,
+): void => {
     console.error('Error:', err);
 
-    const status = err.status || 500;
-    const error = err.code || 'server_error';
-    const message = err.message || 'Internal server error';
+    if (err instanceof ZodError) {
+        const apiError: ApiError = {
+            status: 'error',
+            error: resolveZodErrorCode(err),
+            message: formatZodErrorMessage(err),
+        };
+        res.status(400).json(apiError);
+        return;
+    }
+
+    // 既存の { status, code, message } 形式の業務エラー
+    const legacy = err as { status?: number; code?: string; message?: string };
+    const status = legacy?.status ?? 500;
+    const code: string = legacy?.code ?? ERROR_CODES.SERVER_ERROR;
+    const message = legacy?.message ?? 'Internal server error';
 
     const apiError: ApiError = {
         status: 'error',
-        error,
+        error: code,
         message,
     };
 
     res.status(status).json(apiError);
 };
+
+/**
+ * ZodError の issue からエラーコードを決定する。
+ *
+ * - `baseline_answers` 配下のフィールドエラー → `invalid_answers`
+ *   （必須キー欠落や A-D 以外の値が該当）
+ * - `mbti` フィールドのフォーマット違反 → `invalid_mbti`
+ *   （型違反＝未指定は後段で `invalid_request` として扱う）
+ * - 上記以外 → `invalid_request`
+ */
+function resolveZodErrorCode(error: ZodError): ErrorCode {
+    const baselineAnswerIssue = error.issues.some(
+        (issue) => issue.path.length > 1 && issue.path[0] === 'baseline_answers',
+    );
+    if (baselineAnswerIssue) return ERROR_CODES.INVALID_ANSWERS;
+
+    const mbtiFormatIssue = error.issues.some(
+        (issue) => issue.path[0] === 'mbti' && issue.code !== 'invalid_type',
+    );
+    if (mbtiFormatIssue) return ERROR_CODES.INVALID_MBTI;
+
+    return ERROR_CODES.INVALID_REQUEST;
+}
+
+/**
+ * ZodError の issue 配列を人間可読な 1 行メッセージに整形する。
+ * 例: `baseline_answers.q1_caution: 回答は A / B / C / D のいずれかで指定してください`
+ */
+function formatZodErrorMessage(error: ZodError): string {
+    return error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+            return `${path}: ${issue.message}`;
+        })
+        .join('; ');
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -22,9 +22,10 @@ export const errorHandler = (
     res: Response,
     _next: NextFunction,
 ): void => {
-    console.error('Error:', err);
-
+    // ZodError（入力検証失敗）は 400 系の想定挙動なので warn、それ以外は error で記録する
     if (err instanceof ZodError) {
+        console.warn('Validation failed:', err.issues);
+
         const apiError: ApiError = {
             status: 'error',
             error: resolveZodErrorCode(err),
@@ -34,20 +35,41 @@ export const errorHandler = (
         return;
     }
 
-    // 既存の { status, code, message } 形式の業務エラー
-    const legacy = err as { status?: number; code?: string; message?: string };
-    const status = legacy?.status ?? 500;
-    const code: string = legacy?.code ?? ERROR_CODES.SERVER_ERROR;
-    const message = legacy?.message ?? 'Internal server error';
+    console.error('Error:', err);
+
+    // service 層で投げる業務エラーは { status, code, message } 形式。
+    // status と code の両方が揃っているときだけ業務エラーとして扱い、
+    // それ以外（Error インスタンスや未知オブジェクト）は 500 server_error 固定で返す。
+    // message をそのまま返してしまうと DB 由来のエラー文などの内部情報が漏れうるため。
+    if (isBusinessError(err)) {
+        const apiError: ApiError = {
+            status: 'error',
+            error: err.code,
+            message: err.message ?? 'Internal server error',
+        };
+        res.status(err.status).json(apiError);
+        return;
+    }
 
     const apiError: ApiError = {
         status: 'error',
-        error: code,
-        message,
+        error: ERROR_CODES.SERVER_ERROR,
+        message: 'Internal server error',
     };
-
-    res.status(status).json(apiError);
+    res.status(500).json(apiError);
 };
+
+/**
+ * service 層が throw する業務エラー形式か判定する。
+ * `status`（数値）と `code`（文字列）の両方が揃っていることを必須とする。
+ */
+function isBusinessError(
+    err: unknown,
+): err is { status: number; code: string; message?: string } {
+    if (typeof err !== 'object' || err === null) return false;
+    const e = err as { status?: unknown; code?: unknown };
+    return typeof e.status === 'number' && typeof e.code === 'string';
+}
 
 /**
  * ZodError の issue からエラーコードを決定する。
@@ -57,6 +79,11 @@ export const errorHandler = (
  * - `mbti` フィールドのフォーマット違反 → `invalid_mbti`
  *   （型違反＝未指定は後段で `invalid_request` として扱う）
  * - 上記以外 → `invalid_request`
+ *
+ * 注: 現状は register endpoint 向けのヒューリスティックなマッピング。
+ * 他 endpoint の validate 差し込みが進んだ段階で、スキーマ側にエラーコードの
+ * メタ情報を持たせる設計（例: .refine の params で errorCode を宣言）への
+ * 移行を検討する（Issue #6 の PR 6「仕上げ」で再評価）。
  */
 function resolveZodErrorCode(error: ZodError): ErrorCode {
     const baselineAnswerIssue = error.issues.some(

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,58 @@
+import { RequestHandler } from 'express';
+import { ZodType } from 'zod';
+
+/**
+ * validate ミドルウェアに渡す検証スキーマ。
+ * body / params / query を個別または同時に検証できる。
+ */
+export interface ValidateSchemas {
+    body?: ZodType;
+    params?: ZodType;
+    query?: ZodType;
+}
+
+/**
+ * リクエストの body / params / query を zod スキーマで検証するミドルウェア。
+ *
+ * 検証失敗時は ZodError をそのまま next() に渡し、errorHandler で仕様書通りの
+ * エラーフォーマットに変換する（status / error / message）。
+ *
+ * 検証成功時は parse 結果（transform / default 適用後の値）でリクエストを上書きする。
+ * - body: プロパティ再代入で上書き
+ * - params / query: Express 5 の getter 実装に配慮し、参照を維持したまま中身だけ差し替える
+ */
+export const validate = (schemas: ValidateSchemas): RequestHandler => {
+    return (req, _res, next) => {
+        if (schemas.body) {
+            const result = schemas.body.safeParse(req.body);
+            if (!result.success) return next(result.error);
+            req.body = result.data;
+        }
+
+        if (schemas.params) {
+            const result = schemas.params.safeParse(req.params);
+            if (!result.success) return next(result.error);
+            replaceContents(req.params as Record<string, unknown>, result.data as Record<string, unknown>);
+        }
+
+        if (schemas.query) {
+            const result = schemas.query.safeParse(req.query);
+            if (!result.success) return next(result.error);
+            replaceContents(req.query as Record<string, unknown>, result.data as Record<string, unknown>);
+        }
+
+        next();
+    };
+};
+
+/**
+ * target オブジェクトの中身を source の内容で置き換える。
+ * 参照を維持したまま差し替えるため、Express 5 で getter 経由の
+ * req.params / req.query に対しても安全に使える。
+ */
+function replaceContents(target: Record<string, unknown>, source: Record<string, unknown>): void {
+    for (const key of Object.keys(target)) {
+        delete target[key];
+    }
+    Object.assign(target, source);
+}

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -17,6 +17,10 @@ export interface ValidateSchemas {
  * 検証失敗時は ZodError をそのまま next() に渡し、errorHandler で仕様書通りの
  * エラーフォーマットに変換する（status / error / message）。
  *
+ * body / params / query を同時指定した場合は body → params → query の順に
+ * 検証し、**最初に失敗したスキーマの ZodError を返して以降は検証しない**（fail-fast）。
+ * 複数箇所のエラーを 1 回のレスポンスに集約する用途では使えない。
+ *
  * 検証成功時は parse 結果（transform / default 適用後の値）でリクエストを上書きする。
  * - body: プロパティ再代入で上書き
  * - params / query: Express 5 の getter 実装に配慮し、参照を維持したまま中身だけ差し替える

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * 複数エンドポイントで使い回す横断スキーマ。
+ *
+ * zod v4 のトップレベル API（`z.uuid()` 等）と `{ error: ... }` オプションを使用する。
+ */
+
+/** user_id（UUID 文字列） */
+export const userIdSchema = z.uuid({ error: 'user_id は UUID 形式で指定してください' });
+
+/**
+ * MBTI 形式（I/E + S/N + T/F + J/P の 4 文字）。
+ * 大文字小文字は問わない（service 層で必要に応じて正規化する）。
+ */
+export const mbtiSchema = z
+    .string({ error: 'mbti は文字列で指定してください' })
+    .regex(/^[IE][SN][TF][JP]$/i, {
+        error: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
+    });
+
+/** 基準値アンケートの回答選択肢（A/B/C/D） */
+export const answerOptionSchema = z.enum(['A', 'B', 'C', 'D'], {
+    error: '回答は A / B / C / D のいずれかで指定してください',
+});
+
+export type AnswerOption = z.infer<typeof answerOptionSchema>;

--- a/backend/src/schemas/errorCodes.ts
+++ b/backend/src/schemas/errorCodes.ts
@@ -1,0 +1,19 @@
+/**
+ * API 共通エラーコード定数。
+ *
+ * Notion 仕様書「API 設計書」の「エラーレスポンス」テーブルに定義された
+ * エラーコード文字列を集約し、型で縛って誤字や表記ゆれを防ぐ。
+ */
+export const ERROR_CODES = {
+    INVALID_REQUEST: 'invalid_request',
+    INVALID_MBTI: 'invalid_mbti',
+    INVALID_ANSWERS: 'invalid_answers',
+    INVALID_USER_ID: 'invalid_user_id',
+    INVALID_GAME_TYPE: 'invalid_game_type',
+    INCOMPLETE_GAMES: 'incomplete_games',
+    USER_NOT_FOUND: 'user_not_found',
+    DUPLICATE_SUBMISSION: 'duplicate_submission',
+    SERVER_ERROR: 'server_error',
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];


### PR DESCRIPTION
## 概要

Issue #6 を 6 分割した PR のうち PR 1「基盤整備」。zod@^4 を導入し、後続 PR で各エンドポイントに差し込むための共通基盤（エラーコード定数・共通スキーマ・validate ミドルウェア・errorHandler の ZodError 対応）を揃える。

## 変更内容

- `backend/package.json`: zod@^4.3.6 を依存に追加
- `backend/src/schemas/errorCodes.ts` を追加: API 仕様書のエラーコード文字列を定数 + union 型に集約
- `backend/src/schemas/common.ts` を追加: 横断スキーマ（`userIdSchema` = UUID / `mbtiSchema` / `answerOptionSchema` = A-D）を v4 記法で定義
- `backend/src/middleware/validate.ts` を追加: body / params / query を個別または同時に検証する共通ミドルウェア。Express 5 の getter 実装に配慮し、params / query は参照を維持したまま中身だけ差し替える
- `backend/src/middleware/errorHandler.ts` を更新: ZodError を検知して仕様書通りのフォーマットで 400 応答する分岐を追加。path から `invalid_answers` / `invalid_mbti` / `invalid_request` へマッピング。合わせて、業務エラーは `status`（number）と `code`（string）が両方揃っているときだけそのまま返し、それ以外は 500 `server_error` 固定に倒して内部 message の漏洩を防ぐよう変更

## 関連 Issue

refs #6

## 動作確認

手動で errorHandler に以下を流してレスポンス形状を確認:

| 入力 | 期待 | 結果 |
|---|---|---|
| baseline_answers 配下の値が A-D 以外の ZodError | 400 `invalid_answers` | ✅ |
| baseline_answers 自体が欠落した ZodError | 400 `invalid_request` | ✅ |
| mbti 形式違反の ZodError | 400 `invalid_mbti` | ✅ |
| `{ status: 409, code: 'duplicate_submission', message: '...' }` | 409 `duplicate_submission` | ✅ |
| `new Error('sensitive DB error...')` | 500 `server_error` / `Internal server error`（message 非露出） | ✅ |
| `null` / 文字列 / code 欠落オブジェクト | 500 `server_error`（message 非露出） | ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive request validation for bodies, params, and queries with specific format checks (user ID, MBTI, answer options).

* **Bug Fixes**
  * Validation failures now return HTTP 400 with clear, aggregated messages and specific error codes; unexpected errors return a standardized 500 response.

* **Chores**
  * Introduced a runtime validation utility to support structured request checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->