### PR TITLE
feat: GET 系 2 本の OpenAPI 化（/api/results/:user_id, /health）

### DIFF
--- a/backend/src/openapi/document.ts
+++ b/backend/src/openapi/document.ts
@@ -12,11 +12,12 @@ import { registry } from './registry';
 import '../schemas/common';
 import '../schemas/errorCodes';
 
-// パス登録（POST 系: Issue #5 PR-2a で追加）。
-// GET 系（results / health）は PR-2b で追記する。
+// パス登録。Issue #5 PR-2a で POST 系 3 本、PR-2b で GET 系 2 本を追加。
 import './paths/register';
 import './paths/games';
 import './paths/voice';
+import './paths/results';
+import './paths/health';
 
 /**
  * Real You API の OpenAPI ドキュメントを生成する。

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -202,12 +202,14 @@ export const voiceRespondResponseExample = {
 /**
  * GET /api/results/:user_id のレスポンス例（200 OK）。
  *
- * 仕様書「API 設計書」→ GET /api/results/:user_id に記載された JSON をそのまま転記している。
- * 値は「形を示すための代表値」で、特定ユーザーの実測値ではない。
+ * 仕様書「API 設計書」→ GET /api/results/:user_id の JSON と仕様書「データ構造」→ GameDetail を
+ * 参考にしつつ、タイトル等の文字列は `analysis/scoreCalculator.ts` の実装値と揃えている
+ * （Swagger UI の閲覧者が実際のレスポンスと突合しても齟齬が出ないようにするため）。
+ * 値自体は「形を示すための代表値」で、特定ユーザーの実測値ではない。
  *
- * `details` は仕様書「データ構造」の `GameDetail` 構造に従う。本 example では
- * 各ゲームについて最小限の feature_scores / metrics を 1 件ずつ提示する
- * （網羅すると肥大化するため代表例のみ）。
+ * `details.game_*.feature_scores` は実装側では複数軸（game_1: 3 軸 / game_2: 3 軸 /
+ * game_3: 2 軸）を返す。本 example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、
+ * 実際のレスポンスでは複数要素の配列になる点に注意。
  */
 export const resultsResponseExample = {
     user_id: SAMPLE_USER_ID,
@@ -257,6 +259,8 @@ export const resultsResponseExample = {
         phase_3: 'グループの空気を読みつつ、自分の意見も主張していました。',
     },
     details: {
+        // タイトル文字列は analysis/scoreCalculator.ts の実装値に合わせる
+        // （game_2: 'AIカスタマーサポート' / game_3: '空気読みグループチャット'）
         game_1: {
             title: '利用規約ゲーム',
             feature_scores: [
@@ -267,7 +271,7 @@ export const resultsResponseExample = {
             ],
         },
         game_2: {
-            title: 'AI カスタマーサポート',
+            title: 'AIカスタマーサポート',
             feature_scores: [
                 { axis: 'positivity', name: '積極性', score: 70 },
             ],
@@ -276,7 +280,7 @@ export const resultsResponseExample = {
             ],
         },
         game_3: {
-            title: 'グループチャット',
+            title: '空気読みグループチャット',
             feature_scores: [
                 { axis: 'cooperativeness', name: '協調性', score: 60 },
             ],

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -14,8 +14,8 @@ import { ERROR_CODES, type ApiError, type ErrorCode } from '../schemas/errorCode
  * - `apiErrorExamples` は業務コード別に揃え、各エンドポイントの responses から参照する
  *
  * PR 構成メモ（Issue #5 実装計画参照）:
- * - 本 PR（PR-2a）は POST 系 3 本（register / games / voice）の example を先行で配置
- * - GET 系 2 本（results / health）の example は PR-2b で本ファイルに追記する
+ * - POST 系 3 本（register / games / voice）の example を PR-2a で配置
+ * - GET 系 2 本（results / health）の example を PR-2b で追記
  */
 
 // ---------------------------------------------------------------------------
@@ -193,4 +193,126 @@ export const voiceRespondResponseExample = {
     response: 'パスワードリセットは設定画面から行えます。',
     emotion: 'confident',
     confidence: 0.6,
+} as const;
+
+// ---------------------------------------------------------------------------
+// GET /api/results/:user_id
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/results/:user_id のレスポンス例（200 OK）。
+ *
+ * 仕様書「API 設計書」→ GET /api/results/:user_id に記載された JSON をそのまま転記している。
+ * 値は「形を示すための代表値」で、特定ユーザーの実測値ではない。
+ *
+ * `details` は仕様書「データ構造」の `GameDetail` 構造に従う。本 example では
+ * 各ゲームについて最小限の feature_scores / metrics を 1 件ずつ提示する
+ * （網羅すると肥大化するため代表例のみ）。
+ */
+export const resultsResponseExample = {
+    user_id: SAMPLE_USER_ID,
+    self_mbti: 'ENTP',
+    mbti_scores: {
+        caution: 40,
+        calmness: 50,
+        logic: 70,
+        cooperativeness: 55,
+        positivity: 85,
+    },
+    scores: {
+        caution: 45,
+        calmness: 55,
+        logic: 75,
+        cooperativeness: 60,
+        positivity: 70,
+    },
+    baseline_scores: {
+        caution: 50,
+        calmness: 60,
+        logic: 65,
+        cooperativeness: 55,
+        positivity: 75,
+    },
+    gaps: {
+        caution: -5,
+        calmness: -5,
+        logic: 10,
+        cooperativeness: 5,
+        positivity: -5,
+    },
+    game_breakdown: {
+        game_1: { caution: 45, logic: 75, calmness: 55 },
+        game_2: { positivity: 70, calmness: 55, logic: 75 },
+        game_3: { cooperativeness: 60, positivity: 70, caution: 45 },
+    },
+    feedback: {
+        title: '直感ドリブン',
+        description: 'あなたは論理よりも直感を優先して意思決定する傾向があります。',
+        gap_point: '論理性',
+    },
+    accuracy_score: 78,
+    phase_summaries: {
+        phase_1: '規約を爆速でスクロールし、最後まで読まずに同意しました。',
+        phase_2: 'AI の理不尽な対応に感情的に反応する場面が見られました。',
+        phase_3: 'グループの空気を読みつつ、自分の意見も主張していました。',
+    },
+    details: {
+        game_1: {
+            title: '利用規約ゲーム',
+            feature_scores: [
+                { axis: 'caution', name: '慎重さ', score: 45 },
+            ],
+            metrics: [
+                { label: '読了速度(px/s)', user: 2500, average: 800, category: 'scroll' },
+            ],
+        },
+        game_2: {
+            title: 'AI カスタマーサポート',
+            feature_scores: [
+                { axis: 'positivity', name: '積極性', score: 70 },
+            ],
+            metrics: [
+                { label: '発話数', user: 8, average: 5, category: 'message' },
+            ],
+        },
+        game_3: {
+            title: 'グループチャット',
+            feature_scores: [
+                { axis: 'cooperativeness', name: '協調性', score: 60 },
+            ],
+            metrics: [
+                { label: '発言数', user: 4, average: 3, category: 'message' },
+            ],
+        },
+    },
+} as const;
+
+// ---------------------------------------------------------------------------
+// GET /health
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /health のレスポンス例（200 OK, DB 接続成功時）。
+ *
+ * 仕様書「API 設計書」→ GET /health の JSON を転記。`uptime` はサンプル値として
+ * 1 時間（3600 秒）を採用。
+ */
+export const healthOkResponseExample = {
+    status: 'ok',
+    timestamp: '2026-04-16T10:00:00.000Z',
+    database: 'connected',
+    uptime: 3600,
+} as const;
+
+/**
+ * GET /health のレスポンス例（503 Service Unavailable, DB 切断時）。
+ *
+ * 仕様書で /health の 503 は他エンドポイントの `ApiError` と異なる独自形を返す規定のため、
+ * `apiErrorExamples` は使わず個別の example を用意している（schemas/health.ts 冒頭コメント参照）。
+ */
+export const healthErrorResponseExample = {
+    status: 'error',
+    timestamp: '2026-04-16T10:00:00.000Z',
+    database: 'disconnected',
+    uptime: 3600,
 } as const;

--- a/backend/src/openapi/paths/health.ts
+++ b/backend/src/openapi/paths/health.ts
@@ -1,0 +1,45 @@
+import { registry } from '../registry';
+import {
+    healthErrorResponseSchema,
+    healthOkResponseSchema,
+} from '../../schemas/health';
+
+/**
+ * GET /health のパス登録。
+ *
+ * 設計方針:
+ * - 仕様書「API 設計書」準拠で 200 / 503 を定義する
+ * - `/health` は他のエンドポイントと異なり `/api` プレフィックスを持たない
+ *   （index.ts の `app.use('/health', healthRouter)` 参照）
+ * - 200 と 503 で独自のレスポンス形（`HealthOkResponse` / `HealthErrorResponse`）を
+ *   ステータスコード別に割当てる。`ApiError` とは別形のため `oneOf` は使わない
+ *   （schemas/health.ts 冒頭コメント参照）
+ * - リクエストボディ / パラメータは存在しないので `request` キー自体を省略する
+ */
+registry.registerPath({
+    method: 'get',
+    path: '/health',
+    tags: ['Health'],
+    summary: 'ヘルスチェック',
+    description:
+        'Supabase への疎通確認を含む死活監視用エンドポイント。' +
+        '200 と 503 で独自レスポンス形を返す（他エンドポイントの ApiError とは別形）。',
+    responses: {
+        200: {
+            description: 'DB 接続 OK',
+            content: {
+                'application/json': {
+                    schema: healthOkResponseSchema,
+                },
+            },
+        },
+        503: {
+            description: 'DB 切断（Supabase への疎通失敗）',
+            content: {
+                'application/json': {
+                    schema: healthErrorResponseSchema,
+                },
+            },
+        },
+    },
+});

--- a/backend/src/openapi/paths/results.ts
+++ b/backend/src/openapi/paths/results.ts
@@ -42,8 +42,8 @@ registry.registerPath({
         400: {
             description:
                 'リクエスト不正。主な業務エラーコード: ' +
-                'invalid_user_id（UUID 形式違反）/ ' +
-                'incomplete_games（3 ゲーム全て完了していない）',
+                'invalid_user_id（UUID 形式違反。path params の validate ミドルウェアで検出し errorHandler が 400 にマップ） / ' +
+                'incomplete_games（3 ゲーム全て完了していない。resultService で throw）',
             content: {
                 'application/json': {
                     schema: apiErrorSchema,

--- a/backend/src/openapi/paths/results.ts
+++ b/backend/src/openapi/paths/results.ts
@@ -1,0 +1,78 @@
+import { registry } from '../registry';
+import {
+    resultsParamsSchema,
+    resultsResponseSchema,
+} from '../../schemas/results';
+import { apiErrorSchema, ERROR_CODES } from '../../schemas/errorCodes';
+import { apiErrorExamples } from '../examples';
+
+/**
+ * GET /api/results/:user_id のパス登録。
+ *
+ * 設計方針:
+ * - 仕様書「API 設計書」準拠で 200 / 400 / 404 を定義する
+ * - user_id の UUID 形式違反は validate ミドルウェア経由で 400 `invalid_user_id` に
+ *   マッピングされる（schemas/common.ts の設計方針参照）
+ * - 3 ゲーム全て未完了は resultService 内で 400 `incomplete_games` を投げる
+ * - user_not_found は resultService 内で 404 `user_not_found` を投げる
+ *   （games / voice が user 欠落で 400 を返すのとは仕様が異なる点に注意）
+ *
+ * 本ファイルは `document.ts` から副作用 import されることで registry に登録される。
+ */
+registry.registerPath({
+    method: 'get',
+    path: '/api/results/{user_id}',
+    tags: ['Results'],
+    summary: '診断結果取得',
+    description:
+        '3 ゲーム完了後に呼び出す。analysis_results にキャッシュがあればそれを、' +
+        'なければゲームログから計算して UPSERT した結果を返す。',
+    request: {
+        params: resultsParamsSchema,
+    },
+    responses: {
+        200: {
+            description: '診断結果取得成功',
+            content: {
+                'application/json': {
+                    schema: resultsResponseSchema,
+                },
+            },
+        },
+        400: {
+            description:
+                'リクエスト不正。主な業務エラーコード: ' +
+                'invalid_user_id（UUID 形式違反）/ ' +
+                'incomplete_games（3 ゲーム全て完了していない）',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    examples: {
+                        invalid_user_id: {
+                            summary: 'user_id が UUID 形式でない',
+                            value: apiErrorExamples[ERROR_CODES.INVALID_USER_ID],
+                        },
+                        incomplete_games: {
+                            summary: '3 ゲーム未完了で結果取得',
+                            value: apiErrorExamples[ERROR_CODES.INCOMPLETE_GAMES],
+                        },
+                    },
+                },
+            },
+        },
+        404: {
+            description: '指定された user_id のユーザーが存在しない',
+            content: {
+                'application/json': {
+                    schema: apiErrorSchema,
+                    examples: {
+                        user_not_found: {
+                            summary: 'ユーザーが見つからない',
+                            value: apiErrorExamples[ERROR_CODES.USER_NOT_FOUND],
+                        },
+                    },
+                },
+            },
+        },
+    },
+});

--- a/backend/src/openapi/paths/results.ts
+++ b/backend/src/openapi/paths/results.ts
@@ -48,9 +48,19 @@ registry.registerPath({
                 'application/json': {
                     schema: apiErrorSchema,
                     examples: {
+                        // 共通の apiErrorExamples[INVALID_USER_ID] は games / voice の
+                        // 「user_id が DB に存在しない」ケース（message: 'ユーザーIDが存在しません'）に
+                        // 合わせてあるが、results では「ユーザー存在しない = 404 user_not_found」のため
+                        // 400 invalid_user_id は UUID 形式違反に限定される。共通 example をそのまま
+                        // 使うと Swagger UI 閲覧者に誤解を与えるため、ここでは errorHandler の
+                        // formatZodErrorMessage が実際に出力する文言（path プレフィックス付き）を inline で与える
                         invalid_user_id: {
                             summary: 'user_id が UUID 形式でない',
-                            value: apiErrorExamples[ERROR_CODES.INVALID_USER_ID],
+                            value: {
+                                status: 'error',
+                                error: ERROR_CODES.INVALID_USER_ID,
+                                message: 'user_id: user_id は UUID 形式で指定してください',
+                            },
                         },
                         incomplete_games: {
                             summary: '3 ゲーム未完了で結果取得',

--- a/backend/src/schemas/health.ts
+++ b/backend/src/schemas/health.ts
@@ -1,4 +1,11 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
+import {
+    healthErrorResponseExample,
+    healthOkResponseExample,
+} from '../openapi/examples';
 
 /**
  * GET /health のスキーマ群。
@@ -6,6 +13,8 @@ import { z } from 'zod';
  * - リクエストは入力なし（params / query / body すべて空）のため validate ミドルウェアは不要
  * - 200（正常）と 503（DB 切断）で形が異なるため両方を用意する
  * - 型は z.infer から導出して TS と zod の二重管理を避ける
+ * - OpenAPI メタデータ（description / example）は本ファイルに寄せ、
+ *   example の値は `openapi/examples.ts` に集約する
  *
  * エラーフォーマットについて:
  * Notion 仕様書「API 設計書」で `/health` の 503 は他のエンドポイントの
@@ -20,24 +29,54 @@ import { z } from 'zod';
  * - `uptime` はプロセス起動からの経過秒数（`process.uptime()`）を Math.round した値
  * - `timestamp` は ISO 8601 形式の UTC 時刻文字列
  */
-export const healthOkResponseSchema = z.object({
-    status: z.literal('ok'),
-    timestamp: z.iso.datetime(),
-    database: z.literal('connected'),
-    uptime: z.number().int().nonnegative(),
-});
+export const healthOkResponseSchema = z
+    .object({
+        status: z.literal('ok').openapi({
+            description: '固定値 "ok"（DB 接続成功時）',
+        }),
+        timestamp: z.iso.datetime().openapi({
+            description: 'レスポンス生成時刻（ISO 8601 UTC）',
+            example: healthOkResponseExample.timestamp,
+        }),
+        database: z.literal('connected').openapi({
+            description: '固定値 "connected"（Supabase への疎通成功）',
+        }),
+        uptime: z.number().int().nonnegative().openapi({
+            description: 'プロセス起動からの経過秒数（整数）',
+            example: healthOkResponseExample.uptime,
+        }),
+    })
+    .openapi({
+        description: 'ヘルスチェック成功レスポンス（200 OK）',
+        example: healthOkResponseExample,
+    });
 
 /**
  * GET /health のレスポンス（503 Service Unavailable, DB 切断時）。
  *
  * 仕様書の規定により通常の ApiError 形式ではなく 200 と対称の形を返す。
  */
-export const healthErrorResponseSchema = z.object({
-    status: z.literal('error'),
-    timestamp: z.iso.datetime(),
-    database: z.literal('disconnected'),
-    uptime: z.number().int().nonnegative(),
-});
+export const healthErrorResponseSchema = z
+    .object({
+        status: z.literal('error').openapi({
+            description: '固定値 "error"（DB 切断時）',
+        }),
+        timestamp: z.iso.datetime().openapi({
+            description: 'レスポンス生成時刻（ISO 8601 UTC）',
+            example: healthErrorResponseExample.timestamp,
+        }),
+        database: z.literal('disconnected').openapi({
+            description: '固定値 "disconnected"（Supabase への疎通失敗）',
+        }),
+        uptime: z.number().int().nonnegative().openapi({
+            description: 'プロセス起動からの経過秒数（整数）',
+            example: healthErrorResponseExample.uptime,
+        }),
+    })
+    .openapi({
+        description: 'ヘルスチェック失敗レスポンス（503 Service Unavailable, DB 切断時）',
+        example: healthErrorResponseExample,
+    });
 
 export type HealthOkResponse = z.infer<typeof healthOkResponseSchema>;
 export type HealthErrorResponse = z.infer<typeof healthErrorResponseSchema>;

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -1,3 +1,6 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
 import {
     baselineScoresSchema,
@@ -5,6 +8,7 @@ import {
     mbtiSchema,
     userIdSchema,
 } from './common';
+import { resultsResponseExample } from '../openapi/examples';
 
 /**
  * GET /api/results/:user_id のスキーマ群。
@@ -14,6 +18,8 @@ import {
  * - 業務エラーコード（invalid_user_id / user_not_found / incomplete_games 等）の
  *   マッピングは errorHandler の resolveZodErrorCode / isBusinessError に集約する
  *   （schemas/common.ts の設計方針と同じ）
+ * - OpenAPI メタデータ（description / example）は本ファイルに寄せ、
+ *   example の値は `openapi/examples.ts` に集約する
  */
 
 /**
@@ -42,29 +48,61 @@ const partialBaselineScoresSchema = baselineScoresSchema.partial();
  * ゲームごとのスコア内訳。
  * 各ゲームキー（game_1 / game_2 / game_3）は optional。
  */
-export const gameBreakdownSchema = z.object({
-    game_1: partialBaselineScoresSchema.optional(),
-    game_2: partialBaselineScoresSchema.optional(),
-    game_3: partialBaselineScoresSchema.optional(),
-});
+export const gameBreakdownSchema = z
+    .object({
+        game_1: partialBaselineScoresSchema.optional(),
+        game_2: partialBaselineScoresSchema.optional(),
+        game_3: partialBaselineScoresSchema.optional(),
+    })
+    .openapi({
+        description:
+            'ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため ' +
+            '5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）',
+        example: resultsResponseExample.game_breakdown,
+    });
 
 /**
  * 診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）。
  */
-export const diagnosisFeedbackSchema = z.object({
-    title: z.string(),
-    description: z.string(),
-    gap_point: z.string(),
-});
+export const diagnosisFeedbackSchema = z
+    .object({
+        title: z.string().openapi({
+            description: '診断タイプの見出し（最大ギャップ軸に基づく）',
+            example: resultsResponseExample.feedback.title,
+        }),
+        description: z.string().openapi({
+            description: '診断タイプの説明文',
+            example: resultsResponseExample.feedback.description,
+        }),
+        gap_point: z.string().openapi({
+            description: '自己認識と実測の乖離が最大だった軸名（日本語ラベル）',
+            example: resultsResponseExample.feedback.gap_point,
+        }),
+    })
+    .openapi({
+        description: '診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）',
+        example: resultsResponseExample.feedback,
+    });
 
 /**
  * 各フェーズ（ゲーム）の振り返りテキスト。
  */
-export const phaseSummariesSchema = z.object({
-    phase_1: z.string(),
-    phase_2: z.string(),
-    phase_3: z.string(),
-});
+export const phaseSummariesSchema = z
+    .object({
+        phase_1: z.string().openapi({
+            description: 'Game 1（利用規約）の行動要約',
+        }),
+        phase_2: z.string().openapi({
+            description: 'Game 2（AI カスタマーサポート）の行動要約',
+        }),
+        phase_3: z.string().openapi({
+            description: 'Game 3（グループチャット）の行動要約',
+        }),
+    })
+    .openapi({
+        description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリー',
+        example: resultsResponseExample.phase_summaries,
+    });
 
 /**
  * GET /api/results/:user_id のレスポンス（200 OK）。
@@ -76,19 +114,49 @@ export const phaseSummariesSchema = z.object({
  * - 厳密化は analysis 戻り値の構造を固めてから別 Issue で対応する
  *   （Issue #6 の実装計画「論点」参照）
  */
-export const resultsResponseSchema = z.object({
-    user_id: userIdSchema,
-    self_mbti: mbtiSchema.nullable(),
-    mbti_scores: baselineScoresSchema.nullable(),
-    scores: baselineScoresSchema,
-    baseline_scores: baselineScoresSchema,
-    gaps: gapScoresSchema,
-    game_breakdown: gameBreakdownSchema,
-    feedback: diagnosisFeedbackSchema,
-    accuracy_score: z.number().int().min(0).max(100),
-    phase_summaries: phaseSummariesSchema,
-    details: z.unknown(),
-});
+export const resultsResponseSchema = z
+    .object({
+        user_id: userIdSchema,
+        self_mbti: mbtiSchema.nullable().openapi({
+            description: '自己申告の MBTI タイプ。登録時にスキップした場合は null',
+        }),
+        mbti_scores: baselineScoresSchema.nullable().openapi({
+            description: 'MBTI 理論値（self_mbti から導出）。self_mbti が null の場合は null',
+        }),
+        scores: baselineScoresSchema.openapi({
+            description: '3 ゲームから算出された実測の 5 軸スコア',
+        }),
+        baseline_scores: baselineScoresSchema.openapi({
+            description:
+                'ベースライン（アンケート由来）。self_mbti があれば MBTI 理論値と 70:30 でブレンド済み',
+        }),
+        gaps: gapScoresSchema.openapi({
+            description: '実測 - ベースライン の差分。負値はベースラインを下回ったことを意味する',
+        }),
+        game_breakdown: gameBreakdownSchema,
+        feedback: diagnosisFeedbackSchema,
+        accuracy_score: z.number().int().min(0).max(100).openapi({
+            description: '自己認識精度（0-100 の整数）。100 - |平均ギャップ|',
+            example: resultsResponseExample.accuracy_score,
+        }),
+        phase_summaries: phaseSummariesSchema,
+        /**
+         * 各ゲーム固有の詳細メトリクス。構造は `analysis/scoreCalculator` の戻り値に
+         * 直接依存するため現時点では `z.unknown()` で緩く定義している。
+         * 厳密化は analysis 戻り値の構造を固めてから別 Issue で対応する
+         * （本ファイル冒頭の `details` コメント参照）。
+         */
+        details: z.unknown().openapi({
+            description:
+                '各ゲーム固有の詳細メトリクス（ゲーム別タイトル / feature_scores / metrics）。' +
+                '構造の詳細は仕様書「データ構造」→ GameDetail を参照',
+            example: resultsResponseExample.details,
+        }),
+    })
+    .openapi({
+        description: '診断結果レスポンス（200 OK）',
+        example: resultsResponseExample,
+    });
 
 export type ResultsParams = z.infer<typeof resultsParamsSchema>;
 export type GameBreakdown = z.infer<typeof gameBreakdownSchema>;


### PR DESCRIPTION
## 概要

Issue #5（Swagger/OpenAPI 導入）の PR-2b。GET 系 2 本（`/api/results/:user_id` と `/health`）の OpenAPI スキーマを追加し、Swagger UI 上で全 5 エンドポイントの例示リクエスト/レスポンスが閲覧できる状態にする。

PR-2a（#18）の POST 系実装パターン（`examples.ts` に example 集約 → `schemas/*.ts` に `.openapi()` 付与 → `paths/*.ts` でパス登録 → `document.ts` で副作用 import）を踏襲。

## 変更内容

- `backend/src/openapi/examples.ts`
  - `resultsResponseExample` / `healthOkResponseExample` / `healthErrorResponseExample` を追加
  - `details.game_*.title` は実装（`analysis/scoreCalculator.ts`）の文字列値に合わせる
- `backend/src/schemas/results.ts` に `.openapi({ description, example })` を追記（`gameBreakdownSchema` / `diagnosisFeedbackSchema` / `phaseSummariesSchema` / `resultsResponseSchema`）
- `backend/src/schemas/health.ts` に `.openapi({ description, example })` を追記（200 / 503 両スキーマ）
- `backend/src/openapi/paths/results.ts` を新設（GET /api/results/:user_id。200 / 400 / 404）
- `backend/src/openapi/paths/health.ts` を新設（GET /health。200 / 503、ステータスコード別に独自スキーマ割当）
- `backend/src/openapi/document.ts` に GET 系パスの副作用 import を追加

## 動作確認

- `npx tsc --noEmit` ✅ / `npm run build` ✅
- `buildOpenApiDocument()` で 5 パスすべてが `/api/register` / `/api/games/submit` / `/api/voice/respond` / `/api/results/{user_id}` / `/health` として登録されることを確認
- `/api/results/{user_id}` の path params に `userIdSchema` の description / example が継承されることを確認
- `/health` の 200 / 503 が独立したスキーマ（`HealthOkResponse` / `HealthErrorResponse`）として生成されることを確認

## 補足

`details.game_*.feature_scores` の example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、実際のレスポンスでは複数軸の配列になる点は examples.ts のコメントに明記。

## 関連

refs #5

次（PR-2c）で `docs/api.md` 新設 + `CONTRIBUTING.md` 導線追加 + `docs/setup.md` 追記を行い、Issue をクローズする予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ヘルスチェック（GET /health）APIを追加。稼働状態やDB接続／稼働時間の確認が可能になりました。

* **ドキュメント**
  * 結果取得APIの仕様を拡張。MBTIスコア、ゲーム別内訳、フェーズ要約、詳細なレスポンス例とエラー例を含む完全なAPIドキュメントを提供します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->