### PR TITLE
fix: Swagger UI の Try it out が CORS で 500 を返す問題を修正

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,14 +9,28 @@ import gamesRouter from './routes/games';
 import resultsRouter from './routes/results';
 import voiceRouter from './routes/voice';
 import healthRouter from './routes/health';
-import { errorHandler } from './middleware/errorHandler';
+import { errorHandler, CorsError } from './middleware/errorHandler';
 import { buildOpenApiDocument } from './openapi/document';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-const allowedOrigins = process.env.FRONTEND_URL
+
+// Swagger UI（/api-docs）の有効/無効判定。
+// 'false' 文字列を明示指定した場合のみ無効化する厳格判定（未設定や予期しない値で
+// 誤って無効化される事故を防ぐため）。CORS 許可リスト生成でも参照する。
+const enableSwaggerUi = process.env.ENABLE_SWAGGER_UI !== 'false';
+
+// CORS 許可オリジン。FRONTEND_URL はカンマ区切りで複数指定可。
+// Swagger UI が有効なときは self-origin（backend 自身のオリジン）も許可する。
+// Swagger UI の "Try it out" は backend と同一オリジンから fetch を飛ばすため、
+// self-origin を許可しないと CORS 拒否で API が叩けなくなる。
+// localhost / 127.0.0.1 の両方をカバーする（ブラウザがどちらの表記でアクセスしても通るように）。
+const allowedOrigins: string[] = process.env.FRONTEND_URL
     ? process.env.FRONTEND_URL.split(',')
     : ['http://localhost:3000'];
