### PR TITLE
feat: OpenAPI 基盤 (registry / Swagger UI) を導入

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,7 @@ SUPABASE_URL=your_supabase_url_here
 SUPABASE_KEY=your_supabase_anon_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
 FRONTEND_URL=your_front_end_url
+
+# Swagger UI（/api-docs）の有効/無効を切り替える
+# デフォルトは有効。本番で閉じたい場合のみ "false" を指定する
+ENABLE_SWAGGER_UI=true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.96.0",
         "cors": "^2.8.6",
@@ -16,6 +17,7 @@
         "express": "^5.2.1",
         "form-data": "^4.0.5",
         "multer": "^2.0.2",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^13.0.0",
         "zod": "^4.3.6"
       },
@@ -24,9 +26,22 @@
         "@types/express": "^5.0.6",
         "@types/multer": "^2.0.0",
         "@types/node": "^25.2.3",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+      "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -78,6 +93,13 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.96.0",
@@ -323,6 +345,17 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -1464,6 +1497,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1872,6 +1914,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2133,6 +2199,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yn": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.96.0",
     "cors": "^2.8.6",
@@ -20,6 +21,7 @@
     "express": "^5.2.1",
     "form-data": "^4.0.5",
     "multer": "^2.0.2",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^13.0.0",
     "zod": "^4.3.6"
   },
@@ -28,6 +30,7 @@
     "@types/express": "^5.0.6",
     "@types/multer": "^2.0.0",
     "@types/node": "^25.2.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3"

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,17 +3,19 @@ dotenv.config();
 
 import express from 'express';
 import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
 import registerRouter from './routes/register';
 import gamesRouter from './routes/games';
 import resultsRouter from './routes/results';
 import voiceRouter from './routes/voice';
 import healthRouter from './routes/health';
 import { errorHandler } from './middleware/errorHandler';
+import { buildOpenApiDocument } from './openapi/document';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-const allowedOrigins = process.env.FRONTEND_URL 
-    ? process.env.FRONTEND_URL.split(',') 
+const allowedOrigins = process.env.FRONTEND_URL
+    ? process.env.FRONTEND_URL.split(',')
     : ['http://localhost:3000'];
 
 // Middleware
@@ -35,8 +37,27 @@ app.use('/api/results', resultsRouter);
 app.use('/api/voice', voiceRouter);
 app.use('/health', healthRouter);
 
+// Swagger UI（API ドキュメント閲覧用）
+// デフォルトは有効。本番で閉じたい場合は環境変数 `ENABLE_SWAGGER_UI=false` を設定する。
+// 'false' 文字列を明示指定した場合のみ無効化する厳格判定にすることで、
+// 未設定や予期しない値で誤って無効化される事故を防ぐ。
+const enableSwaggerUi = process.env.ENABLE_SWAGGER_UI !== 'false';
+if (enableSwaggerUi) {
+    const openapiDocument = buildOpenApiDocument();
+    app.use(
+        '/api-docs',
+        swaggerUi.serve,
+        swaggerUi.setup(openapiDocument, {
+            customSiteTitle: 'Real You API Docs',
+        }),
+    );
+}
+
 app.use(errorHandler);
 
 app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
+    if (enableSwaggerUi) {
+        console.log(`Swagger UI: http://localhost:${PORT}/api-docs`);
+    }
 });

