### PR TITLE
feat: voice エンドポイントに zod バリデーションを導入（Issue #6 PR 5/6）

### DIFF
--- a/backend/src/routes/voice.ts
+++ b/backend/src/routes/voice.ts
@@ -1,33 +1,49 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { voiceService } from '../services/voiceService';
 import { userRepository } from '../repositories/userRepository';
+import { validate } from '../middleware/validate';
+import {
+    voiceRespondRequestSchema,
+    VoiceRespondRequest,
+    VoiceRespondResponse,
+} from '../schemas/voice';
 
 const router = Router();
 
-router.post('/respond', async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const { user_id, message, conversation_history } = req.body;
+router.post(
+    '/respond',
+    validate({ body: voiceRespondRequestSchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const { user_id, message, conversation_history } =
+                req.body as VoiceRespondRequest;
 
-        if (!user_id) {
-            throw { status: 400, code: 'invalid_request', message: 'user_id is required' };
+            // user_id の存在確認は DB 参照が必要なため route 層に残す
+            // （形式検証は zod 側で済ませている）
+            const exists = await userRepository.exists(user_id);
+            if (!exists) {
+                throw {
+                    status: 400,
+                    code: 'invalid_user_id',
+                    message: 'ユーザーIDが存在しません',
+                };
+            }
+
+            const result = await voiceService.generateAiResponse(
+                message,
+                conversation_history,
+            );
+
+            const response: VoiceRespondResponse = {
+                response: result.response,
+                emotion: result.emotion,
+                confidence: result.confidence,
+            };
+            res.json(response);
+        } catch (error) {
+            next(error);
         }
-
-        const exists = await userRepository.exists(user_id);
-        if (!exists) {
-            throw { status: 400, code: 'invalid_user_id', message: 'ユーザーIDが存在しません' };
-        }
-
-        const result = await voiceService.generateAiResponse(message, conversation_history);
-
-        res.json({
-            response: result.response,
-            emotion: result.emotion,
-            confidence: result.confidence,
-        });
-    } catch (error) {
-        next(error);
-    }
-});
+    },
+);
 
 export default router;
-

--- a/backend/src/schemas/voice.ts
+++ b/backend/src/schemas/voice.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import { userIdSchema } from './common';
+
+/**
+ * POST /api/voice/respond のスキーマ群。
+ *
+ * - 入力検証は validate ミドルウェア経由で zod に一元化
+ * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ * - 業務エラーコード（invalid_user_id / invalid_request）への
+ *   マッピングは errorHandler の resolveZodErrorCode に集約する
+ *   （schemas/common.ts の設計方針と同じ）
+ */
+
+/**
+ * 会話履歴の 1 メッセージ。role は Gemini API の慣例に合わせて
+ * 'user' / 'assistant' のみ許可する（system は別枠で扱うため含めない）。
+ */
+export const conversationMessageSchema = z.object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string(),
+});
+
+/**
+ * POST /api/voice/respond のリクエストボディ。
+ *
+ * - `message` は仕様書で「空文字不可」のため `.min(1)` を付ける
+ * - `conversation_history` は任意。未指定時は service 層で空配列扱い
+ */
+export const voiceRespondRequestSchema = z.object({
+    user_id: userIdSchema,
+    message: z
+        .string({ error: 'message は文字列で指定してください' })
+        .min(1, { error: 'message は空文字にできません' }),
+    conversation_history: z.array(conversationMessageSchema).optional(),
+});
+
+/**
+ * 応答の感情ラベル。
+ *
+ * 仕様書「API 設計書」で 4 種（confident / apologetic / confused / neutral）に列挙されており、
+ * 実装側（voiceService.estimateEmotion と fallbackData）も同 4 種のみを返す。
+ * enum 化により Issue #5（OpenAPI 化）でも enum 情報をそのまま活用できる。
+ */
+export const voiceEmotionSchema = z.enum([
+    'confident',
+    'apologetic',
+    'confused',
+    'neutral',
+]);
+
+/**
+ * POST /api/voice/respond のレスポンス（200 OK）。
+ *
+ * `confidence` は仕様書で Gemini 成功時 0.6 / フォールバック 0.2-0.3 と規定されているため
+ * 0-1 の範囲制約を付ける（範囲違反は実装バグなのでランタイム検証目的ではなく
+ * 将来の OpenAPI の minimum/maximum 反映を見越した制約）。
+ */
+export const voiceRespondResponseSchema = z.object({
+    response: z.string(),
+    emotion: voiceEmotionSchema,
+    confidence: z.number().min(0).max(1),
+});
+
+export type ConversationMessage = z.infer<typeof conversationMessageSchema>;
+export type VoiceEmotion = z.infer<typeof voiceEmotionSchema>;
+export type VoiceRespondRequest = z.infer<typeof voiceRespondRequestSchema>;
+export type VoiceRespondResponse = z.infer<typeof voiceRespondResponseSchema>;

