### PR TITLE
feat: POST 系 API に OpenAPI スキーマを追加 (PR-2a)

### DIFF
--- a/backend/src/openapi/document.ts
+++ b/backend/src/openapi/document.ts
@@ -6,10 +6,17 @@ import { registry } from './registry';
 // 本ファイルがエントリーポイント（index.ts）から import されることで、
 // 関連スキーマが OpenAPI ドキュメントに取り込まれる。
 //
-// PR-2 で各エンドポイントのスキーマ（register / games / results / voice / health）と
-// ルート登録モジュールを追加する際は、本ファイルに追記する。
+// 共通コンポーネント（other schema から参照されない可能性があるもの）は
+// ここで明示的に import する。エンドポイントのスキーマは paths/*.ts 側の
+// import 連鎖で評価されるため、paths/*.ts を import するだけで足りる。
 import '../schemas/common';
 import '../schemas/errorCodes';
+
+// パス登録（POST 系: Issue #5 PR-2a で追加）。
+// GET 系（results / health）は PR-2b で追記する。
+import './paths/register';
+import './paths/games';
+import './paths/voice';
 
 /**
  * Real You API の OpenAPI ドキュメントを生成する。

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -1,5 +1,4 @@
-import { ERROR_CODES } from '../schemas/errorCodes';
-import type { ApiError } from '../schemas/errorCodes';
+import { ERROR_CODES, type ApiError, type ErrorCode } from '../schemas/errorCodes';
 
 /**
  * OpenAPI ドキュメント用のサンプル値。
@@ -36,52 +35,65 @@ export const SAMPLE_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
 /**
  * 業務エラーコードごとのサンプルレスポンス。
  *
- * 本定数は `ApiError` 型で縛ることで、`ERROR_CODES` 追加時の example 追加忘れを
- * コンパイルエラーとして検知できる（未対応コードは Record の値として必要なため）。
+ * 型設計:
+ * - キーは `ErrorCode`（`ERROR_CODES` の値、snake_case 文字列）に揃える。
+ *   `satisfies Record<ErrorCode, ApiError>` で縛ることで、
+ *   `ERROR_CODES` に新しいコードを追加したとき example 追加忘れを
+ *   「Property 'xxx' is missing」としてコンパイルエラーで検知できる。
+ *   （`Record<string, ApiError>` ではキー側の網羅性が効かないので注意）
+ * - 値の `error` フィールドもキーと同じコードを指す形に統一しているが、
+ *   コンパイラに「キー名と error 値が一致」を強制する仕組みは入れていない。
+ *   入れるとキーごとに型を書き分ける必要があり、取扱いが重くなるため見送り。
+ *
  * message 文言は errorHandler / service 層で実際に返す日本語メッセージに合わせる。
  */
 export const apiErrorExamples = {
-    invalidRequest: {
+    [ERROR_CODES.INVALID_REQUEST]: {
         status: 'error',
         error: ERROR_CODES.INVALID_REQUEST,
         message: '必須フィールドが欠落しています',
     },
-    invalidMbti: {
+    [ERROR_CODES.INVALID_MBTI]: {
         status: 'error',
         error: ERROR_CODES.INVALID_MBTI,
         message: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
     },
-    invalidAnswers: {
+    [ERROR_CODES.INVALID_ANSWERS]: {
         status: 'error',
         error: ERROR_CODES.INVALID_ANSWERS,
         message: '回答は A / B / C / D のいずれかで指定してください',
     },
-    invalidUserId: {
+    [ERROR_CODES.INVALID_USER_ID]: {
         status: 'error',
         error: ERROR_CODES.INVALID_USER_ID,
         message: 'ユーザーIDが存在しません',
     },
-    invalidGameType: {
+    [ERROR_CODES.INVALID_GAME_TYPE]: {
         status: 'error',
         error: ERROR_CODES.INVALID_GAME_TYPE,
         message: 'game_type は 1 / 2 / 3 のいずれかで指定してください',
     },
-    userNotFound: {
+    [ERROR_CODES.INCOMPLETE_GAMES]: {
+        status: 'error',
+        error: ERROR_CODES.INCOMPLETE_GAMES,
+        message: '3 ゲームすべて完了してから結果取得してください',
+    },
+    [ERROR_CODES.USER_NOT_FOUND]: {
         status: 'error',
         error: ERROR_CODES.USER_NOT_FOUND,
         message: '指定されたユーザーが見つかりません',
     },
-    duplicateSubmission: {
+    [ERROR_CODES.DUPLICATE_SUBMISSION]: {
         status: 'error',
         error: ERROR_CODES.DUPLICATE_SUBMISSION,
         message: '同一ゲームの重複送信です',
     },
-    serverError: {
+    [ERROR_CODES.SERVER_ERROR]: {
         status: 'error',
         error: ERROR_CODES.SERVER_ERROR,
         message: 'サーバーエラーが発生しました',
     },
-} as const satisfies Record<string, ApiError>;
+} as const satisfies Record<ErrorCode, ApiError>;
 
 // ---------------------------------------------------------------------------
 // POST /api/register

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -1,0 +1,184 @@
+import { ERROR_CODES } from '../schemas/errorCodes';
+import type { ApiError } from '../schemas/errorCodes';
+
+/**
+ * OpenAPI ドキュメント用のサンプル値。
+ *
+ * 設計方針:
+ * - 例示は Notion 仕様書「API 設計書」の記述を転記する（乖離したら仕様書を唯一の真実として合わせる）
+ * - スキーマ側の `.openapi({ example: ... })` とパス側の `responses.content.example`
+ *   両方から参照されるため、値の重複を避けるために本ファイルに集約する
+ * - 本ファイルは副作用を持たない純粋な定数モジュール。registry への副作用 import は不要
+ *
+ * 配置方針:
+ * - `requestExamples` / `responseExamples` をエンドポイント単位にグルーピング
+ * - `apiErrorExamples` は業務コード別に揃え、各エンドポイントの responses から参照する
+ *
+ * PR 構成メモ（Issue #5 実装計画参照）:
+ * - 本 PR（PR-2a）は POST 系 3 本（register / games / voice）の example を先行で配置
+ * - GET 系 2 本（results / health）の example は PR-2b で本ファイルに追記する
+ */
+
+// ---------------------------------------------------------------------------
+// 共通: user_id サンプル
+// ---------------------------------------------------------------------------
+
+/**
+ * サンプル用の UUID（複数エンドポイントで使い回す）。
+ * 特定ユーザーを指すものではなく、フォーマットを示すための固定値。
+ */
+export const SAMPLE_USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+// ---------------------------------------------------------------------------
+// ApiError の業務コード別サンプル
+// ---------------------------------------------------------------------------
+
+/**
+ * 業務エラーコードごとのサンプルレスポンス。
+ *
+ * 本定数は `ApiError` 型で縛ることで、`ERROR_CODES` 追加時の example 追加忘れを
+ * コンパイルエラーとして検知できる（未対応コードは Record の値として必要なため）。
+ * message 文言は errorHandler / service 層で実際に返す日本語メッセージに合わせる。
+ */
+export const apiErrorExamples = {
+    invalidRequest: {
+        status: 'error',
+        error: ERROR_CODES.INVALID_REQUEST,
+        message: '必須フィールドが欠落しています',
+    },
+    invalidMbti: {
+        status: 'error',
+        error: ERROR_CODES.INVALID_MBTI,
+        message: 'mbti は INTJ / ESFP などの 4 文字で指定してください',
+    },
+    invalidAnswers: {
+        status: 'error',
+        error: ERROR_CODES.INVALID_ANSWERS,
+        message: '回答は A / B / C / D のいずれかで指定してください',
+    },
+    invalidUserId: {
+        status: 'error',
+        error: ERROR_CODES.INVALID_USER_ID,
+        message: 'ユーザーIDが存在しません',
+    },
+    invalidGameType: {
+        status: 'error',
+        error: ERROR_CODES.INVALID_GAME_TYPE,
+        message: 'game_type は 1 / 2 / 3 のいずれかで指定してください',
+    },
+    userNotFound: {
+        status: 'error',
+        error: ERROR_CODES.USER_NOT_FOUND,
+        message: '指定されたユーザーが見つかりません',
+    },
+    duplicateSubmission: {
+        status: 'error',
+        error: ERROR_CODES.DUPLICATE_SUBMISSION,
+        message: '同一ゲームの重複送信です',
+    },
+    serverError: {
+        status: 'error',
+        error: ERROR_CODES.SERVER_ERROR,
+        message: 'サーバーエラーが発生しました',
+    },
+} as const satisfies Record<string, ApiError>;
+
+// ---------------------------------------------------------------------------
+// POST /api/register
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/register のリクエスト例（仕様書準拠）。
+ * baseline_answers は 5 設問すべて必須（A/B/C/D）。
+ */
+export const registerRequestExample = {
+    mbti: 'ENTP',
+    baseline_answers: {
+        q1_caution: 'A',
+        q2_calmness: 'B',
+        q3_logic: 'A',
+        q4_cooperativeness: 'C',
+        q5_positivity: 'A',
+    },
+} as const;
+
+/**
+ * POST /api/register のレスポンス例（201 Created）。
+ */
+export const registerResponseExample = {
+    user_id: SAMPLE_USER_ID,
+    status: 'success',
+} as const;
+
+// ---------------------------------------------------------------------------
+// POST /api/games/submit
+// ---------------------------------------------------------------------------
+
+/**
+ * game_type = 1（利用規約ゲーム）の data サンプル。
+ *
+ * data 構造の詳細は仕様書「データ構造」→ Game1Data を参照。OpenAPI の example は
+ * 「何を送るべきか」をざっくり示すだけなので、全フィールド網羅ではなく
+ * 代表的な値を入れる（仕様書の最小例）。
+ */
+export const submitGameRequestExampleGame1 = {
+    user_id: SAMPLE_USER_ID,
+    game_type: 1,
+    data: {
+        totalTime: 42.5,
+        finalAction: 'agree',
+        reachedBottom: true,
+        scrollEvents: [
+            { position: 0, timestamp: 0 },
+            { position: 1200, timestamp: 2500 },
+        ],
+        hiddenInput: null,
+        checkboxStates: {
+            readConfirm: { checked: true, changed: true },
+            mailMagazine: { checked: true, changed: false },
+            thirdPartyShare: { checked: false, changed: true },
+        },
+        popupStats: {
+            timeToClose: 850,
+            clickCount: 1,
+            mouseJitter: 42.3,
+        },
+        agreeButtonHoverTimeMs: 1200,
+    },
+} as const;
+
+/**
+ * POST /api/games/submit のレスポンス例（200 OK）。
+ * message はサーバ側で `Game ${game_type} data saved` を返す（games.ts 参照）。
+ */
+export const submitGameResponseExample = {
+    status: 'success',
+    message: 'Game 1 data saved',
+} as const;
+
+// ---------------------------------------------------------------------------
+// POST /api/voice/respond
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/voice/respond のリクエスト例（仕様書準拠）。
+ * conversation_history は optional だが、形式を示すため example には含める。
+ */
+export const voiceRespondRequestExample = {
+    user_id: SAMPLE_USER_ID,
+    message: 'パスワードを忘れました',
+    conversation_history: [
+        { role: 'user', content: 'ログインできません' },
+        { role: 'assistant', content: 'どのような問題でしょうか？' },
+    ],
+} as const;
+
+/**
+ * POST /api/voice/respond のレスポンス例（200 OK）。
+ * emotion / confidence の具体値は仕様書「API 設計書」記載値に合わせる。
+ */
+export const voiceRespondResponseExample = {
+    response: 'パスワードリセットは設定画面から行えます。',
+    emotion: 'confident',
+    confidence: 0.6,
+} as const;

--- a/backend/src/openapi/paths/games.ts
+++ b/backend/src/openapi/paths/games.ts
@@ -74,7 +74,12 @@ registry.registerPath({
             content: {
                 'application/json': {
                     schema: apiErrorSchema,
-                    example: apiErrorExamples[ERROR_CODES.DUPLICATE_SUBMISSION],
+                    examples: {
+                        duplicate_submission: {
+                            summary: '同一ユーザー × 同一 game_type の重複送信',
+                            value: apiErrorExamples[ERROR_CODES.DUPLICATE_SUBMISSION],
+                        },
+                    },
                 },
             },
         },

--- a/backend/src/openapi/paths/games.ts
+++ b/backend/src/openapi/paths/games.ts
@@ -1,0 +1,92 @@
+import { registry } from '../registry';
+import {
+    submitGameRequestSchema,
+    submitGameResponseSchema,
+} from '../../schemas/games';
+import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorExamples } from '../examples';
+
+/**
+ * POST /api/games/submit のパス登録。
+ *
+ * 設計方針:
+ * - 仕様書「API 設計書」準拠で 200 / 400 / 404 / 409 を定義する
+ * - 404 は仕様書では「user_id の存在確認 → 存在しない → 400」として扱われるが、
+ *   実装側（gameService.submitGame / userRepository.exists）の整理で今後 404 になりうる
+ *   フロー（ユーザー削除後の送信等）を見越して 404 も登録する
+ *   → 現状の実装（2026-04-22 時点）では 400 `invalid_user_id` を返すため、
+ *     404 の example も `user_not_found` を明示する
+ */
+registry.registerPath({
+    method: 'post',
+    path: '/api/games/submit',
+    tags: ['Games'],
+    summary: 'ゲームプレイデータ送信',
+    description:
+        '各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。' +
+        '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。',
+    request: {
+        body: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: submitGameRequestSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            description: 'ゲームデータ保存成功',
+            content: {
+                'application/json': {
+                    schema: submitGameResponseSchema,
+                },
+            },
+        },
+        400: {
+            description:
+                'リクエスト不正。主な業務エラーコード: ' +
+                'invalid_request（必須フィールド欠落 / data が空）/ ' +
+                'invalid_user_id（user_id が存在しない）/ ' +
+                'invalid_game_type（game_type が 1-3 の範囲外）',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    examples: {
+                        invalidRequest: {
+                            summary: '必須フィールド欠落 / data が空',
+                            value: apiErrorExamples.invalidRequest,
+                        },
+                        invalidUserId: {
+                            summary: 'user_id が存在しない',
+                            value: apiErrorExamples.invalidUserId,
+                        },
+                        invalidGameType: {
+                            summary: 'game_type 範囲外',
+                            value: apiErrorExamples.invalidGameType,
+                        },
+                    },
+                },
+            },
+        },
+        404: {
+            description: '指定されたユーザーが見つからない',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    example: apiErrorExamples.userNotFound,
+                },
+            },
+        },
+        409: {
+            description: '同一ユーザー × 同一 game_type の重複送信',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    example: apiErrorExamples.duplicateSubmission,
+                },
+            },
+        },
+    },
+});

