### PR TITLE
feat: health エンドポイントに zod バリデーションを導入（Issue #6 PR 6/6）

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import registerRouter from './routes/register';
 import gamesRouter from './routes/games';
 import resultsRouter from './routes/results';
 import voiceRouter from './routes/voice';
+import healthRouter from './routes/health';
 import { errorHandler } from './middleware/errorHandler';
 
 const app = express();
@@ -32,30 +33,7 @@ app.use('/api/register', registerRouter);
 app.use('/api/games', gamesRouter);
 app.use('/api/results', resultsRouter);
 app.use('/api/voice', voiceRouter);
-
-// Health check
-app.get('/health', async (req, res) => {
-    try {
-        const { supabase } = await import('./db/client');
-        const { error } = await supabase.from('users').select('*', { count: 'exact', head: true });
-
-        if (error) throw error;
-
-        res.status(200).json({
-            status: 'ok',
-            timestamp: new Date().toISOString(),
-            database: 'connected',
-            uptime: Math.round(process.uptime()),
-        });
-    } catch (err) {
-        res.status(503).json({
-            status: 'error',
-            timestamp: new Date().toISOString(),
-            database: 'disconnected',
-            uptime: Math.round(process.uptime()),
-        });
-    }
-});
+app.use('/health', healthRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -62,14 +62,26 @@ export const errorHandler = (
 
 /**
  * service 層が throw する業務エラー形式か判定する。
- * `status`（数値）と `code`（文字列）の両方が揃っていることを必須とする。
+ *
+ * `status`（数値）と `code`（ERROR_CODES のいずれか）が揃っていることを必須とする。
+ * code を ErrorCode に narrowing することで、ApiError.error（ErrorCode 型）への
+ * 代入がキャストなしで通る。
+ *
+ * code が ERROR_CODES に含まれない値（定義ミス・typo）だった場合は本関数で false を返し、
+ * errorHandler 側で 500 server_error に振り分けられる（内部情報の漏洩を防ぐ）。
  */
+const ERROR_CODE_VALUES: readonly string[] = Object.values(ERROR_CODES);
+
 function isBusinessError(
     err: unknown,
-): err is { status: number; code: string; message?: string } {
+): err is { status: number; code: ErrorCode; message?: string } {
     if (typeof err !== 'object' || err === null) return false;
     const e = err as { status?: unknown; code?: unknown };
-    return typeof e.status === 'number' && typeof e.code === 'string';
+    return (
+        typeof e.status === 'number' &&
+        typeof e.code === 'string' &&
+        ERROR_CODE_VALUES.includes(e.code)
+    );
 }
 
 /**

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -37,7 +37,10 @@ router.get('/', async (_req: Request, res: Response) => {
             uptime: Math.round(process.uptime()),
         };
         res.status(200).json(response);
-    } catch (_err) {
+    } catch (err) {
+        // /health は死活監視で最も参照されるエンドポイント。503 を返した原因を
+        // 運用側で追えるよう、errorHandler に委譲しない代わりにここで必ずログに残す
+        console.error('Health check failed:', err);
         // 仕様: DB 切断は 503 + ApiError ではなく health 固有の形状で返す
         const response: HealthErrorResponse = {
             status: 'error',

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -24,9 +24,12 @@ const router = Router();
  */
 router.get('/', async (_req: Request, res: Response) => {
     try {
+        // head: true だけで「PostgREST → DB」の接続確認は成立する。
+        // count: 'exact' を付けると毎回 SELECT COUNT(*) が走りテーブル成長時に負荷が出るため外す。
+        // カラムは最小の 'id' に絞る（head: true で行データは返らないが意図を明確化する目的）。
         const { error } = await supabase
             .from('users')
-            .select('*', { count: 'exact', head: true });
+            .select('id', { head: true });
 
         if (error) throw error;
 

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,52 @@
+import { Router, Request, Response } from 'express';
+import { supabase } from '../db/client';
+import {
+    HealthOkResponse,
+    HealthErrorResponse,
+} from '../schemas/health';
+
+const router = Router();
+
+/**
+ * GET /health
+ *
+ * Supabase への疎通確認を含むヘルスチェック。
+ *
+ * レスポンス規約（Notion 仕様書「API 設計書」準拠）:
+ * - 200: DB 接続 OK（`status: 'ok'`, `database: 'connected'`）
+ * - 503: DB 切断（`status: 'error'`, `database: 'disconnected'`）
+ *
+ * エラー委譲について:
+ * 通常の route は失敗時に next(err) で errorHandler に委譲するが、
+ * /health は「DB 切断を 503 + 独自フォーマットで返す」という仕様のため、
+ * try/catch で自前にレスポンスを構築する。next(err) に流すと errorHandler の
+ * 500 server_error 形式に変換されてしまい、仕様逸脱となるので注意。
+ */
+router.get('/', async (_req: Request, res: Response) => {
+    try {
+        const { error } = await supabase
+            .from('users')
+            .select('*', { count: 'exact', head: true });
+
+        if (error) throw error;
+
+        const response: HealthOkResponse = {
+            status: 'ok',
+            timestamp: new Date().toISOString(),
+            database: 'connected',
+            uptime: Math.round(process.uptime()),
+        };
+        res.status(200).json(response);
+    } catch (_err) {
+        // 仕様: DB 切断は 503 + ApiError ではなく health 固有の形状で返す
+        const response: HealthErrorResponse = {
+            status: 'error',
+            timestamp: new Date().toISOString(),
+            database: 'disconnected',
+            uptime: Math.round(process.uptime()),
+        };
+        res.status(503).json(response);
+    }
+});
+
+export default router;

--- a/backend/src/routes/voice.ts
+++ b/backend/src/routes/voice.ts
@@ -7,6 +7,7 @@ import {
     VoiceRespondRequest,
     VoiceRespondResponse,
 } from '../schemas/voice';
+import { ERROR_CODES } from '../schemas/errorCodes';
 
 const router = Router();
 
@@ -24,7 +25,7 @@ router.post(
             if (!exists) {
                 throw {
                     status: 400,
-                    code: 'invalid_user_id',
+                    code: ERROR_CODES.INVALID_USER_ID,
                     message: 'ユーザーIDが存在しません',
                 };
             }

--- a/backend/src/schemas/errorCodes.ts
+++ b/backend/src/schemas/errorCodes.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /**
  * API 共通エラーコード定数。
  *
@@ -17,3 +19,35 @@ export const ERROR_CODES = {
 } as const;
 
 export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];
+
+/**
+ * エラーコードの zod スキーマ。
+ * 仕様書で列挙されたコードのみに縛るため、`ERROR_CODES` の値を z.literal に展開する。
+ * 値を追加する際は `ERROR_CODES` と本配列の両方を更新すること。
+ */
+const errorCodeSchema = z.union([
+    z.literal(ERROR_CODES.INVALID_REQUEST),
+    z.literal(ERROR_CODES.INVALID_MBTI),
+    z.literal(ERROR_CODES.INVALID_ANSWERS),
+    z.literal(ERROR_CODES.INVALID_USER_ID),
+    z.literal(ERROR_CODES.INVALID_GAME_TYPE),
+    z.literal(ERROR_CODES.INCOMPLETE_GAMES),
+    z.literal(ERROR_CODES.USER_NOT_FOUND),
+    z.literal(ERROR_CODES.DUPLICATE_SUBMISSION),
+    z.literal(ERROR_CODES.SERVER_ERROR),
+]);
+
+/**
+ * API 共通エラーレスポンス。
+ *
+ * Notion 仕様書「API 設計書」の「エラーレスポンス」で規定された
+ * `{ status: "error", error, message }` 形式を zod 化したもの。
+ * `ApiError` 型は本スキーマから `z.infer` で導出する。
+ */
+export const apiErrorSchema = z.object({
+    status: z.literal('error'),
+    error: errorCodeSchema,
+    message: z.string(),
+});
+
+export type ApiError = z.infer<typeof apiErrorSchema>;

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -57,5 +57,13 @@ export const submitGameResponseSchema = z.object({
     message: z.string(),
 });
 
+/**
+ * ゲーム種別（1/2/3）の TS 型。
+ * `gameTypeSchema` から `z.infer` で導出するため、値の追加時は
+ * `types/index.ts` の `GAME_TYPES` と本スキーマの z.literal 配列を同期すれば
+ * 本型も自動で追随する。
+ */
+export type GameType = z.infer<typeof gameTypeSchema>;
+
 export type SubmitGameRequest = z.infer<typeof submitGameRequestSchema>;
 export type SubmitGameResponse = z.infer<typeof submitGameResponseSchema>;

--- a/backend/src/schemas/health.ts
+++ b/backend/src/schemas/health.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * GET /health のスキーマ群。
+ *
+ * - リクエストは入力なし（params / query / body すべて空）のため validate ミドルウェアは不要
+ * - 200（正常）と 503（DB 切断）で形が異なるため両方を用意する
+ * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ *
+ * エラーフォーマットについて:
+ * Notion 仕様書「API 設計書」で `/health` の 503 は他のエンドポイントの
+ * `ApiError`（`status: 'error', error, message`）とは異なる独自形を返す規定に
+ * なっている（`database: 'disconnected'` を含む運用監視向けのフィールド）。
+ * そのため本ファイルは apiErrorSchema を使わず個別に定義する。
+ */
+
+/**
+ * GET /health のレスポンス（200 OK）。
+ *
+ * - `uptime` はプロセス起動からの経過秒数（`process.uptime()`）を Math.round した値
+ * - `timestamp` は ISO 8601 形式の UTC 時刻文字列
+ */
+export const healthOkResponseSchema = z.object({
+    status: z.literal('ok'),
+    timestamp: z.iso.datetime(),
+    database: z.literal('connected'),
+    uptime: z.number().int().nonnegative(),
+});
+
+/**
+ * GET /health のレスポンス（503 Service Unavailable, DB 切断時）。
+ *
+ * 仕様書の規定により通常の ApiError 形式ではなく 200 と対称の形を返す。
+ */
+export const healthErrorResponseSchema = z.object({
+    status: z.literal('error'),
+    timestamp: z.iso.datetime(),
+    database: z.literal('disconnected'),
+    uptime: z.number().int().nonnegative(),
+});
+
+export type HealthOkResponse = z.infer<typeof healthOkResponseSchema>;
+export type HealthErrorResponse = z.infer<typeof healthErrorResponseSchema>;

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -5,13 +5,14 @@ import { analysisResultRepository, AnalysisResultRow } from '../repositories/ana
 
 import { getMbtiScores } from '../analysis/mbtiScoreTable';
 import { BaselineScores, ResultResponse } from '../types';
+import { ERROR_CODES } from '../schemas/errorCodes';
 
 export const resultService = {
     async getResult(userId: string): Promise<ResultResponse> {
         // ユーザー取得
         const user = await userRepository.findById(userId);
         if (!user) {
-            throw { status: 404, code: 'user_not_found', message: 'User not found' };
+            throw { status: 404, code: ERROR_CODES.USER_NOT_FOUND, message: 'User not found' };
         }
 
         // 1. ベースラインスコア取得 (アンケート結果)
@@ -40,7 +41,7 @@ export const resultService = {
         // キャッシュなし → ゲームログから計算
         const gameLogs = await gameRepository.findLogsByUserId(userId);
         if (gameLogs.length < 3) {
-            throw { status: 400, code: 'incomplete_games', message: 'All games must be completed' };
+            throw { status: 400, code: ERROR_CODES.INCOMPLETE_GAMES, message: 'All games must be completed' };
         }
 
         // 分析（analysis/ に委譲）

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -39,11 +39,8 @@ export type {
   VoiceRespondResponse,
 } from '../schemas/voice';
 
-export interface ApiError {
-  status: "error";
-  error: string;
-  message: string;
-}
+// ApiError は schemas/errorCodes.ts の apiErrorSchema から導出した型を再エクスポート
+export type { ApiError } from '../schemas/errorCodes';
 
 // ========================================
 // DB型定義

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -15,10 +15,10 @@ export type {
   RegisterResponse,
 } from '../schemas/register';
 
-export type GameType = 1 | 2 | 3;
-
 // games エンドポイントの型は schemas/games.ts に集約済み
+// GameType は gameTypeSchema（= GAME_TYPES の z.literal 展開）からの導出型を再エクスポート
 export type {
+  GameType,
   SubmitGameRequest,
   SubmitGameResponse,
 } from '../schemas/games';


### PR DESCRIPTION
## 概要

Issue #6（zod によるリクエスト/レスポンスバリデーション導入）の最終 PR（6/6）。
`GET /health` のレスポンススキーマ追加と、残る `types/index.ts` の zod 由来化を行う。

## 変更内容

### 新規
- `src/schemas/health.ts` — 200 / 503 両方のレスポンス zod スキーマを定義（`HealthOkResponse` / `HealthErrorResponse`）
- `src/routes/health.ts` — `index.ts` 内のインライン `/health` ハンドラを Router に切り出し、他エンドポイントと同じ構成に統一

### 既存改修
- `src/index.ts` — インライン `/health` ハンドラを削除し `healthRouter` をマウント
- `src/types/index.ts` — `GameType` を `gameTypeSchema` からの `z.infer` 導出に / `ApiError` を `apiErrorSchema` からの導出に置き換え。zod 由来型の再エクスポート中心の構成に整理
- `src/schemas/errorCodes.ts` — `apiErrorSchema` を追加し `error` フィールドを `ErrorCode` の union で narrowing
- `src/middleware/errorHandler.ts` — `isBusinessError` の `code` を runtime で `ERROR_CODES` 値集合に含まれるか検証する narrowing に強化。未知 code は 500 `server_error` に振り分け（内部情報漏洩防止）
- `src/services/resultService.ts` / `src/routes/voice.ts` — `throw` 時の `code` を文字列リテラルから `ERROR_CODES.XXX` 定数参照へ統一

## 実装メモ

- `/health` は DB 切断時に 503 + 独自形状（`database: 'disconnected'` 等）を返す仕様のため `apiErrorSchema` は使わず個別定義。errorHandler に委譲すると `server_error` 形式に変換されてしまうため、ルート内 try/catch で自前レスポンスを構築する。503 時は `console.error` を残し運用で原因追跡できるようにした
- supabase クライアントは他 repository と同じく静的 import に統一（元の動的 import でも挙動は同じだったが、読み手の混乱を減らすため）

## 検証

`node dist/index.js` 経由で全エンドポイントに curl を投げ、以下 10 ケースが仕様書通りに応答することを確認:

| # | エンドポイント | ケース | 期待 HTTP | 期待 error code | 結果 |
|---|---|---|---|---|---|
| 1 | POST /api/register | mbti 形式違反 | 400 | `invalid_mbti` | OK |
| 2 | POST /api/register | 回答 A-D 以外 | 400 | `invalid_answers` | OK |
| 3 | POST /api/register | baseline_answers 欠落 | 400 | `invalid_request` | OK |
| 4 | POST /api/games/submit | user_id UUID 不正 | 400 | `invalid_user_id` | OK |
| 5 | POST /api/games/submit | game_type 4 | 400 | `invalid_game_type` | OK |
| 6 | POST /api/games/submit | data 空 | 400 | `invalid_request` | OK |
| 7 | GET /api/results/:user_id | user_id UUID 不正 | 400 | `invalid_user_id` | OK |
| 8 | POST /api/voice/respond | user_id 欠落 | 400 | `invalid_user_id` | OK |
| 9 | POST /api/voice/respond | message 空文字 | 400 | `invalid_request` | OK |
| 10 | GET /health | 正常時 | 200 | — | OK |

## 完了条件

- [x] 全 5 エンドポイントで zod ベースのバリデーションが動作する
- [x] バリデーション失敗時、仕様書通りのエラーフォーマットで応答する
- [x] 既存の手書きバリデーションが zod に置き換わっている
- [x] リクエスト/レスポンスの TS 型が zod から導出されている

closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ヘルスチェックAPIを追加。データベース接続状態、タイムスタンプ、稼働時間を返します。

* **Improvements**
  * エラーコードを標準化し、生成されるエラーの一貫性を向上。
  * エラーレスポンスのスキーマと型定義を導入／拡充して検証を強化。
  * 内部ロジックで使用する型の再利用により型安全性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->