+if (enableSwaggerUi) {
+    allowedOrigins.push(`http://localhost:${PORT}`, `http://127.0.0.1:${PORT}`);
+}
 
 // Middleware
 app.use(cors({
@@ -24,7 +38,9 @@ app.use(cors({
         if (!origin || allowedOrigins.includes(origin)) {
             callback(null, true);
         } else {
-            callback(new Error('Not allowed by CORS'));
+            // 専用の CorsError を投げて errorHandler 側で 403 に振り分ける
+            // （通常の Error だと 500 server_error に落ちてしまうため）。
+            callback(new CorsError(`Origin not allowed: ${origin}`));
         }
     },
 }));
@@ -38,10 +54,8 @@ app.use('/api/voice', voiceRouter);
 app.use('/health', healthRouter);
 
 // Swagger UI（API ドキュメント閲覧用）
-// デフォルトは有効。本番で閉じたい場合は環境変数 `ENABLE_SWAGGER_UI=false` を設定する。
-// 'false' 文字列を明示指定した場合のみ無効化する厳格判定にすることで、
-// 未設定や予期しない値で誤って無効化される事故を防ぐ。
-const enableSwaggerUi = process.env.ENABLE_SWAGGER_UI !== 'false';
+// デフォルトは有効。本番で閉じたい場合は環境変数 `ENABLE_SWAGGER_UI=false` を設定する
+// （判定ロジックは上部の `enableSwaggerUi` 参照）。
 if (enableSwaggerUi) {
     const openapiDocument = buildOpenApiDocument();
     app.use(

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -4,12 +4,29 @@ import { ApiError } from '../types';
 import { ERROR_CODES, ErrorCode } from '../schemas/errorCodes';
 
 /**
+ * CORS による拒否を表す専用エラー。
+ *
+ * `cors` ミドルウェアの origin コールバックで `new Error(...)` を投げると、
+ * Express のエラーハンドラに流れて通常の Error と区別が付かなくなる
+ * （メッセージ文字列で判定することになり脆い）。
+ * 専用クラスを用意して `instanceof` で判定できるようにすることで、
+ * errorHandler 側で 403 系の扱いに振り分ける。
+ */
+export class CorsError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'CorsError';
+    }
+}
+
+/**
  * Express のエラーハンドラ。
  *
  * 対応するエラー:
  * - ZodError: validate ミドルウェアから来る検証失敗。
  *   path / code から API 設計書のエラーコードへマッピングして 400 で返す
  *   （resolveZodErrorCode 参照）。
+ * - CorsError: CORS 許可リスト外のオリジンからのリクエスト。403 で返す。
  * - { status, code, message } 形式のオブジェクト: service 層で throw される業務エラー。
  *   status / code をそのまま使う。
  * - その他: 500 server_error として返す。
@@ -33,6 +50,23 @@ export const errorHandler = (
             message: formatZodErrorMessage(err),
         };
         res.status(400).json(apiError);
+        return;
+    }
+
+    // CORS による拒否は設定ミスや許可外オリジンからのアクセスであり、
+    // サーバー内部エラー（500）ではなく 403 で返す。
+    // ログは warn（業務上想定しうる 4xx 挙動のため error 扱いにしない）。
+    // エラーコードは既存の `invalid_request` を流用（仕様書への新規コード追加はスコープ外）。
+    // 内部情報（許可リストの中身など）を漏らさないため、クライアントへの message は固定文言にする。
+    if (err instanceof CorsError) {
+        console.warn('CORS rejected:', err.message);
+
+        const apiError: ApiError = {
+            status: 'error',
+            error: ERROR_CODES.INVALID_REQUEST,
+            message: 'CORS によりリクエストが拒否されました',
+        };
+        res.status(403).json(apiError);
         return;
     }
 


### PR DESCRIPTION
## 概要

Swagger UI の Try it out から API を実行すると CORS 違反となり、500 `server_error` が返っていた問題を修正する。

closes #22

## 変更内容

### 1. CORS 許可リストに self-origin を追加（`src/index.ts`）

Swagger UI の Try it out は backend 自身のオリジン（`http://localhost:3001`）から `fetch` を飛ばすため、self-origin が許可リストに含まれていないと CORS で弾かれる。

- `ENABLE_SWAGGER_UI` が有効なとき、`http://localhost:${PORT}` と `http://127.0.0.1:${PORT}` を許可リストに追加
- `enableSwaggerUi` の判定を CORS 設定より前に移動し、許可リスト生成と Swagger UI マウントで共有

**Issue 本文の方針「リクエストの Host と一致するオリジンを許可」から、`PORT` 環境変数ベースの静的リストに変更しています。`cors` ミドルウェアの `origin` コールバックは `req` を受けられない制約があるのと、Host ヘッダを信用するのは Host Header Injection の温床になり得るため、静的リストの方が堅い判断です。**

### 2. `CorsError` クラスを追加し、errorHandler で 403 に振り分け（`src/middleware/errorHandler.ts`）

- 従来は `new Error('Not allowed by CORS')` を投げており、errorHandler で他の Error と区別できず 500 `server_error` に落ちていた
- 専用の `CorsError extends Error` を追加し、`instanceof` で型判定できるように
- errorHandler に `CorsError` 分岐を追加: **403 + `invalid_request` + 固定 message** で返す
- ログは `console.warn` レベル（業務想定しうる 4xx 挙動のため error 扱いにしない）
- クライアントへの message は固定文言にして内部情報（許可リストの中身など）を漏らさない

エラーコードは既存の `ERROR_CODES.INVALID_REQUEST` を流用。仕様書（api-design.md）への新規エラーコード追加はスコープ外。

## 運用上の注意

- 本番環境では `ENABLE_SWAGGER_UI=false` を設定する運用（`.env.example` に既に明記済み）。未設定時は self-origin が許可リストに載るため、本番で Swagger を閉じる目的なら環境変数を正しく設定する必要がある

## 動作確認

1. `cd backend && npm run dev`
2. `http://localhost:3001/api-docs` にアクセス
3. `POST /api/register` を展開し「Try it out」→「Execute」
4. 仕様通りのレスポンス（正常系 201、バリデーションエラー 400 等）が返ることを確認
5. 許可外オリジン（例: curl で `Origin: http://evil.example.com` を付与）からのリクエストに対して 403 `invalid_request` が返ることを確認

## スコープ外

- Swagger UI 以外の CORS 運用見直し（別検討）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * CORS エラーハンドリングを改善しました。許可されていないオリジンからのリクエストに対して、より適切なエラーレスポンス（403ステータス）を返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->