### PR TITLE
docs: Swagger (OpenAPI) のドキュメントを整備

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,9 @@
 ブランチ・コミット・PR・Issue の運用ルールはこちら。
 
 → [docs/development-rule.md](docs/development-rule.md)
+
+## API 仕様
+
+バックエンド API の仕様は Swagger UI から閲覧できます。Swagger UI の開き方・仕組み・スキーマの更新手順はこちら。
+
+→ [docs/api.md](docs/api.md)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,5 +5,5 @@ GEMINI_API_KEY=your_gemini_api_key_here
 FRONTEND_URL=your_front_end_url
 
 # Swagger UI（/api-docs）の有効/無効を切り替える
-# デフォルトは有効。本番で閉じたい場合のみ "false" を指定する
+# 開発環境では true（デフォルト）、本番環境では false に設定する
 ENABLE_SWAGGER_UI=true

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,9 +18,11 @@ http://localhost:3001/api-docs
 
 Swagger UI 上の「Try it out」ボタンからその場で API を叩いて挙動を確認することもできます。
 
-### 本番環境などで公開したくないとき
+### 本番環境での扱い
 
-`ENABLE_SWAGGER_UI=false` を明示的に指定した場合のみ `/api-docs` のマウントが無効化されます。未設定や他の値では有効のままです（`backend/.env.example` 参照）。
+**本番環境では `ENABLE_SWAGGER_UI=false` を設定し、Swagger UI を無効化します。** API 仕様を外部に公開する必要がないこと、および攻撃面を減らすことが理由です。
+
+`false` を明示的に指定した場合のみ無効化され、未設定や他の値では有効のままです（`backend/.env.example` 参照）。
 
 ## 仕組み
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,61 @@
+# API 仕様
+
+Real You のバックエンド API は OpenAPI 3.1 に対応しており、Swagger UI から閲覧できます。
+
+## Swagger UI を開く
+
+backend を起動した状態で、以下の URL にアクセスすると API 仕様が閲覧できます。
+
+```
+http://localhost:3001/api-docs
+```
+
+閲覧できる情報:
+
+- 全エンドポイントのパス・メソッド・概要
+- リクエスト / レスポンスのスキーマと具体例
+- エラーレスポンスの業務コード一覧と、コード別の例示
+
+Swagger UI 上の「Try it out」ボタンからその場で API を叩いて挙動を確認することもできます。
+
+### 本番環境などで公開したくないとき
+
+`ENABLE_SWAGGER_UI=false` を環境変数に設定すると、`/api-docs` のマウントを無効化できます。デフォルトは有効です。未設定 / その他の値では有効のままです（`backend/.env.example` 参照）。
+
+## 仕組み
+
+Real You では **zod スキーマを仕様の Single Source of Truth（単一の真実）** として扱い、そこから OpenAPI ドキュメントを自動生成しています。
+
+```
+zod スキーマ（backend/src/schemas/*.ts）
+      │
+      │  .openapi({ description, example, ... }) でメタデータ付与
+      ▼
+OpenAPIRegistry（backend/src/openapi/registry.ts）
+      │
+      │  registerPath() でエンドポイントを登録
+      │  （backend/src/openapi/paths/*.ts）
+      ▼
+OpenAPI ドキュメント（backend/src/openapi/document.ts）
+      │
+      ▼
+Swagger UI（/api-docs）
+```
+
+使用ライブラリ:
+
+- [`@asteasolutions/zod-to-openapi`](https://github.com/asteasolutions/zod-to-openapi) — zod スキーマに `.openapi()` メソッドを生やし、OpenAPI ドキュメントを生成する
+- [`swagger-ui-express`](https://github.com/scottie1984/swagger-ui-express) — 生成したドキュメントを Swagger UI として配信する
+
+## スキーマを更新するとき
+
+API の入出力を変更する場合は、以下の流れで作業します。
+
+1. `backend/src/schemas/` の該当ファイルで zod スキーマを更新する
+2. 必要に応じて `.openapi({ description, example })` のメタデータを追記 / 変更する
+3. example の値を変える場合は `backend/src/openapi/examples.ts` を更新する（複数箇所から参照されているため）
+4. エンドポイント自体の追加 / 変更がある場合は `backend/src/openapi/paths/` 配下を更新する
+5. 新しく追加したエンドポイントのパスファイルは `backend/src/openapi/document.ts` に副作用 import を追記する
+6. backend を再起動し、`/api-docs` で反映を確認する
+
+zod スキーマの変更はリクエスト検証にも直接反映されます（検証ミドルウェアが同じスキーマを使っているため、仕様と実装が乖離しません）。

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@ Swagger UI 上の「Try it out」ボタンからその場で API を叩いて挙
 
 ### 本番環境などで公開したくないとき
 
-`ENABLE_SWAGGER_UI=false` を環境変数に設定すると、`/api-docs` のマウントを無効化できます。デフォルトは有効です。未設定 / その他の値では有効のままです（`backend/.env.example` 参照）。
+`ENABLE_SWAGGER_UI=false` を明示的に指定した場合のみ `/api-docs` のマウントが無効化されます。未設定や他の値では有効のままです（`backend/.env.example` 参照）。
 
 ## 仕組み
 
@@ -55,7 +55,7 @@ API の入出力を変更する場合は、以下の流れで作業します。
 2. 必要に応じて `.openapi({ description, example })` のメタデータを追記 / 変更する
 3. example の値を変える場合は `backend/src/openapi/examples.ts` を更新する（複数箇所から参照されているため）
 4. エンドポイント自体の追加 / 変更がある場合は `backend/src/openapi/paths/` 配下を更新する
-5. 新しく追加したエンドポイントのパスファイルは `backend/src/openapi/document.ts` に副作用 import を追記する
+5. **新規にパスファイルを追加した場合のみ**、`backend/src/openapi/document.ts` に副作用 import を追記する（既存ファイルの編集だけであれば不要）
 6. backend を再起動し、`/api-docs` で反映を確認する
 
 zod スキーマの変更はリクエスト検証にも直接反映されます（検証ミドルウェアが同じスキーマを使っているため、仕様と実装が乖離しません）。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,6 +56,8 @@ npm run dev
 
 `http://localhost:3001/health` にアクセスして、レスポンスが返ってくれば OK。
 
+`http://localhost:3001/api-docs` にアクセスすると Swagger UI で API 仕様が閲覧できます（詳細は [docs/api.md](api.md) を参照）。
+
 ### Frontend
 
 ```bash


### PR DESCRIPTION
## 概要

Issue #5（Swagger / OpenAPI 導入）の最終 PR（PR-2c）。実装は PR-1 / PR-2a / PR-2b（#17 / #18 / #20）で完了済みのため、本 PR はドキュメント整備に限定する。

## 変更内容

- `docs/api.md` を新設
  - Swagger UI の開き方（`http://localhost:3001/api-docs`）
  - `ENABLE_SWAGGER_UI=false` の無効化指定
  - zod を Single Source of Truth として OpenAPI を自動生成する仕組みの概要
  - スキーマ / エンドポイントを更新する際の手順
- `CONTRIBUTING.md` に「API 仕様」セクションを追加し、`docs/api.md` への導線を設置
- `docs/setup.md` の起動確認セクションに Swagger UI の案内を 1 行追記

エラーコード一覧は Swagger UI 側で閲覧可能なため、二重管理を避けて `docs/api.md` には載せていない。

closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * バックエンドのAPI仕様をSwagger UIで閲覧・試行できるドキュメントを追加
  * ローカルでのAPI閲覧手順（URLと「Try it out」の使い方）を明記
  * セットアップ手順にAPIドキュメントへのアクセス方法を追記
  * コントリビューター向けガイドにAPI仕様セクションを新設し、運用上のSwagger UIの有効/無効設定について記載
<!-- end of auto-generated comment: release notes by coderabbit.ai -->