--- a/backend/src/services/fallbackData.ts
+++ b/backend/src/services/fallbackData.ts
@@ -9,9 +9,11 @@
  * ラリー3: ユーザーが諦める・怒る・別手段を探す
  */
 
+import { VoiceEmotion } from '../schemas/voice';
+
 export interface FallbackEntry {
   keywords: string[];
-  responses: Array<{ response: string; emotion: string }>;
+  responses: Array<{ response: string; emotion: VoiceEmotion }>;
 }
 
 export const FALLBACK_TABLE: FallbackEntry[] = [
@@ -164,7 +166,7 @@ export const FALLBACK_TABLE: FallbackEntry[] = [
   },
 ];
 
-export const DEFAULT_RESPONSES: Array<{ response: string; emotion: string }> = [
+export const DEFAULT_RESPONSES: Array<{ response: string; emotion: VoiceEmotion }> = [
   { response: 'なるほど、少々お待ちください。今確認しております。', emotion: 'confused' },
   { response: 'ご状況は承りました。弊社のご案内ページをご確認いただけますでしょうか。', emotion: 'confident' },
   { response: 'そのお問い合わせは担当者が対応いたします。', emotion: 'apologetic' },

--- a/backend/src/services/fallbackService.ts
+++ b/backend/src/services/fallbackService.ts
@@ -4,12 +4,14 @@
  */
 
 import { FALLBACK_TABLE, DEFAULT_RESPONSES } from './fallbackData';
+import { VoiceRespondResponse } from '../schemas/voice';
 
-export interface FallbackResponse {
-  response: string;
-  emotion: string;
-  confidence: number;
-}
+/**
+ * フォールバック返答の型。
+ * voice API の外向きレスポンス型（VoiceRespondResponse）と完全一致させ、
+ * voiceService 側で型アサーションなしでそのまま返せるようにしている。
+ */
+export type FallbackResponse = VoiceRespondResponse;
 
 /**
  * メッセージのキーワードをもとにフォールバック返答を返す。

--- a/backend/src/services/voiceService.ts
+++ b/backend/src/services/voiceService.ts
@@ -6,6 +6,13 @@
  * 2. 失敗時はエラーをスロー（モック/フォールバックは使用しない）
  */
 
+import {
+    ConversationMessage,
+    VoiceEmotion,
+    VoiceRespondResponse,
+} from '../schemas/voice';
+import { getKeywordFallback } from './fallbackService';
+
 const GEMINI_TIMEOUT_MS = 5000;
 
 // プロンプトは短く・速く
@@ -13,18 +20,7 @@ const SYSTEM_PROMPT = `あなたはカスタマーサポート担当です。少
 
 const PRIMARY_MODEL = 'gemini-2.0-flash-lite';
 
-interface ConversationMessage {
-    role: 'user' | 'assistant';
-    content: string;
-}
-
-interface VoiceResponse {
-    response: string;
-    emotion: string;
-    confidence: number;
-}
-
-function estimateEmotion(text: string): string {
+function estimateEmotion(text: string): VoiceEmotion {
     if (text.includes('多分') || text.includes('思います') || text.includes('かも')) return 'confused';
     if (text.includes('ありがとう') || text.includes('承りました')) return 'confident';
     if (text.includes('すみません') || text.includes('申し訳')) return 'apologetic';
@@ -40,7 +36,7 @@ async function requestToModel(
     contents: any[],
     apiKey: string,
     signal: AbortSignal,
-): Promise<VoiceResponse> {
+): Promise<VoiceRespondResponse> {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${apiKey}`;
 
     const response = await fetch(url, {
@@ -78,7 +74,7 @@ async function callGeminiSequential(
     message: string,
     conversationHistory: ConversationMessage[],
     apiKey: string,
-): Promise<VoiceResponse> {
+): Promise<VoiceRespondResponse> {
     // 会話履歴は直近1件のみ（速度優先）
     const recentHistory = conversationHistory.slice(-1);
     const contents: any[] = [];
@@ -110,17 +106,12 @@ async function callGeminiSequential(
 // メインの voiceService
 // ============================
 
-import { getKeywordFallback } from './fallbackService';
-
 export const voiceService = {
     async generateAiResponse(
         message: string,
         conversationHistory?: ConversationMessage[],
-    ): Promise<VoiceResponse> {
-        if (!message) {
-            throw { status: 400, code: 'invalid_request', message: 'message is required' };
-        }
-
+    ): Promise<VoiceRespondResponse> {
+        // message の必須・空文字チェックは route 層の zod スキーマに一元化済み
         const apiKey = process.env.GEMINI_API_KEY;
 
         if (!apiKey) {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -31,6 +31,14 @@ export type {
   ResultResponse,
 } from '../schemas/results';
 
+// voice エンドポイントの型は schemas/voice.ts に集約済み
+export type {
+  ConversationMessage,
+  VoiceEmotion,
+  VoiceRespondRequest,
+  VoiceRespondResponse,
+} from '../schemas/voice';
+
 export interface ApiError {
   status: "error";
   error: string;


### PR DESCRIPTION
## 概要

Issue #6 の実装計画 PR 5/6 として、`POST /api/voice/respond` に zod バリデーションを導入する。

refs #6

## 変更内容

### 新規

- `backend/src/schemas/voice.ts`
  - `voiceRespondRequestSchema`: `user_id`（共通 `userIdSchema`）/ `message`（空文字不可）/ `conversation_history`（optional）
  - `conversationMessageSchema`: `role` は `z.enum(['user', 'assistant'])`
  - `voiceEmotionSchema`: 仕様書に列挙された 4 種（confident / apologetic / confused / neutral）を `z.enum`
  - `voiceRespondResponseSchema`: レスポンス型。`confidence` に 0-1 範囲制約
  - 型は `z.infer` から導出

### 変更

- `backend/src/routes/voice.ts`
  - `validate({ body: voiceRespondRequestSchema })` を差し込み
  - 手書きの `user_id` 必須チェックを削除（zod に移譲）
  - `userRepository.exists()` による DB 存在確認は route に残す
- `backend/src/services/voiceService.ts`
  - 冒頭の `if (!message)` 手書きチェックを削除（zod に移譲）
  - 内部 `ConversationMessage` / `VoiceResponse` interface を schemas 由来型へ置き換え
  - `estimateEmotion` の戻り値型を `string` → `VoiceEmotion` に narrow
- `backend/src/services/fallbackService.ts`
  - `FallbackResponse` 型を `VoiceRespondResponse` のエイリアスに変更（voice API の戻り値と構造的に完全一致）
- `backend/src/services/fallbackData.ts`
  - `emotion` 型を `string` → `VoiceEmotion` に narrow
- `backend/src/types/index.ts`
  - voice 系型（`ConversationMessage` / `VoiceEmotion` / `VoiceRespondRequest` / `VoiceRespondResponse`）を再エクスポート

## fallback 周りの扱いについて

実装計画の「やらないこと」に「fallbackData.ts など分析ロジック内部データの **zod 化**」と記載があるが、本 PR では zod スキーマによるランタイム検証は導入していない。voiceService の戻り値型を schemas 由来の `VoiceRespondResponse` に統一する過程で、`getKeywordFallback` の戻り値型も chain 上 narrow が必要になったため、fallbackData / fallbackService の `emotion` を TS 型（`VoiceEmotion`）で narrow するのみに留めている。fallbackData の実体データ（キーワード・返答文言）に変更はない。

## 動作確認

- `npx tsc --noEmit`: ✅
- `npm run build`: ✅
- 不正リクエスト時の業務エラーコードは既存の `resolveZodErrorCode` にマッピング済み:
  - `user_id` 欠落・形式違反 → `invalid_user_id`
  - `message` 欠落・空文字 → `invalid_request`
  - `conversation_history` 形式違反 → `invalid_request`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 音声APIのリクエスト検証が強化され、無効な入力に対するエラーハンドリングが改善されました。

* **その他の改善**
  * API応答形式が統一化され、より一貫した結果の返却が保証されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->