--- a/backend/src/openapi/paths/games.ts
+++ b/backend/src/openapi/paths/games.ts
@@ -3,19 +3,18 @@ import {
     submitGameRequestSchema,
     submitGameResponseSchema,
 } from '../../schemas/games';
-import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorSchema, ERROR_CODES } from '../../schemas/errorCodes';
 import { apiErrorExamples } from '../examples';
 
 /**
  * POST /api/games/submit のパス登録。
  *
  * 設計方針:
- * - 仕様書「API 設計書」準拠で 200 / 400 / 404 / 409 を定義する
- * - 404 は仕様書では「user_id の存在確認 → 存在しない → 400」として扱われるが、
- *   実装側（gameService.submitGame / userRepository.exists）の整理で今後 404 になりうる
- *   フロー（ユーザー削除後の送信等）を見越して 404 も登録する
- *   → 現状の実装（2026-04-22 時点）では 400 `invalid_user_id` を返すため、
- *     404 の example も `user_not_found` を明示する
+ * - 仕様書「API 設計書」準拠で 200 / 400 / 409 を定義する
+ * - user_id が見つからない場合も仕様書・実装ともに 400 `invalid_user_id` を返すため、
+ *   404 レスポンスは定義しない（OpenAPI を Single Source of Truth とするため、
+ *   実装と乖離する予測を書かない）。仕様変更で 404 を返すようになったら
+ *   まず仕様書を更新してから本ファイルに追記する。
  */
 registry.registerPath({
     method: 'post',
@@ -48,34 +47,25 @@ registry.registerPath({
             description:
                 'リクエスト不正。主な業務エラーコード: ' +
                 'invalid_request（必須フィールド欠落 / data が空）/ ' +
-                'invalid_user_id（user_id が存在しない）/ ' +
+                'invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ ' +
                 'invalid_game_type（game_type が 1-3 の範囲外）',
             content: {
                 'application/json': {
                     schema: apiErrorSchema,
                     examples: {
-                        invalidRequest: {
+                        invalid_request: {
                             summary: '必須フィールド欠落 / data が空',
-                            value: apiErrorExamples.invalidRequest,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_REQUEST],
                         },
-                        invalidUserId: {
-                            summary: 'user_id が存在しない',
-                            value: apiErrorExamples.invalidUserId,
+                        invalid_user_id: {
+                            summary: 'user_id が不正（形式違反 / 欠落 / 存在しない）',
+                            value: apiErrorExamples[ERROR_CODES.INVALID_USER_ID],
                         },
-                        invalidGameType: {
+                        invalid_game_type: {
                             summary: 'game_type 範囲外',
-                            value: apiErrorExamples.invalidGameType,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_GAME_TYPE],
                         },
                     },
-                },
-            },
-        },
-        404: {
-            description: '指定されたユーザーが見つからない',
-            content: {
-                'application/json': {
-                    schema: apiErrorSchema,
-                    example: apiErrorExamples.userNotFound,
                 },
             },
         },
@@ -84,7 +74,7 @@ registry.registerPath({
             content: {
                 'application/json': {
                     schema: apiErrorSchema,
-                    example: apiErrorExamples.duplicateSubmission,
+                    example: apiErrorExamples[ERROR_CODES.DUPLICATE_SUBMISSION],
                 },
             },
         },

--- a/backend/src/openapi/paths/register.ts
+++ b/backend/src/openapi/paths/register.ts
@@ -3,7 +3,7 @@ import {
     registerRequestSchema,
     registerResponseSchema,
 } from '../../schemas/register';
-import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorSchema, ERROR_CODES } from '../../schemas/errorCodes';
 import { apiErrorExamples } from '../examples';
 
 /**
@@ -54,17 +54,17 @@ registry.registerPath({
                 'application/json': {
                     schema: apiErrorSchema,
                     examples: {
-                        invalidMbti: {
+                        invalid_mbti: {
                             summary: 'MBTI 形式違反',
-                            value: apiErrorExamples.invalidMbti,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_MBTI],
                         },
-                        invalidAnswers: {
+                        invalid_answers: {
                             summary: '回答値違反（A-D 以外）',
-                            value: apiErrorExamples.invalidAnswers,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_ANSWERS],
                         },
-                        invalidRequest: {
+                        invalid_request: {
                             summary: '必須フィールド欠落',
-                            value: apiErrorExamples.invalidRequest,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_REQUEST],
                         },
                     },
                 },

--- a/backend/src/openapi/paths/register.ts
+++ b/backend/src/openapi/paths/register.ts
@@ -1,0 +1,74 @@
+import { registry } from '../registry';
+import {
+    registerRequestSchema,
+    registerResponseSchema,
+} from '../../schemas/register';
+import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorExamples } from '../examples';
+
+/**
+ * POST /api/register のパス登録。
+ *
+ * 設計方針:
+ * - ルート登録は各エンドポイント単位でファイルを分ける（スキーマファイルとの 1:1 対応）
+ * - レスポンス定義の status code は仕様書「API 設計書」準拠（本エンドポイントは 201 と 400 のみ）
+ * - エラーレスポンスは `apiErrorSchema`（PR-1 で components に登録済）を参照し、
+ *   `examples` で業務コード別のパターンを提示する
+ *
+ * 本ファイルは `document.ts` から副作用 import されることで registry に登録される。
+ * 直接実行せず、import するだけでよい設計。
+ */
+registry.registerPath({
+    method: 'post',
+    path: '/api/register',
+    tags: ['Register'],
+    summary: 'ユーザー登録',
+    description:
+        'MBTI 選択 + 基準値アンケート（5 設問）完了時にユーザーを新規登録する。' +
+        'mbti は null / 省略で MBTI 診断スキップ扱いになる。',
+    request: {
+        body: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: registerRequestSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        201: {
+            description: 'ユーザー登録成功',
+            content: {
+                'application/json': {
+                    schema: registerResponseSchema,
+                },
+            },
+        },
+        400: {
+            description:
+                'リクエスト不正。主な業務エラーコード: ' +
+                'invalid_mbti（MBTI 形式違反）/ invalid_answers（A-D 以外の回答）/ ' +
+                'invalid_request（必須フィールド欠落）',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    examples: {
+                        invalidMbti: {
+                            summary: 'MBTI 形式違反',
+                            value: apiErrorExamples.invalidMbti,
+                        },
+                        invalidAnswers: {
+                            summary: '回答値違反（A-D 以外）',
+                            value: apiErrorExamples.invalidAnswers,
+                        },
+                        invalidRequest: {
+                            summary: '必須フィールド欠落',
+                            value: apiErrorExamples.invalidRequest,
+                        },
+                    },
+                },
+            },
+        },
+    },
+});

--- a/backend/src/openapi/paths/voice.ts
+++ b/backend/src/openapi/paths/voice.ts
@@ -1,0 +1,66 @@
+import { registry } from '../registry';
+import {
+    voiceRespondRequestSchema,
+    voiceRespondResponseSchema,
+} from '../../schemas/voice';
+import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorExamples } from '../examples';
+
+/**
+ * POST /api/voice/respond のパス登録。
+ *
+ * 設計方針:
+ * - 仕様書「API 設計書」準拠で 200 / 400 を定義する
+ * - 実装側（routes/voice.ts）では user_id 未存在時に 400 `invalid_user_id` を返すため、
+ *   400 の examples に `invalid_user_id` を含める
+ */
+registry.registerPath({
+    method: 'post',
+    path: '/api/voice/respond',
+    tags: ['Voice'],
+    summary: 'AI 応答生成（Game 2 用）',
+    description:
+        'Game 2（AI カスタマーサポート）のユーザー発話に対し、Gemini API で AI 応答を生成する。' +
+        'Gemini 失敗時はキーワードマッチングのフォールバックに切り替わる（confidence が下がる）。',
+    request: {
+        body: {
+            required: true,
+            content: {
+                'application/json': {
+                    schema: voiceRespondRequestSchema,
+                },
+            },
+        },
+    },
+    responses: {
+        200: {
+            description: 'AI 応答生成成功',
+            content: {
+                'application/json': {
+                    schema: voiceRespondResponseSchema,
+                },
+            },
+        },
+        400: {
+            description:
+                'リクエスト不正。主な業務エラーコード: ' +
+                'invalid_request（必須フィールド欠落 / message が空）/ ' +
+                'invalid_user_id（user_id が存在しない）',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    examples: {
+                        invalidRequest: {
+                            summary: '必須フィールド欠落 / message が空',
+                            value: apiErrorExamples.invalidRequest,
+                        },
+                        invalidUserId: {
+                            summary: 'user_id が存在しない',
+                            value: apiErrorExamples.invalidUserId,
+                        },
+                    },
+                },
+            },
+        },
+    },
+});

