### PR TITLE
feat: games エンドポイントに zod バリデーションを導入（Issue #6 PR 3/6）

### DIFF
--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -82,6 +82,16 @@ function isBusinessError(
  * - `baseline_answers` 配下のフィールド:
  *   - キー欠落（invalid_type、値が undefined）→ invalid_request
  *   - 値違反（custom、A-D 以外の文字列）→ invalid_answers
+ * - `user_id` フィールド:
+ *   - 型違反・UUID 形式違反・キー欠落 → invalid_user_id
+ *     （mbti パターンと同じく、フィールド単位でエラーコードを寄せる方針。
+ *      旧手書き実装の「user_id が存在しない → invalid_user_id」と同じカテゴリ）
+ * - `game_type` フィールド:
+ *   - 型違反・値違反（invalid_union）・キー欠落 → invalid_game_type
+ *     （mbti パターン踏襲）
+ * - `data` フィールド（および配下）:
+ *   - 型違反・空オブジェクト違反・キー欠落 → invalid_request
+ *     （data は構造がゲームごとに異なるためフィールド固有コードを用意しない）
  * - その他（ネスト親レベルの必須欠落など）→ invalid_request
  *
  * 共通スキーマ（schemas/common.ts）が issue.code を区別できる形で設計されている
@@ -94,8 +104,11 @@ function isBusinessError(
  *   両方 invalid_type として扱われる。旧実装では後者を invalid_answers に
  *   振り分けていたため厳密にはリグレッションだが、FE は TypeScript 型で
  *   文字列を強制しており実運用では発生しない（明示的妥協）。
+ * - user_id / game_type の「キー欠落」は旧実装では invalid_request にしていたが、
+ *   フィールド単位で寄せる方針に統一したため invalid_user_id / invalid_game_type
+ *   として扱う。FE は TS 型で必須を強制しており実運用では発生しない（明示的妥協）。
  *
- * エンドポイント（user_id / game_type 等）が増えた場合は、本関数に
+ * エンドポイント（results / voice 等）が増えた場合は、本関数に
  * 対応するマッピング分岐を 1 行ずつ追加する。
  *
  * 優先度制御について:
@@ -127,6 +140,24 @@ function resolveZodErrorCode(error: ZodError): ErrorCode {
             if (issue.code === 'invalid_type') return ERROR_CODES.INVALID_REQUEST;
             // それ以外（custom など）= A-D 以外の値違反
             return ERROR_CODES.INVALID_ANSWERS;
+        }
+
+        // user_id フィールドのエラー（型違反・UUID 形式違反・キー欠落）
+        if (top === 'user_id') {
+            return ERROR_CODES.INVALID_USER_ID;
+        }
+
+        // game_type フィールドのエラー（型違反・値違反・キー欠落）
+        // z.union の値違反は issue.code = 'invalid_union' で届く
+        if (top === 'game_type') {
+            return ERROR_CODES.INVALID_GAME_TYPE;
+        }
+
+        // data フィールドのエラー（型違反・空オブジェクト違反・ネスト配下）
+        // data は構造がゲーム依存のためフィールド固有コードは持たず、
+        // すべて invalid_request に寄せる（仕様書「data が空 → 400」に合致）
+        if (top === 'data') {
+            return ERROR_CODES.INVALID_REQUEST;
         }
     }
     return ERROR_CODES.INVALID_REQUEST;

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -1,22 +1,31 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { gameService } from '../services/gameService';
-import { SubmitGameRequest, SubmitGameResponse } from '../types';
+import { validate } from '../middleware/validate';
+import {
+    submitGameRequestSchema,
+    SubmitGameRequest,
+    SubmitGameResponse,
+} from '../schemas/games';
 
 const router = Router();
 
-router.post('/submit', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const { user_id, game_type, data } = req.body as SubmitGameRequest;
-        await gameService.submitGame(user_id, game_type, data);
+router.post(
+    '/submit',
+    validate({ body: submitGameRequestSchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const { user_id, game_type, data } = req.body as SubmitGameRequest;
+            await gameService.submitGame(user_id, game_type, data);
 
-        const response: SubmitGameResponse = {
-            status: 'success',
-            message: `Game ${game_type} data saved`,
-        };
-        res.json(response);
-    } catch (error) {
-        next(error);
-    }
-});
+            const response: SubmitGameResponse = {
+                status: 'success',
+                message: `Game ${game_type} data saved`,
+            };
+            res.json(response);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
 
 export default router;

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { userIdSchema } from './common';
+import { GAME_TYPES } from '../types';
+
+/**
+ * POST /api/games/submit のスキーマ群。
+ *
+ * - 入力検証は validate ミドルウェア経由で zod に一元化
+ * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ * - 業務エラーコード（invalid_user_id / invalid_game_type 等）への
+ *   マッピングは errorHandler の resolveZodErrorCode に集約する
+ *   （schemas/common.ts の設計方針と同じ）
+ */
+
+/**
+ * ゲーム種別（1: 利用規約 / 2: AI チャット / 3: グループチャット）。
+ *
+ * types/index.ts の `GAME_TYPES` 定数を唯一の真実とし、
+ * ここではその値を z.literal に展開して zod スキーマ化する。
+ *
+ * NOTE: 現状 GAME_TYPES の値は 1/2/3 で固定のため、
+ * 明示的にリテラル配列として記述している。値を追加する際は
+ * types/index.ts と本スキーマの両方を更新すること（将来的には
+ * GAME_TYPES の値を自動展開する形にリファクタ可）。
+ */
+export const gameTypeSchema = z.union([
+    z.literal(GAME_TYPES.TERMS_GAME),
+    z.literal(GAME_TYPES.AI_CHAT),
+    z.literal(GAME_TYPES.GROUP_CHAT),
+]);
+
+/**
+ * ゲーム固有の行動データ。
+ * 構造はゲームごとに大きく異なるため、スキーマ層では空でないオブジェクトであることのみを検証する。
+ * 各ゲームの `data` 構造の検証は analysis 層の責務（別 Issue で型化予定）。
+ */
+export const gameDataSchema = z
+    .record(z.string(), z.unknown())
+    .refine((d) => Object.keys(d).length > 0, {
+        error: 'data は空オブジェクトにできません',
+    });
+
+/**
+ * POST /api/games/submit のリクエストボディ。
+ */
+export const submitGameRequestSchema = z.object({
+    user_id: userIdSchema,
+    game_type: gameTypeSchema,
+    data: gameDataSchema,
+});
+
+/**
+ * POST /api/games/submit のレスポンス（200 OK）。
+ */
+export const submitGameResponseSchema = z.object({
+    status: z.literal('success'),
+    message: z.string(),
+});
+
+export type SubmitGameRequest = z.infer<typeof submitGameRequestSchema>;
+export type SubmitGameResponse = z.infer<typeof submitGameResponseSchema>;

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -1,32 +1,28 @@
 import { userRepository } from '../repositories/userRepository';
 import { gameRepository } from '../repositories/gameRepository';
-import { GameType, GAME_TYPES } from '../types';
+import { GameType } from '../types';
+import { ERROR_CODES } from '../schemas/errorCodes';
 
 export const gameService = {
-    async submitGame(userId: string, gameType: GameType, data: Record<string, any>) {
-        // バリデーション
-        if (!userId || !gameType || !data) {
-            throw { status: 400, code: 'invalid_request', message: 'user_id, game_type, and data are required' };
-        }
-
-        if (Object.keys(data).length === 0) {
-            throw { status: 400, code: 'invalid_request', message: 'data cannot be empty' };
-        }
-
-        if (!Object.values(GAME_TYPES).includes(gameType)) {
-            throw { status: 400, code: 'invalid_game_type', message: `game_type must be one of: ${Object.values(GAME_TYPES).join(', ')}` };
-        }
-
+    /**
+     * ゲームプレイデータを保存する。
+     *
+     * リクエスト形状の検証（必須・型・game_type の範囲・data が空でないこと）は
+     * route 層の zod ミドルウェアで完了している前提。
+     * ここでは DB を参照しないと判定できない業務ルール
+     * （ユーザー存在確認・同一ゲーム重複送信）のみを行う。
+     */
+    async submitGame(userId: string, gameType: GameType, data: Record<string, unknown>) {
         // ユーザー存在確認
         const exists = await userRepository.exists(userId);
         if (!exists) {
-            throw { status: 400, code: 'invalid_user_id', message: 'User not found' };
+            throw { status: 400, code: ERROR_CODES.INVALID_USER_ID, message: 'User not found' };
         }
 
         // 重複送信チェック
         const alreadySubmitted = await gameRepository.existsLog(userId, gameType);
         if (alreadySubmitted) {
-            throw { status: 409, code: 'duplicate_submission', message: `Game ${gameType} is already submitted` };
+            throw { status: 409, code: ERROR_CODES.DUPLICATE_SUBMISSION, message: `Game ${gameType} is already submitted` };
         }
 
         // 保存

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -22,16 +22,11 @@ export type {
 
 export type GameType = 1 | 2 | 3;
 
-export interface SubmitGameRequest {
-  user_id: string;
-  game_type: GameType;
-  data: Record<string, any>;
-}
-
-export interface SubmitGameResponse {
-  status: "success" | "error";
-  message: string;
-}
+// games エンドポイントの型は schemas/games.ts に集約済み
+export type {
+  SubmitGameRequest,
+  SubmitGameResponse,
+} from '../schemas/games';
 
 export interface DiagnosisFeedback {
   title: string;


### PR DESCRIPTION
## 概要

Issue #6 の **PR 3/6**。`POST /api/games/submit` のリクエスト/レスポンスに zod スキーマを導入し、service に散在していた手書きバリデーションを route 層に寄せる。

PR 1（#8）でマージ済みの基盤資産（`schemas/common.ts` / `schemas/errorCodes.ts` / `middleware/validate.ts` / ZodError 対応済みの `errorHandler.ts`）と、PR 2（#9）で確立した register の実装パターンを踏襲する。

## 変更内容

### games エンドポイント本体

#### `backend/src/schemas/games.ts`（新規）
- `gameTypeSchema`: `z.union([z.literal(1), z.literal(2), z.literal(3)])` を `GAME_TYPES` 定数から展開
- `gameDataSchema`: `z.record(z.string(), z.unknown()).refine(d => Object.keys(d).length > 0)` で「空オブジェクト不可」を担保
- `submitGameRequestSchema`: `user_id` は共通 `userIdSchema`（UUID）を再利用、`game_type` / `data` は上記
- `submitGameResponseSchema`: `status: 'success'`、`message: string`
- 型は `z.infer` から導出

#### `backend/src/routes/games.ts`
- `validate({ body: submitGameRequestSchema })` をハンドラ前に差し込み
- import を `types` から `schemas/games` へ切り替え

#### `backend/src/services/gameService.ts`
- 必須・型・`game_type` の範囲・`data` が空でないことの手書きバリデーションをすべて削除（zod ミドルウェアに集約）
- DB 依存の業務ルール（ユーザー存在確認 → `invalid_user_id`、重複送信 → `duplicate_submission`）のみ残す
- エラーコードを `ERROR_CODES` 定数経由に変更（文字列ハードコードを排除）
- 第 3 引数の型を `Record<string, any>` → `Record<string, unknown>` に（`any` 禁止ルール対応）

#### `backend/src/types/index.ts`
- `SubmitGameRequest` / `SubmitGameResponse` の元定義を削除し、`schemas/games.ts` から再エクスポート

### エラーコードマッピング拡張

#### `backend/src/middleware/errorHandler.ts`
- `resolveZodErrorCode` に以下の分岐を追加:
  - `user_id`（型違反・UUID 形式違反・キー欠落）→ `invalid_user_id`
  - `game_type`（型違反・値違反 `invalid_union`・キー欠落）→ `invalid_game_type`
  - `data`（型違反・空オブジェクト違反・ネスト配下）→ `invalid_request`
- 方針は PR 2 の mbti と同じく「フィールド単位でエラーコードを寄せる」

## 注意点（既知の妥協）

旧手書き実装では `user_id` / `game_type` の **キー欠落を `invalid_request`** にしていたが、本 PR では mbti パターンに合わせて **`invalid_user_id` / `invalid_game_type`** に寄せている。

- 背景: zod v4 ではトップレベル必須フィールドで「キー欠落（undefined）」と「型違反」の両方が `invalid_type` で届き、issue.code で確実に区別できない。PR 2 の mbti も同様の方針で寄せており、一貫性を優先
- 実運用への影響: FE は TS 型で必須を強制するため、このケースは発生しない

仕様書（api-design.md「必須フィールド欠落 → invalid_request」）との厳密な整合は将来的なリファクタ課題。

## 動作確認

- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 通過
- [ ] 手動 curl でエラーコードが仕様書通り返ることの確認（マージ前に動作確認予定）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ゲーム送信APIのエラーメッセージング精度を向上し、`user_id`、`game_type`、`data`フィールドに関する具体的なエラーコードを実装。

* **Chores**
  * リクエスト検証ロジックを再構成し、ルート層で一元管理。
  * ユーザー向けの型定義を統一。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->