### PR TITLE
feat: GET /api/results/:user_id の zod バリデーションを導入

### DIFF
--- a/backend/src/routes/results.ts
+++ b/backend/src/routes/results.ts
@@ -12,9 +12,13 @@ const router = Router();
 router.get(
     '/:user_id',
     validate({ params: resultsParamsSchema }),
-    async (req: Request, res: Response, next: NextFunction) => {
+    async (
+        req: Request<ResultsParams>,
+        res: Response,
+        next: NextFunction,
+    ) => {
         try {
-            const { user_id } = req.params as unknown as ResultsParams;
+            const { user_id } = req.params;
             const result: ResultResponse = await resultService.getResult(user_id);
 
             res.json(result);

--- a/backend/src/routes/results.ts
+++ b/backend/src/routes/results.ts
@@ -1,17 +1,27 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { resultService } from '../services/resultService';
+import { validate } from '../middleware/validate';
+import {
+    resultsParamsSchema,
+    ResultsParams,
+    ResultResponse,
+} from '../schemas/results';
 
 const router = Router();
 
-router.get('/:user_id', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const userId = req.params.user_id as string;
-        const result = await resultService.getResult(userId);
+router.get(
+    '/:user_id',
+    validate({ params: resultsParamsSchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const { user_id } = req.params as unknown as ResultsParams;
+            const result: ResultResponse = await resultService.getResult(user_id);
 
-        res.json(result);
-    } catch (error) {
-        next(error);
-    }
-});
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    },
+);
 
 export default router;

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -55,16 +55,41 @@ export const answerOptionSchema = z
     );
 
 /**
+ * 5 軸各軸のスコア値（0-100 の正値）。
+ * baseline_scores / scores / mbti_scores の各軸で共通利用する。
+ */
+const boundedScoreSchema = z.number().min(0).max(100);
+
+/**
  * 5 軸スコア（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）。
  *
- * 本スキーマは以下のいずれの用途にも再利用する:
- * - baseline_scores / scores / mbti_scores（0-100 の正値）
- * - gaps（実測 - 自己申告の差分。負値を取りうる）
+ * 用途: baseline_scores / scores / mbti_scores（0-100 の正値）
+ * gaps は負値を取りうるため別途 `gapScoresSchema` を用意する。
  *
- * そのため範囲制約（min/max）は付けず `z.number()` とする。
- * 型は既存の `BaselineScores` interface と構造的に同一になる。
+ * 範囲制約を付ける理由:
+ * - 仕様書「API 設計書」で各軸は 0-100 と明示されている
+ * - Issue #5（OpenAPI 化）で zod スキーマを API 仕様に流用するため、
+ *   制約をスキーマに乗せておくと OpenAPI の number/minimum/maximum に反映される
+ * - `z.infer` の結果型は `number` のままで既存コードへの影響はない
+ *   （`.min/.max` はランタイム検証にのみ作用）
  */
 export const baselineScoresSchema = z.object({
+    caution: boundedScoreSchema,
+    calmness: boundedScoreSchema,
+    logic: boundedScoreSchema,
+    cooperativeness: boundedScoreSchema,
+    positivity: boundedScoreSchema,
+});
+
+export type BaselineScores = z.infer<typeof baselineScoresSchema>;
+
+/**
+ * 5 軸ギャップ（実測 - 自己申告の差分）。
+ *
+ * `baselineScoresSchema` と構造は同一だが、負値を取りうるため
+ * 範囲制約（0-100）を付けない別スキーマとして分離している。
+ */
+export const gapScoresSchema = z.object({
     caution: z.number(),
     calmness: z.number(),
     logic: z.number(),
@@ -72,4 +97,4 @@ export const baselineScoresSchema = z.object({
     positivity: z.number(),
 });
 
-export type BaselineScores = z.infer<typeof baselineScoresSchema>;
+export type GapScores = z.infer<typeof gapScoresSchema>;

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -55,10 +55,14 @@ export const answerOptionSchema = z
     );
 
 /**
- * 5 軸各軸のスコア値（0-100 の正値）。
+ * 5 軸各軸のスコア値（0-100 の整数）。
  * baseline_scores / scores / mbti_scores の各軸で共通利用する。
+ *
+ * 整数制約を付ける理由:
+ * - 仕様書「DB 設計書」で baseline_* / score_* カラムはすべて `INT` 型
+ * - 値の生成経路はすべて `Math.round` または整数定数のため常に整数
  */
-const boundedScoreSchema = z.number().min(0).max(100);
+const boundedScoreSchema = z.number().int().min(0).max(100);
 
 /**
  * 5 軸スコア（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）。
@@ -88,13 +92,14 @@ export type BaselineScores = z.infer<typeof baselineScoresSchema>;
  *
  * `baselineScoresSchema` と構造は同一だが、負値を取りうるため
  * 範囲制約（0-100）を付けない別スキーマとして分離している。
+ * 整数制約は維持する（仕様書「DB 設計書」で gap_* カラムは `INT` 型）。
  */
 export const gapScoresSchema = z.object({
-    caution: z.number(),
-    calmness: z.number(),
-    logic: z.number(),
-    cooperativeness: z.number(),
-    positivity: z.number(),
+    caution: z.number().int(),
+    calmness: z.number().int(),
+    logic: z.number().int(),
+    cooperativeness: z.number().int(),
+    positivity: z.number().int(),
 });
 
 export type GapScores = z.infer<typeof gapScoresSchema>;

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -53,3 +53,23 @@ export const answerOptionSchema = z
             (ANSWER_OPTIONS as readonly string[]).includes(val),
         { error: '回答は A / B / C / D のいずれかで指定してください' },
     );
+
+/**
+ * 5 軸スコア（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）。
+ *
+ * 本スキーマは以下のいずれの用途にも再利用する:
+ * - baseline_scores / scores / mbti_scores（0-100 の正値）
+ * - gaps（実測 - 自己申告の差分。負値を取りうる）
+ *
+ * そのため範囲制約（min/max）は付けず `z.number()` とする。
+ * 型は既存の `BaselineScores` interface と構造的に同一になる。
+ */
+export const baselineScoresSchema = z.object({
+    caution: z.number(),
+    calmness: z.number(),
+    logic: z.number(),
+    cooperativeness: z.number(),
+    positivity: z.number(),
+});
+
+export type BaselineScores = z.infer<typeof baselineScoresSchema>;

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
     baselineScoresSchema,
+    gapScoresSchema,
     mbtiSchema,
     userIdSchema,
 } from './common';
@@ -84,7 +85,7 @@ export const resultsResponseSchema = z.object({
     mbti_scores: baselineScoresSchema.nullable(),
     scores: baselineScoresSchema,
     baseline_scores: baselineScoresSchema,
-    gaps: baselineScoresSchema,
+    gaps: gapScoresSchema,
     game_breakdown: gameBreakdownSchema,
     feedback: diagnosisFeedbackSchema,
     accuracy_score: z.number(),

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -79,7 +79,7 @@ export const phaseSummariesSchema = z.object({
  *   （Issue #6 の実装計画「論点」参照）
  */
 export const resultsResponseSchema = z.object({
-    user_id: z.string(),
+    user_id: userIdSchema,
     self_mbti: mbtiSchema.nullable(),
     mbti_scores: baselineScoresSchema.nullable(),
     scores: baselineScoresSchema,

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -32,14 +32,11 @@ export const resultsParamsSchema = z.object({
  *
  * ゲームごとにどの軸を測るかが異なるため（例: game_1 は caution/logic/calmness のみ）、
  * Partial 相当として各軸を optional にしている。
+ *
+ * `baselineScoresSchema.partial()` を使うことで、キー定義の単一ソース化と
+ * 0-100 の範囲制約の継承を同時に実現している。
  */
-const partialBaselineScoresSchema = z.object({
-    caution: z.number().optional(),
-    calmness: z.number().optional(),
-    logic: z.number().optional(),
-    cooperativeness: z.number().optional(),
-    positivity: z.number().optional(),
-});
+const partialBaselineScoresSchema = baselineScoresSchema.partial();
 
 /**
  * ゲームごとのスコア内訳。

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import {
+    baselineScoresSchema,
+    mbtiSchema,
+    userIdSchema,
+} from './common';
+
+/**
+ * GET /api/results/:user_id のスキーマ群。
+ *
+ * - 入力検証は validate ミドルウェア経由で zod に一元化
+ * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ * - 業務エラーコード（invalid_user_id / user_not_found / incomplete_games 等）の
+ *   マッピングは errorHandler の resolveZodErrorCode / isBusinessError に集約する
+ *   （schemas/common.ts の設計方針と同じ）
+ */
+
+/**
+ * パスパラメータ。user_id は UUID 文字列。
+ *
+ * 共通スキーマの `userIdSchema`（UUID 検証）をそのまま利用する。
+ * errorHandler 側で path[0] === 'user_id' のエラーは `invalid_user_id` に
+ * マッピング済みのため、検証失敗時の業務コードも仕様書準拠となる。
+ */
+export const resultsParamsSchema = z.object({
+    user_id: userIdSchema,
+});
+
+/**
+ * 5 軸各軸ごとのスコアを optional にした構造。
+ *
+ * ゲームごとにどの軸を測るかが異なるため（例: game_1 は caution/logic/calmness のみ）、
+ * Partial 相当として各軸を optional にしている。
+ */
+const partialBaselineScoresSchema = z.object({
+    caution: z.number().optional(),
+    calmness: z.number().optional(),
+    logic: z.number().optional(),
+    cooperativeness: z.number().optional(),
+    positivity: z.number().optional(),
+});
+
+/**
+ * ゲームごとのスコア内訳。
+ * 各ゲームキー（game_1 / game_2 / game_3）は optional。
+ */
+export const gameBreakdownSchema = z.object({
+    game_1: partialBaselineScoresSchema.optional(),
+    game_2: partialBaselineScoresSchema.optional(),
+    game_3: partialBaselineScoresSchema.optional(),
+});
+
+/**
+ * 診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）。
+ */
+export const diagnosisFeedbackSchema = z.object({
+    title: z.string(),
+    description: z.string(),
+    gap_point: z.string(),
+});
+
+/**
+ * 各フェーズ（ゲーム）の振り返りテキスト。
+ */
+export const phaseSummariesSchema = z.object({
+    phase_1: z.string(),
+    phase_2: z.string(),
+    phase_3: z.string(),
+});
+
+/**
+ * GET /api/results/:user_id のレスポンス（200 OK）。
+ *
+ * `details` について（暫定定義）:
+ * - 本フィールドは各ゲーム固有のメトリクスと特徴スコアを含み、構造が広く
+ *   analysis 層（scoreCalculator.ts）の戻り値構造に直接依存する
+ * - 現時点では `z.unknown()` とし、FE 側は既存の型定義に従って参照する
+ * - 厳密化は analysis 戻り値の構造を固めてから別 Issue で対応する
+ *   （Issue #6 の実装計画「論点」参照）
+ */
+export const resultsResponseSchema = z.object({
+    user_id: z.string(),
+    self_mbti: mbtiSchema.nullable(),
+    mbti_scores: baselineScoresSchema.nullable(),
+    scores: baselineScoresSchema,
+    baseline_scores: baselineScoresSchema,
+    gaps: baselineScoresSchema,
+    game_breakdown: gameBreakdownSchema,
+    feedback: diagnosisFeedbackSchema,
+    accuracy_score: z.number(),
+    phase_summaries: phaseSummariesSchema,
+    details: z.unknown(),
+});
+
+export type ResultsParams = z.infer<typeof resultsParamsSchema>;
+export type GameBreakdown = z.infer<typeof gameBreakdownSchema>;
+export type DiagnosisFeedback = z.infer<typeof diagnosisFeedbackSchema>;
+export type PhaseSummaries = z.infer<typeof phaseSummariesSchema>;
+export type ResultResponse = z.infer<typeof resultsResponseSchema>;

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -85,7 +85,7 @@ export const resultsResponseSchema = z.object({
     gaps: gapScoresSchema,
     game_breakdown: gameBreakdownSchema,
     feedback: diagnosisFeedbackSchema,
-    accuracy_score: z.number(),
+    accuracy_score: z.number().int().min(0).max(100),
     phase_summaries: phaseSummariesSchema,
     details: z.unknown(),
 });

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -2,13 +2,8 @@
 // API Request/Response型
 // ========================================
 
-export interface BaselineScores {
-  caution: number; // 0-100
-  calmness: number;
-  logic: number;
-  cooperativeness: number;
-  positivity: number;
-}
+// BaselineScores は schemas/common.ts の baselineScoresSchema から導出した型を再エクスポート
+export type { BaselineScores } from '../schemas/common';
 
 // AnswerOption は zod の answerOptionSchema から導出した型を再エクスポート
 export type { AnswerOption } from '../schemas/common';
@@ -28,37 +23,13 @@ export type {
   SubmitGameResponse,
 } from '../schemas/games';
 
-export interface DiagnosisFeedback {
-  title: string;
-  description: string;
-  gap_point: string;
-}
-
-export interface GameBreakdown {
-  game_1?: Partial<BaselineScores>;
-  game_2?: Partial<BaselineScores>;
-  game_3?: Partial<BaselineScores>;
-}
-
-export interface PhaseSummaries {
-  phase_1: string; // 利用規約での行動サマリー
-  phase_2: string; // カスタマーサポートでの行動サマリー
-  phase_3: string; // グループチャットでの行動サマリー
-}
-
-export interface ResultResponse {
-  user_id: string;
-  self_mbti: string | null;
-  mbti_scores: BaselineScores | null; // MBTI理論値スコア（スキップ時はnull）
-  scores: BaselineScores; // 実測スコア
-  baseline_scores: BaselineScores; // 自己申告スコア
-  gaps: BaselineScores; // 差分
-  game_breakdown: GameBreakdown;
-  feedback: DiagnosisFeedback;
-  accuracy_score: number; // 自己認識精度（0-100）
-  phase_summaries: PhaseSummaries; // 各フェーズの振り返りテキスト
-  details: any; // 各ゲームごとの詳細メトリクスと特徴スコア
-}
+// results エンドポイントの型は schemas/results.ts に集約済み
+export type {
+  DiagnosisFeedback,
+  GameBreakdown,
+  PhaseSummaries,
+  ResultResponse,
+} from '../schemas/results';
 
 export interface ApiError {
   status: "error";


### PR DESCRIPTION
## 概要

Issue #6（zod 導入）の PR 4。`GET /api/results/:user_id` に zod バリデーションを差し込み、TS 型を zod スキーマから導出する。

refs #6

## 変更内容

### `schemas/common.ts`
- `baselineScoresSchema` を追加
  - `baseline_scores` / `scores` / `mbti_scores` / `gaps` の 4 用途で共通利用
  - gaps は負値を取りうるため範囲制約（min/max）は付けない

### `schemas/results.ts`（新規）
- `resultsParamsSchema`: `user_id` を `userIdSchema`（UUID）で検証
- `resultsResponseSchema`: 仕様書「API 設計書」通りの構造
  - `self_mbti` / `mbti_scores` は nullable
  - `details` は `z.unknown()` で暫定定義（analysis 戻り値の厳密化は別 Issue）
- `partialBaselineScoresSchema`: `game_breakdown` 配下の各軸 optional 化

### `routes/results.ts`
- `validate({ params: resultsParamsSchema })` を差し込み
- ハンドラ型を `Request<ResultsParams>` に変更し、`req.params` を型安全に取り出す
- 業務エラー（`user_not_found` / `incomplete_games`）は service 層のまま維持

### `types/index.ts`
- `BaselineScores` / `DiagnosisFeedback` / `GameBreakdown` / `PhaseSummaries` / `ResultResponse` を zod 由来型の再エクスポートに差し替え
- `details: any` のルール違反を解消（`z.unknown()` 由来の `unknown` に）
- 既存の services / repositories / analysis からの参照は構造的に互換のため変更不要

## 検証

### バリデーション挙動
- 不正な UUID → `400 invalid_user_id`（errorHandler の user_id マッピング）
- 未登録 user_id → `404 user_not_found`（service 層、既存挙動）
- ゲーム未完了 → `400 incomplete_games`（service 層、既存挙動）

### PR 前チェック
- `npx tsc --noEmit` ✅
- `npm run build` ✅

## スコープ外

- `details` フィールドの厳密な型化（別 Issue で提案）
- PR 5（voice）/ PR 6（health + 仕上げ）
- `types/index.ts` の `GameLog.raw_data: any` 等 DB 型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * リクエストパラメータ検証を導入し、エンドポイントへの不正入力を早期に検出するように改善。
  * 結果レスポンスのスキーマを追加し、APIの応答構造が明確に定義されました。

* **Refactor**
  * 基本スコアやギャップスコア等の型定義をスキーマ化して再配置し、型管理を一元化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->