--- a/backend/src/openapi/document.ts
+++ b/backend/src/openapi/document.ts
@@ -29,9 +29,6 @@ export function buildOpenApiDocument(): OpenAPIObject {
         info: {
             title: 'Real You API',
             version: '1.0.0',
-            description:
-                'MBTI 診断ゲーム「Real You」のバックエンド API 仕様。\n' +
-                '詳細はプロジェクトの「API 設計書」を参照してください。',
         },
         servers: [
             {

--- a/backend/src/openapi/document.ts
+++ b/backend/src/openapi/document.ts
@@ -1,0 +1,43 @@
+import { OpenApiGeneratorV31 } from '@asteasolutions/zod-to-openapi';
+import type { OpenAPIObject } from 'openapi3-ts/oas31';
+import { registry } from './registry';
+
+// スキーマ側の `.openapi()` 付与と `registry.register()` を副作用として評価する。
+// 本ファイルがエントリーポイント（index.ts）から import されることで、
+// 関連スキーマが OpenAPI ドキュメントに取り込まれる。
+//
+// PR-2 で各エンドポイントのスキーマ（register / games / results / voice / health）と
+// ルート登録モジュールを追加する際は、本ファイルに追記する。
+import '../schemas/common';
+import '../schemas/errorCodes';
+
+/**
+ * Real You API の OpenAPI ドキュメントを生成する。
+ *
+ * 生成タイミング: サーバ起動時に 1 度だけ実行し、生成済みオブジェクトを
+ * `swagger-ui-express` にそのまま渡す（リクエスト毎に生成する必要はない）。
+ *
+ * 仕様:
+ * - OpenAPI 3.1 を採用（zod v4 の機能と相性が良いため、zod-to-openapi v8 も V31 を推奨）
+ * - `servers` は相対 URL（`/`）で指定することで、Swagger UI がアクセス元オリジンを
+ *   そのまま採用する（localhost / 本番ドメイン双方で動く）
+ */
+export function buildOpenApiDocument(): OpenAPIObject {
+    const generator = new OpenApiGeneratorV31(registry.definitions);
+    return generator.generateDocument({
+        openapi: '3.1.0',
+        info: {
+            title: 'Real You API',
+            version: '1.0.0',
+            description:
+                'MBTI 診断ゲーム「Real You」のバックエンド API 仕様。\n' +
+                '詳細はプロジェクトの「API 設計書」を参照してください。',
+        },
+        servers: [
+            {
+                url: '/',
+                description: 'Current origin（アクセスしたホストをそのまま使用）',
+            },
+        ],
+    });
+}

--- a/backend/src/openapi/registry.ts
+++ b/backend/src/openapi/registry.ts
@@ -1,0 +1,35 @@
+import {
+    extendZodWithOpenApi,
+    OpenAPIRegistry,
+} from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+/**
+ * zod-to-openapi 基盤: zod 拡張と OpenAPIRegistry シングルトン。
+ *
+ * 設計方針:
+ * - 本プロジェクトでは zod を Single Source of Truth とし、既存スキーマへ
+ *   `.openapi({ description, example, ... })` でメタデータを付与することで
+ *   OpenAPI ドキュメントを自動生成する（Issue #5 実装計画参照）
+ * - `extendZodWithOpenApi(z)` は zod の各種スキーマ型のプロトタイプに `.openapi()`
+ *   メソッドを生やす副作用を持つ。スキーマ側で `.openapi()` を呼ぶ前に本モジュールが
+ *   評価されている必要があるため、`.openapi()` を使用するスキーマファイルの冒頭で
+ *   本モジュールを副作用 import する（例: `import '../openapi/registry';`）
+ * - `OpenAPIRegistry` は生成対象のスキーマ・パス・コンポーネントを蓄える入れ物。
+ *   シングルトンで共有し、複数箇所から `registry.register()` / `registry.registerPath()`
+ *   できるようにする
+ */
+
+// zod プロトタイプに `.openapi()` を追加（プロセス内で 1 度だけ実行される）
+extendZodWithOpenApi(z);
+
+/**
+ * プロジェクト共通の OpenAPI レジストリ（シングルトン）。
+ *
+ * - コンポーネント登録: `registry.register('Name', zodSchema)`
+ * - パス登録: `registry.registerPath({ method, path, request, responses })`（PR-2 で追加）
+ *
+ * レジストリに登録された内容は `document.ts` の `buildOpenApiDocument()` が
+ * 一括で OpenAPI v3.1 ドキュメントに変換する。
+ */
+export const registry = new OpenAPIRegistry();

--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -1,3 +1,6 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
 
 /**
@@ -11,10 +14,18 @@ import { z } from 'zod';
  *    スキーマ宣言時に業務コードを埋め込む一般的手段が存在しないため）
  *
  * zod v4 のトップレベル API（`z.uuid()` 等）と error オプションを使用する。
+ *
+ * OpenAPI メタデータ（`.openapi({ description, example })`）は Issue #5 の
+ * OpenAPI 化で付与。description は API 設計書の文言に合わせる。
  */
 
 /** user_id（UUID 文字列） */
-export const userIdSchema = z.uuid({ error: 'user_id は UUID 形式で指定してください' });
+export const userIdSchema = z
+    .uuid({ error: 'user_id は UUID 形式で指定してください' })
+    .openapi({
+        description: 'ユーザー識別子（UUID v4）',
+        example: '550e8400-e29b-41d4-a716-446655440000',
+    });
 
 /**
  * MBTI 形式（I/E + S/N + T/F + J/P の 4 文字）。
@@ -24,6 +35,10 @@ export const mbtiSchema = z
     .string({ error: 'mbti は文字列で指定してください' })
     .regex(/^[IE][SN][TF][JP]$/i, {
         error: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
+    })
+    .openapi({
+        description: 'MBTI タイプ（I/E + S/N + T/F + J/P の 4 文字、大文字小文字不問）',
+        example: 'INTJ',
     });
 
 /**
@@ -40,8 +55,8 @@ export const mbtiSchema = z
  *
  * type predicate（`val is AnswerOption`）により z.infer の型は 'A' | 'B' | 'C' | 'D' に narrowing される。
  *
- * OpenAPI 化（Issue #6 PR 6）の際は zod-openapi の .openapi({ enum: [...] }) で
- * enum 情報を補う必要がある（z.string() のままだと OpenAPI 側で enum が失われるため）。
+ * OpenAPI 化では `.openapi({ enum: [...] })` で enum 情報を補う
+ * （z.string().refine() のままだと OpenAPI 側で enum が失われるため）。
  */
 const ANSWER_OPTIONS = ['A', 'B', 'C', 'D'] as const;
 export type AnswerOption = typeof ANSWER_OPTIONS[number];
@@ -52,7 +67,12 @@ export const answerOptionSchema = z
         (val): val is AnswerOption =>
             (ANSWER_OPTIONS as readonly string[]).includes(val),
         { error: '回答は A / B / C / D のいずれかで指定してください' },
-    );
+    )
+    .openapi({
+        description: '基準値アンケートの回答選択肢（A / B / C / D のいずれか）',
+        enum: [...ANSWER_OPTIONS],
+        example: 'A',
+    });
 
 /**
  * 5 軸各軸のスコア値（0-100 の整数）。
@@ -77,13 +97,26 @@ const boundedScoreSchema = z.number().int().min(0).max(100);
  * - `z.infer` の結果型は `number` のままで既存コードへの影響はない
  *   （`.min/.max` はランタイム検証にのみ作用）
  */
-export const baselineScoresSchema = z.object({
-    caution: boundedScoreSchema,
-    calmness: boundedScoreSchema,
-    logic: boundedScoreSchema,
-    cooperativeness: boundedScoreSchema,
-    positivity: boundedScoreSchema,
-});
+export const baselineScoresSchema = z
+    .object({
+        caution: boundedScoreSchema.openapi({ description: '慎重さ（0-100）' }),
+        calmness: boundedScoreSchema.openapi({ description: '冷静さ（0-100）' }),
+        logic: boundedScoreSchema.openapi({ description: '論理性（0-100）' }),
+        cooperativeness: boundedScoreSchema.openapi({
+            description: '協調性（0-100）',
+        }),
+        positivity: boundedScoreSchema.openapi({ description: '積極性（0-100）' }),
+    })
+    .openapi({
+        description: '5 軸スコア（0-100 の整数）。baseline_scores / scores / mbti_scores で共通利用',
+        example: {
+            caution: 60,
+            calmness: 55,
+            logic: 70,
+            cooperativeness: 45,
+            positivity: 65,
+        },
+    });
 
 export type BaselineScores = z.infer<typeof baselineScoresSchema>;
 
@@ -94,12 +127,23 @@ export type BaselineScores = z.infer<typeof baselineScoresSchema>;
  * 範囲制約（0-100）を付けない別スキーマとして分離している。
  * 整数制約は維持する（仕様書「DB 設計書」で gap_* カラムは `INT` 型）。
  */
-export const gapScoresSchema = z.object({
-    caution: z.number().int(),
-    calmness: z.number().int(),
-    logic: z.number().int(),
-    cooperativeness: z.number().int(),
-    positivity: z.number().int(),
-});
+export const gapScoresSchema = z
+    .object({
+        caution: z.number().int().openapi({ description: '慎重さのギャップ（実測 - 自己申告）' }),
+        calmness: z.number().int().openapi({ description: '冷静さのギャップ' }),
+        logic: z.number().int().openapi({ description: '論理性のギャップ' }),
+        cooperativeness: z.number().int().openapi({ description: '協調性のギャップ' }),
+        positivity: z.number().int().openapi({ description: '積極性のギャップ' }),
+    })
+    .openapi({
+        description: '5 軸ギャップ（実測 - 自己申告）。負値を取りうる整数',
+        example: {
+            caution: -5,
+            calmness: 10,
+            logic: 0,
+            cooperativeness: 15,
+            positivity: -8,
+        },
+    });
 
 export type GapScores = z.infer<typeof gapScoresSchema>;

--- a/backend/src/schemas/errorCodes.ts
+++ b/backend/src/schemas/errorCodes.ts
@@ -1,4 +1,8 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 
 /**
  * API 共通エラーコード定数。
@@ -24,18 +28,32 @@ export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];
  * エラーコードの zod スキーマ。
  * 仕様書で列挙されたコードのみに縛るため、`ERROR_CODES` の値を z.literal に展開する。
  * 値を追加する際は `ERROR_CODES` と本配列の両方を更新すること。
+ *
+ * OpenAPI では `.openapi({ enum: [...] })` で enum として出力する。
+ * z.union<z.literal> の構成から OpenAPI 側で `anyOf` に落ちてしまうのを避け、
+ * 単一の string enum として Swagger UI / IDE 補完で扱いやすくするため。
  */
-const errorCodeSchema = z.union([
-    z.literal(ERROR_CODES.INVALID_REQUEST),
-    z.literal(ERROR_CODES.INVALID_MBTI),
-    z.literal(ERROR_CODES.INVALID_ANSWERS),
-    z.literal(ERROR_CODES.INVALID_USER_ID),
-    z.literal(ERROR_CODES.INVALID_GAME_TYPE),
-    z.literal(ERROR_CODES.INCOMPLETE_GAMES),
-    z.literal(ERROR_CODES.USER_NOT_FOUND),
-    z.literal(ERROR_CODES.DUPLICATE_SUBMISSION),
-    z.literal(ERROR_CODES.SERVER_ERROR),
-]);
+const errorCodeSchema = z
+    .union([
+        z.literal(ERROR_CODES.INVALID_REQUEST),
+        z.literal(ERROR_CODES.INVALID_MBTI),
+        z.literal(ERROR_CODES.INVALID_ANSWERS),
+        z.literal(ERROR_CODES.INVALID_USER_ID),
+        z.literal(ERROR_CODES.INVALID_GAME_TYPE),
+        z.literal(ERROR_CODES.INCOMPLETE_GAMES),
+        z.literal(ERROR_CODES.USER_NOT_FOUND),
+        z.literal(ERROR_CODES.DUPLICATE_SUBMISSION),
+        z.literal(ERROR_CODES.SERVER_ERROR),
+    ])
+    .openapi({
+        description:
+            'API 設計書「エラーレスポンス」で規定された業務エラーコード。 ' +
+            '400: invalid_mbti / invalid_answers / invalid_request / invalid_user_id / ' +
+            'invalid_game_type / incomplete_games、404: user_not_found、' +
+            '409: duplicate_submission、500: server_error。',
+        enum: Object.values(ERROR_CODES),
+        example: ERROR_CODES.INVALID_REQUEST,
+    });
 
 /**
  * API 共通エラーレスポンス。
@@ -43,11 +61,31 @@ const errorCodeSchema = z.union([
  * Notion 仕様書「API 設計書」の「エラーレスポンス」で規定された
  * `{ status: "error", error, message }` 形式を zod 化したもの。
  * `ApiError` 型は本スキーマから `z.infer` で導出する。
+ *
+ * `registry.register('ApiError', ...)` で共通コンポーネントとして登録し、
+ * PR-2 で各エンドポイントのエラーレスポンスから `$ref` で参照する。
  */
-export const apiErrorSchema = z.object({
-    status: z.literal('error'),
-    error: errorCodeSchema,
-    message: z.string(),
-});
+export const apiErrorSchema = registry.register(
+    'ApiError',
+    z
+        .object({
+            status: z.literal('error').openapi({
+                description: '固定値 "error"（成功時は各レスポンスが個別に status を返す）',
+            }),
+            error: errorCodeSchema,
+            message: z.string().openapi({
+                description: '開発者向けの日本語説明（エンドユーザー向け文言ではない）',
+                example: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
+            }),
+        })
+        .openapi({
+            description: 'API 共通エラーレスポンス形式',
+            example: {
+                status: 'error',
+                error: ERROR_CODES.INVALID_MBTI,
+                message: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
+            },
+        }),
+);
 
 export type ApiError = z.infer<typeof apiErrorSchema>;


### PR DESCRIPTION
## 概要

Issue #5（Swagger 導入）の 2 PR 分割のうち **PR-1（基盤整備）**。
`@asteasolutions/zod-to-openapi` と `swagger-ui-express` を導入し、`/api-docs` で Swagger UI を閲覧できるようにする。

実際のエンドポイント（`register` / `games` / `results` / `voice` / `health`）の OpenAPI 化は **PR-2（`feature/openapi-endpoints`）** で行う。

refs #5

## 変更内容

### 依存追加
- `@asteasolutions/zod-to-openapi`（zod → OpenAPI 変換）
- `swagger-ui-express` + `@types/swagger-ui-express`（UI 提供）

### OpenAPI 基盤
- `backend/src/openapi/registry.ts` — `extendZodWithOpenApi(z)` と `OpenAPIRegistry` シングルトン
- `backend/src/openapi/document.ts` — `buildOpenApiDocument()` で OpenAPI v3.1 ドキュメントを生成

### 共通スキーマへのメタデータ付与
- `schemas/common.ts` — `userIdSchema` / `mbtiSchema` / `answerOptionSchema` / `baselineScoresSchema` / `gapScoresSchema` に `description` / `example`（および enum 情報）を付与
- `schemas/errorCodes.ts` — `errorCodeSchema` に enum を付与し、`apiErrorSchema` を `ApiError` として `components.schemas` に登録

### Swagger UI 公開
- `src/index.ts` に `/api-docs` をマウント
- 環境変数 `ENABLE_SWAGGER_UI=false` で明示的に無効化可能（デフォルトは有効）
- `.env.example` に `ENABLE_SWAGGER_UI` を追記

## 動作確認

- `npm run build` → OK
- サーバ起動 → `/api-docs` で Swagger UI が表示される（200）
- `ENABLE_SWAGGER_UI=false` 指定時 → `/api-docs` が 404 になり、他のルートは従来通り動作
- 生成された OpenAPI ドキュメント: `openapi: 3.1.0` / `info.title: Real You API` / `components.schemas: [ApiError]`（paths は PR-2 で追加）

## スコープ外（PR-2 で対応）

- 各エンドポイントスキーマへの `.openapi()` + example 付与
- `registry.registerPath()` による全ルート登録
- `backend/src/openapi/examples.ts` 新設
- `docs/api.md` 新設 / `CONTRIBUTING.md` 導線 / `docs/setup.md` 追記

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Swagger UIによるインタラクティブなAPIドキュメントを追加しました（/api-docs）。

* **設定変更**
  * 新しい環境変数 ENABLE_SWAGGER_UI を追加（デフォルト: 有効）。この設定でドキュメント表示を無効化できます。

* **ドキュメント**
  * APIスキーマに説明や例を追加し、エラー応答や各フィールドのメタ情報を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->