### PR TITLE
feat: register エンドポイントに zod バリデーションを導入（Issue #6 PR 2/6）

### DIFF
--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -8,7 +8,8 @@ import { ERROR_CODES, ErrorCode } from '../schemas/errorCodes';
  *
  * 対応するエラー:
  * - ZodError: validate ミドルウェアから来る検証失敗。
- *   path / code から適切な ErrorCode にマッピングして 400 で返す。
+ *   path / code から API 設計書のエラーコードへマッピングして 400 で返す
+ *   （resolveZodErrorCode 参照）。
  * - { status, code, message } 形式のオブジェクト: service 層で throw される業務エラー。
  *   status / code をそのまま使う。
  * - その他: 500 server_error として返す。
@@ -72,30 +73,40 @@ function isBusinessError(
 }
 
 /**
- * ZodError の issue からエラーコードを決定する。
+ * ZodError の issue から API 設計書のエラーコードを決定する。
  *
- * - `baseline_answers` 配下のフィールドエラー → `invalid_answers`
- *   （必須キー欠落や A-D 以外の値が該当）
- * - `mbti` フィールドのフォーマット違反 → `invalid_mbti`
- *   （型違反＝未指定は後段で `invalid_request` として扱う）
- * - 上記以外 → `invalid_request`
+ * 判定ルール（仕様書 notion-docs/api-design.md のエラーコード表に準拠）:
+ * - `mbti` フィールドの形式違反（invalid_format）→ invalid_mbti
+ * - `baseline_answers` 配下のフィールド:
+ *   - キー欠落（invalid_type）→ invalid_request
+ *   - 値違反（custom, A-D 以外）→ invalid_answers
+ * - その他（ネスト親レベルの必須欠落など）→ invalid_request
  *
- * 注: 現状は register endpoint 向けのヒューリスティックなマッピング。
- * 他 endpoint の validate 差し込みが進んだ段階で、スキーマ側にエラーコードの
- * メタ情報を持たせる設計（例: .refine の params で errorCode を宣言）への
- * 移行を検討する（Issue #6 の PR 6「仕上げ」で再評価）。
+ * 共通スキーマ（schemas/common.ts）が issue.code を区別できる形で設計されている
+ * ことを前提とする。特に answerOptionSchema は z.string().refine() を使い、
+ * 必須欠落と値違反で異なる issue.code を返すようにしている。
+ *
+ * エンドポイント（user_id / game_type 等）が増えた場合は、本関数に
+ * 対応するマッピング分岐を 1 行ずつ追加する。
  */
 function resolveZodErrorCode(error: ZodError): ErrorCode {
-    const baselineAnswerIssue = error.issues.some(
-        (issue) => issue.path.length > 1 && issue.path[0] === 'baseline_answers',
-    );
-    if (baselineAnswerIssue) return ERROR_CODES.INVALID_ANSWERS;
+    for (const issue of error.issues) {
+        const top = issue.path[0];
+        const isNested = issue.path.length > 1;
 
-    const mbtiFormatIssue = error.issues.some(
-        (issue) => issue.path[0] === 'mbti' && issue.code !== 'invalid_type',
-    );
-    if (mbtiFormatIssue) return ERROR_CODES.INVALID_MBTI;
+        // mbti フィールドの形式違反
+        if (top === 'mbti' && issue.code === 'invalid_format') {
+            return ERROR_CODES.INVALID_MBTI;
+        }
 
+        // baseline_answers 配下のフィールドエラー
+        if (top === 'baseline_answers' && isNested) {
+            // invalid_type = キー欠落（値が undefined で z.string() が弾いた）
+            if (issue.code === 'invalid_type') return ERROR_CODES.INVALID_REQUEST;
+            // それ以外（custom など）= 値違反
+            return ERROR_CODES.INVALID_ANSWERS;
+        }
+    }
     return ERROR_CODES.INVALID_REQUEST;
 }
 

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -97,6 +97,14 @@ function isBusinessError(
  *
  * エンドポイント（user_id / game_type 等）が増えた場合は、本関数に
  * 対応するマッピング分岐を 1 行ずつ追加する。
+ *
+ * 優先度制御について:
+ * 複数 issue が同時に存在する場合（例: mbti と baseline_answers の両方にエラー）、
+ * 最初にマッチした issue で即 return するため、結果は zod の issue 順序
+ * （スキーマ定義順、今回は mbti → baseline_answers）に従う。
+ * 現状のスキーマ定義順で API 設計書上も自然な優先度になっており実害はないが、
+ * 将来エンドポイントが増え明示的な優先度制御が必要になった場合は、
+ * 全 issue を走査した後に優先度リストで選ぶ方式へリファクタする。
  */
 function resolveZodErrorCode(error: ZodError): ErrorCode {
     for (const issue of error.issues) {
@@ -110,6 +118,9 @@ function resolveZodErrorCode(error: ZodError): ErrorCode {
         }
 
         // baseline_answers 配下のフィールドエラー
+        // 注: baseline_answers 自体の欠落（path が ['baseline_answers'] のみ）は
+        // isNested=false のため本分岐には入らず、ループ末尾の fallthrough で
+        // INVALID_REQUEST として扱われる（仕様書「必須フィールド欠落」に合致）。
         if (top === 'baseline_answers' && isNested) {
             // invalid_type = キー欠落 (undefined) または非文字列型違反
             // （上述の通り区別不可のため一律 invalid_request に寄せる）

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -76,15 +76,24 @@ function isBusinessError(
  * ZodError の issue から API 設計書のエラーコードを決定する。
  *
  * 判定ルール（仕様書 notion-docs/api-design.md のエラーコード表に準拠）:
- * - `mbti` フィールドの形式違反（invalid_format）→ invalid_mbti
+ * - `mbti` フィールド:
+ *   - 形式違反（invalid_format、"XXXX" 等）→ invalid_mbti
+ *   - 型違反（invalid_type、数値等）→ invalid_mbti（旧手書き実装互換）
  * - `baseline_answers` 配下のフィールド:
- *   - キー欠落（invalid_type）→ invalid_request
- *   - 値違反（custom, A-D 以外）→ invalid_answers
+ *   - キー欠落（invalid_type、値が undefined）→ invalid_request
+ *   - 値違反（custom、A-D 以外の文字列）→ invalid_answers
  * - その他（ネスト親レベルの必須欠落など）→ invalid_request
  *
  * 共通スキーマ（schemas/common.ts）が issue.code を区別できる形で設計されている
  * ことを前提とする。特に answerOptionSchema は z.string().refine() を使い、
  * 必須欠落と値違反で異なる issue.code を返すようにしている。
+ *
+ * 既知の妥協（実運用で影響なし）:
+ * - baseline_answers 配下に数値等の非文字列が来た場合、z.string() では
+ *   「キー欠落（undefined）」と「型違反」を issue.code で区別できず、
+ *   両方 invalid_type として扱われる。旧実装では後者を invalid_answers に
+ *   振り分けていたため厳密にはリグレッションだが、FE は TypeScript 型で
+ *   文字列を強制しており実運用では発生しない（明示的妥協）。
  *
  * エンドポイント（user_id / game_type 等）が増えた場合は、本関数に
  * 対応するマッピング分岐を 1 行ずつ追加する。
@@ -94,16 +103,18 @@ function resolveZodErrorCode(error: ZodError): ErrorCode {
         const top = issue.path[0];
         const isNested = issue.path.length > 1;
 
-        // mbti フィールドの形式違反
-        if (top === 'mbti' && issue.code === 'invalid_format') {
+        // mbti フィールドのエラー
+        // 形式違反 ("XXXX" 等) と型違反 (数値等) の両方を invalid_mbti に寄せる
+        if (top === 'mbti' && (issue.code === 'invalid_format' || issue.code === 'invalid_type')) {
             return ERROR_CODES.INVALID_MBTI;
         }
 
         // baseline_answers 配下のフィールドエラー
         if (top === 'baseline_answers' && isNested) {
-            // invalid_type = キー欠落（値が undefined で z.string() が弾いた）
+            // invalid_type = キー欠落 (undefined) または非文字列型違反
+            // （上述の通り区別不可のため一律 invalid_request に寄せる）
             if (issue.code === 'invalid_type') return ERROR_CODES.INVALID_REQUEST;
-            // それ以外（custom など）= 値違反
+            // それ以外（custom など）= A-D 以外の値違反
             return ERROR_CODES.INVALID_ANSWERS;
         }
     }

--- a/backend/src/routes/register.ts
+++ b/backend/src/routes/register.ts
@@ -1,19 +1,28 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { registerService } from '../services/registerService';
-import { RegisterRequest, RegisterResponse } from '../types';
+import { validate } from '../middleware/validate';
+import {
+    registerRequestSchema,
+    RegisterRequest,
+    RegisterResponse,
+} from '../schemas/register';
 
 const router = Router();
 
-router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const { mbti, baseline_answers } = req.body as RegisterRequest;
-        const userId = await registerService.registerUser(mbti, baseline_answers);
+router.post(
+    '/',
+    validate({ body: registerRequestSchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const { mbti, baseline_answers } = req.body as RegisterRequest;
+            const userId = await registerService.registerUser(mbti, baseline_answers);
 
-        const response: RegisterResponse = { user_id: userId, status: 'success' };
-        res.status(201).json(response);
-    } catch (error) {
-        next(error);
-    }
-});
+            const response: RegisterResponse = { user_id: userId, status: 'success' };
+            res.status(201).json(response);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
 
 export default router;

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -3,7 +3,14 @@ import { z } from 'zod';
 /**
  * 複数エンドポイントで使い回す横断スキーマ。
  *
- * zod v4 のトップレベル API（`z.uuid()` 等）と `{ error: ... }` オプションを使用する。
+ * 設計方針:
+ * - スキーマはリクエスト/レスポンスの「形」とメッセージのみカスタマイズする
+ * - 業務エラーコード（API 設計書の invalid_mbti / invalid_answers 等）への
+ *   マッピングは errorHandler の resolveZodErrorCode に集約する
+ *   （理由: zod v4 では error 関数の戻り値の params が issue に伝播せず、
+ *    スキーマ宣言時に業務コードを埋め込む一般的手段が存在しないため）
+ *
+ * zod v4 のトップレベル API（`z.uuid()` 等）と error オプションを使用する。
  */
 
 /** user_id（UUID 文字列） */
@@ -19,9 +26,30 @@ export const mbtiSchema = z
         error: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
     });
 
-/** 基準値アンケートの回答選択肢（A/B/C/D） */
-export const answerOptionSchema = z.enum(['A', 'B', 'C', 'D'], {
-    error: '回答は A / B / C / D のいずれかで指定してください',
-});
+/**
+ * 基準値アンケートの回答選択肢（A/B/C/D）。
+ *
+ * z.enum ではなく z.string().refine() を使う理由:
+ * - z.enum は「必須欠落（undefined）」と「値違反（A-D 以外）」を両方 invalid_value
+ *   として返すため、errorHandler 側で API 設計書のエラーコード
+ *   （invalid_request / invalid_answers）に区別してマッピングできない
+ * - z.string().refine() なら:
+ *   - 必須欠落 → z.string() の invalid_type issue
+ *   - 値違反 → refine の custom issue
+ *   と issue.code で区別可能
+ *
+ * type predicate（`val is AnswerOption`）により z.infer の型は 'A' | 'B' | 'C' | 'D' に narrowing される。
+ *
+ * OpenAPI 化（Issue #6 PR 6）の際は zod-openapi の .openapi({ enum: [...] }) で
+ * enum 情報を補う必要がある（z.string() のままだと OpenAPI 側で enum が失われるため）。
+ */
+const ANSWER_OPTIONS = ['A', 'B', 'C', 'D'] as const;
+export type AnswerOption = typeof ANSWER_OPTIONS[number];
 
-export type AnswerOption = z.infer<typeof answerOptionSchema>;
+export const answerOptionSchema = z
+    .string({ error: '回答は必須です' })
+    .refine(
+        (val): val is AnswerOption =>
+            (ANSWER_OPTIONS as readonly string[]).includes(val),
+        { error: '回答は A / B / C / D のいずれかで指定してください' },
+    );

--- a/backend/src/schemas/register.ts
+++ b/backend/src/schemas/register.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { answerOptionSchema, mbtiSchema } from './common';
+
+/**
+ * POST /api/register のスキーマ群。
+ *
+ * - 入力検証は validate ミドルウェア経由で zod に一元化
+ * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ */
+
+/**
+ * 5 軸の基準値アンケート回答（A/B/C/D）。
+ * 5 設問すべて必須。未知プロパティは zod v4 のデフォルト挙動で strip される。
+ */
+export const baselineAnswersSchema = z.object({
+    q1_caution: answerOptionSchema,
+    q2_calmness: answerOptionSchema,
+    q3_logic: answerOptionSchema,
+    q4_cooperativeness: answerOptionSchema,
+    q5_positivity: answerOptionSchema,
+});
+
+/**
+ * POST /api/register のリクエストボディ。
+ * mbti は省略・null 許容（自己診断スキップに対応）。指定された場合は MBTI 形式に従う。
+ */
+export const registerRequestSchema = z.object({
+    mbti: mbtiSchema.nullish(),
+    baseline_answers: baselineAnswersSchema,
+});
+
+/**
+ * POST /api/register のレスポンス（201 Created）。
+ */
+export const registerResponseSchema = z.object({
+    user_id: z.uuid(),
+    status: z.literal('success'),
+});
+
+export type BaselineAnswers = z.infer<typeof baselineAnswersSchema>;
+export type RegisterRequest = z.infer<typeof registerRequestSchema>;
+export type RegisterResponse = z.infer<typeof registerResponseSchema>;

--- a/backend/src/services/registerService.ts
+++ b/backend/src/services/registerService.ts
@@ -1,61 +1,46 @@
 import { v4 as uuidv4 } from 'uuid';
 import { userRepository } from '../repositories/userRepository';
 import { BaselineAnswers, BaselineScores } from '../types';
+import { AnswerOption } from '../schemas/common';
 
-// 回答 → スコア変換マップ
-const SCORE_MAP: Record<string, number> = {
+/**
+ * アンケート回答（A〜D）→ 0〜100 のスコア変換マップ。
+ * AnswerOption が A/B/C/D に縛られているため、フォールバックは不要。
+ * 中立値の 50 は意図的に省き、ユーザーに必ずどちらかへ寄った選択を求める。
+ */
+const SCORE_MAP: Record<AnswerOption, number> = {
     'A': 100, // Strongly Agree
     'B': 75,  // Agree
-    'C': 25,  // Disagree (Skip 50 to force choice)
+    'C': 25,  // Disagree
     'D': 0,   // Strongly Disagree
 };
 
 function convertAnswersToScores(answers: BaselineAnswers): BaselineScores {
-    const convert = (value: string): number => SCORE_MAP[value] ?? 50;
     return {
-        caution: convert(answers.q1_caution),
-        calmness: convert(answers.q2_calmness),
-        logic: convert(answers.q3_logic),
-        cooperativeness: convert(answers.q4_cooperativeness),
-        positivity: convert(answers.q5_positivity),
+        caution: SCORE_MAP[answers.q1_caution],
+        calmness: SCORE_MAP[answers.q2_calmness],
+        logic: SCORE_MAP[answers.q3_logic],
+        cooperativeness: SCORE_MAP[answers.q4_cooperativeness],
+        positivity: SCORE_MAP[answers.q5_positivity],
     };
 }
 
 export const registerService = {
-    async registerUser(mbti: string | null | undefined, baselineAnswers: BaselineAnswers) {
-        // バリデーション
-        if (mbti) {
-            const mbtiRegex = /^[IE][SN][TF][JP]$/i;
-            if (!mbtiRegex.test(mbti)) {
-                throw { status: 400, code: 'invalid_mbti', message: 'MBTI must be a valid 4-letter type (e.g., INTJ, ESFP)' };
-            }
-        }
-
-        if (!baselineAnswers) {
-            throw { status: 400, code: 'invalid_request', message: 'baseline_answers is required' };
-        }
-
-        const requiredKeys = ['q1_caution', 'q2_calmness', 'q3_logic', 'q4_cooperativeness', 'q5_positivity'];
-        const providedKeys = Object.keys(baselineAnswers);
-        const missingKeys = requiredKeys.filter(k => !providedKeys.includes(k));
-
-        if (missingKeys.length > 0) {
-            throw { status: 400, code: 'invalid_request', message: `Missing baseline_answers keys: ${missingKeys.join(', ')}` };
-        }
-
-        const validValues = ['A', 'B', 'C', 'D'];
-        const invalidKeys = requiredKeys.filter(k => !validValues.includes((baselineAnswers as any)[k]));
-        if (invalidKeys.length > 0) {
-            // エラーメッセージで有効な値を案内
-            throw { status: 400, code: 'invalid_answers', message: `Answers must be one of [${validValues.join(', ')}]. Invalid keys: ${invalidKeys.join(', ')}` };
-        }
-
-        // A-E → 数値に変換
+    /**
+     * ユーザーを新規作成する。
+     *
+     * リクエスト形状の検証は route 層の zod ミドルウェアで完了している前提で、
+     * ここでは A-D → スコア変換と DB 登録のみ行う。
+     */
+    async registerUser(
+        mbti: string | null | undefined,
+        baselineAnswers: BaselineAnswers,
+    ): Promise<string> {
         const baselineScores = convertAnswersToScores(baselineAnswers);
 
         const userId = uuidv4();
-        await userRepository.create(userId, mbti || null, baselineScores);
+        await userRepository.create(userId, mbti ?? null, baselineScores);
 
         return userId;
-    }
+    },
 };

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -10,25 +10,15 @@ export interface BaselineScores {
   positivity: number;
 }
 
-export type AnswerOption = 'A' | 'B' | 'C' | 'D';
+// AnswerOption は zod の answerOptionSchema から導出した型を再エクスポート
+export type { AnswerOption } from '../schemas/common';
 
-export interface BaselineAnswers {
-  q1_caution: AnswerOption;
-  q2_calmness: AnswerOption;
-  q3_logic: AnswerOption;
-  q4_cooperativeness: AnswerOption;
-  q5_positivity: AnswerOption;
-}
-
-export interface RegisterRequest {
-  mbti?: string | null; // オプショナル
-  baseline_answers: BaselineAnswers; // 必須
-}
-
-export interface RegisterResponse {
-  user_id: string; // UUID
-  status: "success";
-}
+// register エンドポイントの型は schemas/register.ts に集約済み
+export type {
+  BaselineAnswers,
+  RegisterRequest,
+  RegisterResponse,
+} from '../schemas/register';
 
 export type GameType = 1 | 2 | 3;
 


### PR DESCRIPTION
## 概要

Issue #6 の **PR 2/6**。`POST /api/register` のリクエスト/レスポンスに zod スキーマを導入し、service に散在していた手書きバリデーションを route 層に寄せる。

初回 push 後に手動動作確認でリグレッション（キー欠落時のエラーコード）が発覚したため、共通スキーマの設計見直しと errorHandler の仕様準拠マッピングを追加で修正している。

PR 1（#8）でマージ済みの基盤資産（`schemas/common.ts` / `schemas/errorCodes.ts` / `middleware/validate.ts` / ZodError 対応済みの `errorHandler.ts`）を再利用する。

## 変更内容

### register エンドポイント本体

#### `backend/src/schemas/register.ts`（新規）
- `baselineAnswersSchema`: 5 設問すべて必須、各値は `answerOptionSchema`（A/B/C/D）で縛る
- `registerRequestSchema`: `mbti` は `mbtiSchema.nullish()`（省略・null 許容）、`baseline_answers` は必須
- `registerResponseSchema`: `user_id` は UUID、`status` は `'success'` 固定
- 型は `z.infer` から導出して TS と zod の二重管理を回避

#### `backend/src/routes/register.ts`
- `validate({ body: registerRequestSchema })` をハンドラ前に差し込み
- import を `types` から `schemas/register` へ切り替え

#### `backend/src/services/registerService.ts`
- MBTI 正規表現チェック、`baseline_answers` 必須チェック、必須キー欠落チェック、A-D 値チェックの手書きバリデーションをすべて削除（zod ミドルウェアに集約）
- `SCORE_MAP` を `Record<AnswerOption, number>` に変更し、`?? 50` フォールバックを削除（zod で A-D に絞られているためデッドコード）

#### `backend/src/types/index.ts`
- `BaselineAnswers` / `RegisterRequest` / `RegisterResponse` / `AnswerOption` の元定義を削除し、`schemas/register.ts` および `schemas/common.ts` から再エクスポート

### 共通スキーマの設計見直しと仕様準拠マッピング修正

動作確認で「キー欠落が仕様書通り `invalid_request` を返さず `invalid_answers` になる」リグレッションが発覚。zod v4 の挙動を調査した結果、以下の設計に落ち着いた。

#### `backend/src/schemas/common.ts`
- `answerOptionSchema` を `z.enum` から `z.string().refine()` に変更
  - zod v4 の `z.enum` は必須欠落と値違反を両方 `invalid_value` で返すため、errorHandler 側で区別できない
  - `z.string().refine()` なら「必須欠落 → `invalid_type`」「値違反 → `custom`」と `issue.code` で区別可能
  - `type predicate` により `z.infer` の型は `'A' | 'B' | 'C' | 'D'` のままに narrowing される
- OpenAPI 化（PR 6）時は `.openapi({ enum: ['A','B','C','D'] })` で enum 情報を補う必要がある旨をコメントで明記

#### `backend/src/middleware/errorHandler.ts`
- `resolveZodErrorCode` を仕様書通りのマッピングに修正
  - `mbti` の形式違反 / 型違反 → `invalid_mbti`（旧手書き実装と互換）
  - `baseline_answers` 配下のキー欠落 → `invalid_request`
  - `baseline_answers` 配下の値違反（A-D 以外） → `invalid_answers`
  - その他 → `invalid_request`

## 動作確認

### 静的チェック
- `npx tsc --noEmit`: pass
- `npm run build`: pass

### curl による動作確認
| ケース | 入力 | 期待エラーコード | 実際 |
|---|---|---|---|
| 正常系 | 完全な body | 201（user_id 返却） | ✅ |
| mbti 形式違反 | `mbti: "XXXX"` | `invalid_mbti` | ✅ |
| mbti 型違反 | `mbti: 123` | `invalid_mbti` | ✅ |
| baseline_answers 丸ごと欠落 | body に無し | `invalid_request` | ✅ |
| キー欠落 | q4/q5 を省略 | `invalid_request` | ✅ |
| 値違反 | `q1_caution: "X"` | `invalid_answers` | ✅ |

## 明示的妥協（実運用で影響なし）

`baseline_answers` 配下に **文字列以外の値**（数値など）が送られた場合、旧手書き実装では `invalid_answers` を返していたが、本 PR では `invalid_request` に寄せている。

- 理由: zod v4 の `z.string()` では「キー欠落（undefined）」と「非文字列型違反（数値等）」を `issue.code` で区別できない
- 影響: 実運用では FE が TypeScript 型（`'A' \| 'B' \| 'C' \| 'D'`）で文字列を強制しているため発生しない
- 対応: `errorHandler.ts` 内のコメントに妥協理由と旧挙動を明記

## スコープ外（後続 PR 対応）

- `POST /api/games/submit` の zod 化（PR 3）
- `GET /api/results/:user_id` の zod 化（PR 4）
- `POST /api/voice/respond` の zod 化（PR 5）
- `GET /health` の zod 化と `types/index.ts` の最終整理 + zod-openapi 導入（PR 6）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チューニング**
  * ユーザー登録の入力検証を導入・強化しました。選択肢やMBTIの検証がより厳密になり、不正な入力を早期に検出します。
  * 登録処理のレスポンス仕様は変わらず、成功時は201で返却されます。

* **バグ修正**
  * 検証エラー時のエラーマッピングを見直し、エラーメッセージとステータスの一貫性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->