--- a/backend/src/openapi/paths/voice.ts
+++ b/backend/src/openapi/paths/voice.ts
@@ -3,7 +3,7 @@ import {
     voiceRespondRequestSchema,
     voiceRespondResponseSchema,
 } from '../../schemas/voice';
-import { apiErrorSchema } from '../../schemas/errorCodes';
+import { apiErrorSchema, ERROR_CODES } from '../../schemas/errorCodes';
 import { apiErrorExamples } from '../examples';
 
 /**
@@ -11,8 +11,8 @@ import { apiErrorExamples } from '../examples';
  *
  * 設計方針:
  * - 仕様書「API 設計書」準拠で 200 / 400 を定義する
- * - 実装側（routes/voice.ts）では user_id 未存在時に 400 `invalid_user_id` を返すため、
- *   400 の examples に `invalid_user_id` を含める
+ * - 実装側（routes/voice.ts）では user_id が不正（形式違反 / 欠落 / 未存在）の場合に
+ *   400 `invalid_user_id` を返すため、400 の examples に `invalid_user_id` を含める
  */
 registry.registerPath({
     method: 'post',
@@ -45,18 +45,18 @@ registry.registerPath({
             description:
                 'リクエスト不正。主な業務エラーコード: ' +
                 'invalid_request（必須フィールド欠落 / message が空）/ ' +
-                'invalid_user_id（user_id が存在しない）',
+                'invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）',
             content: {
                 'application/json': {
                     schema: apiErrorSchema,
                     examples: {
-                        invalidRequest: {
+                        invalid_request: {
                             summary: '必須フィールド欠落 / message が空',
-                            value: apiErrorExamples.invalidRequest,
+                            value: apiErrorExamples[ERROR_CODES.INVALID_REQUEST],
                         },
-                        invalidUserId: {
-                            summary: 'user_id が存在しない',
-                            value: apiErrorExamples.invalidUserId,
+                        invalid_user_id: {
+                            summary: 'user_id が不正（形式違反 / 欠落 / 存在しない）',
+                            value: apiErrorExamples[ERROR_CODES.INVALID_USER_ID],
                         },
                     },
                 },

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -1,6 +1,13 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
 import { userIdSchema } from './common';
 import { GAME_TYPES } from '../types';
+import {
+    submitGameRequestExampleGame1,
+    submitGameResponseExample,
+} from '../openapi/examples';
 
 /**
  * POST /api/games/submit のスキーマ群。
@@ -10,6 +17,8 @@ import { GAME_TYPES } from '../types';
  * - 業務エラーコード（invalid_user_id / invalid_game_type 等）への
  *   マッピングは errorHandler の resolveZodErrorCode に集約する
  *   （schemas/common.ts の設計方針と同じ）
+ * - OpenAPI メタデータ（description / example）は本ファイルに寄せ、
+ *   example の値は `openapi/examples.ts` に集約する
  */
 
 /**
@@ -22,40 +31,79 @@ import { GAME_TYPES } from '../types';
  * 明示的にリテラル配列として記述している。値を追加する際は
  * types/index.ts と本スキーマの両方を更新すること（将来的には
  * GAME_TYPES の値を自動展開する形にリファクタ可）。
+ *
+ * OpenAPI では `.openapi({ enum: [...] })` で enum 情報を補う
+ * （z.union<z.literal> のままだと OpenAPI 側で `anyOf` に落ちてしまうため）。
  */
-export const gameTypeSchema = z.union([
-    z.literal(GAME_TYPES.TERMS_GAME),
-    z.literal(GAME_TYPES.AI_CHAT),
-    z.literal(GAME_TYPES.GROUP_CHAT),
-]);
+export const gameTypeSchema = z
+    .union([
+        z.literal(GAME_TYPES.TERMS_GAME),
+        z.literal(GAME_TYPES.AI_CHAT),
+        z.literal(GAME_TYPES.GROUP_CHAT),
+    ])
+    .openapi({
+        description:
+            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット',
+        enum: [
+            GAME_TYPES.TERMS_GAME,
+            GAME_TYPES.AI_CHAT,
+            GAME_TYPES.GROUP_CHAT,
+        ],
+        example: GAME_TYPES.TERMS_GAME,
+    });
 
 /**
  * ゲーム固有の行動データ。
  * 構造はゲームごとに大きく異なるため、スキーマ層では空でないオブジェクトであることのみを検証する。
  * 各ゲームの `data` 構造の検証は analysis 層の責務（別 Issue で型化予定）。
+ *
+ * OpenAPI 上は自由形式オブジェクト（`additionalProperties: true`）として表現される。
+ * 具体的な各ゲームの data 構造は仕様書「データ構造」を参照（examples に game_1 の例を掲載）。
  */
 export const gameDataSchema = z
     .record(z.string(), z.unknown())
     .refine((d) => Object.keys(d).length > 0, {
         error: 'data は空オブジェクトにできません',
+    })
+    .openapi({
+        description:
+            'ゲーム固有の行動データ。game_type ごとに構造が異なる（仕様書「データ構造」参照）。空オブジェクト不可',
+        example: submitGameRequestExampleGame1.data,
     });
 
 /**
  * POST /api/games/submit のリクエストボディ。
  */
-export const submitGameRequestSchema = z.object({
-    user_id: userIdSchema,
-    game_type: gameTypeSchema,
-    data: gameDataSchema,
-});
+export const submitGameRequestSchema = z
+    .object({
+        user_id: userIdSchema,
+        game_type: gameTypeSchema,
+        data: gameDataSchema,
+    })
+    .openapi({
+        description:
+            '各ゲーム終了時に行動データを送信するリクエスト。' +
+            '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
+        example: submitGameRequestExampleGame1,
+    });
 
 /**
  * POST /api/games/submit のレスポンス（200 OK）。
  */
-export const submitGameResponseSchema = z.object({
-    status: z.literal('success'),
-    message: z.string(),
-});
+export const submitGameResponseSchema = z
+    .object({
+        status: z.literal('success').openapi({
+            description: '固定値 "success"',
+        }),
+        message: z.string().openapi({
+            description: '保存されたゲームを示す運用向けメッセージ',
+            example: submitGameResponseExample.message,
+        }),
+    })
+    .openapi({
+        description: 'ゲームデータ保存成功レスポンス（200 OK）',
+        example: submitGameResponseExample,
+    });
 
 /**
  * ゲーム種別（1/2/3）の TS 型。

--- a/backend/src/schemas/register.ts
+++ b/backend/src/schemas/register.ts
@@ -1,41 +1,74 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
 import { answerOptionSchema, mbtiSchema } from './common';
+import {
+    registerRequestExample,
+    registerResponseExample,
+} from '../openapi/examples';
 
 /**
  * POST /api/register のスキーマ群。
  *
  * - 入力検証は validate ミドルウェア経由で zod に一元化
  * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ * - OpenAPI メタデータ（description / example）は本ファイルに寄せ、
+ *   example の値は `openapi/examples.ts` に集約して複数参照（スキーマ / パス登録）を単一ソース化する
  */
 
 /**
  * 5 軸の基準値アンケート回答（A/B/C/D）。
  * 5 設問すべて必須。未知プロパティは zod v4 のデフォルト挙動で strip される。
  */
-export const baselineAnswersSchema = z.object({
-    q1_caution: answerOptionSchema,
-    q2_calmness: answerOptionSchema,
-    q3_logic: answerOptionSchema,
-    q4_cooperativeness: answerOptionSchema,
-    q5_positivity: answerOptionSchema,
-});
+export const baselineAnswersSchema = z
+    .object({
+        q1_caution: answerOptionSchema,
+        q2_calmness: answerOptionSchema,
+        q3_logic: answerOptionSchema,
+        q4_cooperativeness: answerOptionSchema,
+        q5_positivity: answerOptionSchema,
+    })
+    .openapi({
+        description:
+            '5 軸の基準値アンケート回答。各軸（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）に ' +
+            'A / B / C / D のいずれかで回答する（A=100, B=75, C=25, D=0 点に内部変換される）',
+        example: registerRequestExample.baseline_answers,
+    });
 
 /**
  * POST /api/register のリクエストボディ。
  * mbti は省略・null 許容（自己診断スキップに対応）。指定された場合は MBTI 形式に従う。
  */
-export const registerRequestSchema = z.object({
-    mbti: mbtiSchema.nullish(),
-    baseline_answers: baselineAnswersSchema,
-});
+export const registerRequestSchema = z
+    .object({
+        mbti: mbtiSchema.nullish(),
+        baseline_answers: baselineAnswersSchema,
+    })
+    .openapi({
+        description:
+            'MBTI 選択 + 基準値アンケート（5 設問）完了時に送信する登録リクエスト。' +
+            'mbti は任意（null / 省略でスキップ扱い）、baseline_answers は全 5 設問必須',
+        example: registerRequestExample,
+    });
 
 /**
  * POST /api/register のレスポンス（201 Created）。
  */
-export const registerResponseSchema = z.object({
-    user_id: z.uuid(),
-    status: z.literal('success'),
-});
+export const registerResponseSchema = z
+    .object({
+        user_id: z.uuid().openapi({
+            description: '新規発行されたユーザー識別子（UUID v4）',
+            example: registerResponseExample.user_id,
+        }),
+        status: z.literal('success').openapi({
+            description: '固定値 "success"',
+        }),
+    })
+    .openapi({
+        description: '登録成功レスポンス（201 Created）',
+        example: registerResponseExample,
+    });
 
 export type BaselineAnswers = z.infer<typeof baselineAnswersSchema>;
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;

--- a/backend/src/schemas/voice.ts
+++ b/backend/src/schemas/voice.ts
@@ -1,5 +1,12 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
 import { userIdSchema } from './common';
+import {
+    voiceRespondRequestExample,
+    voiceRespondResponseExample,
+} from '../openapi/examples';
 
 /**
  * POST /api/voice/respond のスキーマ群。
@@ -9,16 +16,28 @@ import { userIdSchema } from './common';
  * - 業務エラーコード（invalid_user_id / invalid_request）への
  *   マッピングは errorHandler の resolveZodErrorCode に集約する
  *   （schemas/common.ts の設計方針と同じ）
+ * - OpenAPI メタデータ（description / example）は本ファイルに寄せ、
+ *   example の値は `openapi/examples.ts` に集約する
  */
 
 /**
  * 会話履歴の 1 メッセージ。role は Gemini API の慣例に合わせて
  * 'user' / 'assistant' のみ許可する（system は別枠で扱うため含めない）。
  */
-export const conversationMessageSchema = z.object({
-    role: z.enum(['user', 'assistant']),
-    content: z.string(),
-});
+export const conversationMessageSchema = z
+    .object({
+        role: z.enum(['user', 'assistant']).openapi({
+            description: '発話者。user=エンドユーザー / assistant=AI',
+            example: 'user',
+        }),
+        content: z.string().openapi({
+            description: '発話テキスト',
+            example: 'ログインできません',
+        }),
+    })
+    .openapi({
+        description: '会話履歴の 1 メッセージ（Gemini API の messages 形式に準拠）',
+    });
 
 /**
  * POST /api/voice/respond のリクエストボディ。
@@ -26,27 +45,43 @@ export const conversationMessageSchema = z.object({
  * - `message` は仕様書で「空文字不可」のため `.min(1)` を付ける
  * - `conversation_history` は任意。未指定時は service 層で空配列扱い
  */
-export const voiceRespondRequestSchema = z.object({
-    user_id: userIdSchema,
-    message: z
-        .string({ error: 'message は文字列で指定してください' })
-        .min(1, { error: 'message は空文字にできません' }),
-    conversation_history: z.array(conversationMessageSchema).optional(),
-});
+export const voiceRespondRequestSchema = z
+    .object({
+        user_id: userIdSchema,
+        message: z
+            .string({ error: 'message は文字列で指定してください' })
+            .min(1, { error: 'message は空文字にできません' })
+            .openapi({
+                description: 'ユーザーの発話テキスト。空文字不可',
+                example: voiceRespondRequestExample.message,
+            }),
+        conversation_history: z
+            .array(conversationMessageSchema)
+            .optional()
+            .openapi({
+                description:
+                    '会話履歴（任意）。サーバ側では直近 1 件のみ使用する（仕様書「API 設計書」参照）',
+            }),
+    })
+    .openapi({
+        description: 'Game 2（AI カスタマーサポート）で AI 応答を生成するリクエスト',
+        example: voiceRespondRequestExample,
+    });
 
 /**
  * 応答の感情ラベル。
  *
  * 仕様書「API 設計書」で 4 種（confident / apologetic / confused / neutral）に列挙されており、
  * 実装側（voiceService.estimateEmotion と fallbackData）も同 4 種のみを返す。
- * enum 化により Issue #5（OpenAPI 化）でも enum 情報をそのまま活用できる。
+ * enum 化により OpenAPI でも enum 情報をそのまま活用できる。
  */
-export const voiceEmotionSchema = z.enum([
-    'confident',
-    'apologetic',
-    'confused',
-    'neutral',
-]);
+export const voiceEmotionSchema = z
+    .enum(['confident', 'apologetic', 'confused', 'neutral'])
+    .openapi({
+        description:
+            '応答の感情ラベル。confident=自信あり / apologetic=謝罪的 / confused=困惑 / neutral=中立',
+        example: 'confident',
+    });
 
 /**
  * POST /api/voice/respond のレスポンス（200 OK）。
@@ -55,11 +90,23 @@ export const voiceEmotionSchema = z.enum([
  * 0-1 の範囲制約を付ける（範囲違反は実装バグなのでランタイム検証目的ではなく
  * 将来の OpenAPI の minimum/maximum 反映を見越した制約）。
  */
-export const voiceRespondResponseSchema = z.object({
-    response: z.string(),
-    emotion: voiceEmotionSchema,
-    confidence: z.number().min(0).max(1),
-});
+export const voiceRespondResponseSchema = z
+    .object({
+        response: z.string().openapi({
+            description: 'AI の返答テキスト',
+            example: voiceRespondResponseExample.response,
+        }),
+        emotion: voiceEmotionSchema,
+        confidence: z.number().min(0).max(1).openapi({
+            description:
+                '応答の確信度（0-1）。Gemini 成功時は 0.6、フォールバック時は 0.2-0.3',
+            example: voiceRespondResponseExample.confidence,
+        }),
+    })
+    .openapi({
+        description: 'AI 応答生成レスポンス（200 OK）',
+        example: voiceRespondResponseExample,
+    });
 
 export type ConversationMessage = z.infer<typeof conversationMessageSchema>;
 export type VoiceEmotion = z.infer<typeof voiceEmotionSchema>;


### PR DESCRIPTION
## 概要

Issue #5 の PR-2a。POST 系 3 エンドポイント（`/api/register` / `/api/games/submit` / `/api/voice/respond`）に OpenAPI スキーマを付与し、Swagger UI に表示されるようにする。

## 変更内容

### 基盤
- `backend/src/openapi/examples.ts` 新設
  - OpenAPI ドキュメントで参照する example 値を 1 ファイルに集約
  - `apiErrorExamples` は `Record<ErrorCode, ApiError>` で縛り、`ERROR_CODES` 追加時の example 追加忘れをコンパイルエラーで検知
  - `SAMPLE_USER_ID` / 各エンドポイントの request / response 例を `notion-docs/api-design.md` から転記

### 各エンドポイント
- `schemas/{register,games,voice}.ts` に `.openapi({ description, example })` を付与
- `openapi/paths/{register,games,voice}.ts` 新設、`registry.registerPath()` を呼び出して登録
  - POST `/api/register`: 201 / 400 (invalid_mbti / invalid_answers / invalid_request)
  - POST `/api/games/submit`: 200 / 400 / 409 (invalid_request / invalid_user_id / invalid_game_type / duplicate_submission)
  - POST `/api/voice/respond`: 200 / 400 (invalid_request / invalid_user_id)
- `openapi/document.ts` から paths モジュールを副作用 import

## 設計メモ

- レスポンスコードは Notion 仕様書「API 設計書」および実装に忠実に定義した。OpenAPI を Single Source of Truth として扱うため、「将来対応予測」に基づく乖離は含めない。
- `gameTypeSchema`（`z.union<z.literal>`）は OpenAPI では `anyOf` に落ちるため `.openapi({ enum: [...] })` で enum 情報を補う。

## スコープ外

- GET 系 2 本（`/api/results/:user_id` / `/health`）の OpenAPI 化 → PR-2b
- ドキュメント整備（`docs/api.md` 新設 / `CONTRIBUTING.md` / `docs/setup.md` 追記）→ PR-2c

## 動作確認

Swagger UI（`/api-docs`）で 3 エンドポイントが表示され、各 examples が切り替え可能であることを確認。

## 関連

refs #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * OpenAPIドキュメントを拡張：新しいエンドポイント（ユーザー登録、ゲーム提出、音声応答）を追加し、各エンドポイントに対するリクエスト/レスポンス例と代表的なエラー例を明記しました。
  * スキーマに説明・例を付与して、API仕様の可読性と利用しやすさを向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->