### PR TITLE
fix: 分析レイヤーの死にコードと NaN 伝播バグを一括修正

### DIFF
--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -3,7 +3,6 @@ import { PhaseSummaries } from '../types';
 /**
  * 各フェーズの行動データから、結果画面に表示するサマリーテキストを生成する
  *
- * ★ たまちゃへ：ここを実装してください
  * - 各ゲームの raw_data を受け取って、ユーザーの行動を日本語テキストにまとめる
  * - 例: 「利用規約を12秒で同意しました。読了率8%」
  * - raw_data の構造は ANALYSIS_GUIDE.md を参照
@@ -12,17 +11,22 @@ export function buildPhaseSummaries(
     game1Raw: any | undefined,
     game2Raw: any | undefined,
     game3Raw: any | undefined,
+    game1Metrics?: { averageSpeed?: number; reversalCount?: number },
 ): PhaseSummaries {
-    
+
     // --- Phase 1: 利用規約ゲームの要約 ---
     let phase1Text = 'データなし';
     if (game1Raw) {
-        const timeSec = (game1Raw.totalTime || 0).toFixed(1);
-        const speed = game1Raw.scrollMetrics?.averageSpeed || 0;
+        const timeSec = (game1Raw.totalTime ?? 0).toFixed(1);
+        // scrollEvents から算出済みの平均速度を calculateGame1() の戻り値経由で受け取る
+        // （仕様書上、FE は scrollEvents のみ送信する設計）
+        const speed = game1Metrics?.averageSpeed ?? 0;
         const speedText = speed > 2000 ? '爆速でスクロールし' : speed < 1000 ? 'じっくりと読み込み' : '平均的な速度で確認し';
-        
+
+        // 仕様書「データ構造 → Game1Data → checkboxStates」で mailMagazine は { checked, changed } 形式
+        // mailMagazine は初期値 ON のため checked === true が「外し忘れ＝罠にひっかかった」判定
         let trapText = '';
-        const mailChecked = game1Raw.checkboxStates?.mailMagazine?.final;
+        const mailChecked = game1Raw.checkboxStates?.mailMagazine?.checked;
         if (mailChecked) trapText = 'メルマガの罠に見事に引っかかりました。';
         else trapText = '不要なチェックは見逃さず外しました。';
 
@@ -35,9 +39,9 @@ export function buildPhaseSummaries(
         const method = game2Raw.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
         const turns = game2Raw.turns || [];
         
-        // 平均反応速度を計算
-        const avgReaction = turns.length > 0 
-            ? turns.reduce((sum: number, t: any) => sum + (t.reactionTimeMs || 2000), 0) / turns.length 
+        // 平均反応速度を計算（`??` で null/undefined のみフォールバック。本ファイル内での整合性のため）
+        const avgReaction = turns.length > 0
+            ? turns.reduce((sum: number, t: any) => sum + (t.reactionTimeMs ?? 2000), 0) / turns.length
             : 2000;
         
         const reactionText = avgReaction < 800 ? 'AIの理不尽な対応に即座に反応し' : 'AIの対応に対して一呼吸おいてから';
@@ -57,7 +61,7 @@ export function buildPhaseSummaries(
         const socialText = conformRate >= 60 ? 'グループの空気を敏感に察知して周りに合わせ' : '周りに流されず我が道をゆく選択肢を取り';
         
         const avgReaction = stages.length > 0
-            ? stages.reduce((sum: number, s: any) => sum + (s.reactionTime || 2000), 0) / stages.length
+            ? stages.reduce((sum: number, s: any) => sum + (s.reactionTimeMs ?? 2000), 0) / stages.length
             : 2000;
         const speedText = avgReaction < 2000 ? '即決でアクションを起こしました。' : '慎重にタイミングを伺いました。';
 

--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -38,12 +38,15 @@ export function buildPhaseSummaries(
     if (game2Raw) {
         const method = game2Raw.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
         const turns = game2Raw.turns || [];
-        
-        // 平均反応速度を計算（`??` で null/undefined のみフォールバック。本ファイル内での整合性のため）
+
+        // サマリーテキスト用の平均反応速度。`?? 2000` は未測定時の中立値（「慎重側」と「即応側」の境界）。
+        // scoreCalculator.ts は同じフィールドを `?? 0` で扱うため、reactionTimeMs が null（= 無発話/
+        // タイムアウトの正規値）のペイロードではテキストとスコアで評価が食い違う可能性がある。
+        // 根本対応（null を集計対象外として扱う統一ロジック）は Issue #11 の派生で行う。
         const avgReaction = turns.length > 0
             ? turns.reduce((sum: number, t: any) => sum + (t.reactionTimeMs ?? 2000), 0) / turns.length
             : 2000;
-        
+
         const reactionText = avgReaction < 800 ? 'AIの理不尽な対応に即座に反応し' : 'AIの対応に対して一呼吸おいてから';
         
         phase2Text = `${reactionText}、${method}反論を展開しました。`;
@@ -60,6 +63,8 @@ export function buildPhaseSummaries(
         
         const socialText = conformRate >= 60 ? 'グループの空気を敏感に察知して周りに合わせ' : '周りに流されず我が道をゆく選択肢を取り';
         
+        // サマリーテキスト用の平均反応速度。`?? 2000` は中立値（Phase 2 と同じ方針）。
+        // scoreCalculator.ts 側は `?? 0` のため、null 混入時の挙動差は Issue #11 派生で整合化する。
         const avgReaction = stages.length > 0
             ? stages.reduce((sum: number, s: any) => sum + (s.reactionTimeMs ?? 2000), 0) / stages.length
             : 2000;

--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -11,7 +11,7 @@ export function buildPhaseSummaries(
     game1Raw: any | undefined,
     game2Raw: any | undefined,
     game3Raw: any | undefined,
-    game1Metrics?: { averageSpeed?: number; reversalCount?: number },
+    game1Metrics?: { averageSpeed?: number },
 ): PhaseSummaries {
 
     // --- Phase 1: 利用規約ゲームの要約 ---

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -134,7 +134,17 @@ function calculateGame1(data: any) {
 //積極性・冷静さ・論理性を評価
 
 function calculateGame2(data: any) {
-  if (!data) return { positivity: 50, calmness: 50, logic: 50 };
+  // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+  // アクセスして undefined がレスポンスに漏れるのを防ぐため）
+  if (!data) return {
+    positivity: 50,
+    calmness: 50,
+    logic: 50,
+    avgReact: 0,
+    totalSpeech: 0,
+    avgVolume: 0,
+    logicWordsCount: 0,
+  };
 
   const turns = data.turns || [];
 
@@ -177,6 +187,9 @@ function calculateGame2(data: any) {
   const sVolume = sigmoidInv(avgVolume, -15, 0.5);
   const sSilence = linearInv(silenceRate, 0.05, 0.5);
   const sTyping = linearInv(
+    // 未計測時は中立値 200（linearInv の中央付近）にフォールバック。
+    // 他の reducer と違い 0 にすると「打鍵ブレ極小＝満点」扱いになり
+    // 冷静さが不当に上振れるため、意図的に ?? 0 とは揃えていない。
     data.textInputMetrics?.typingIntervalVariance ?? 200,
     50,
     500
@@ -210,7 +223,15 @@ function calculateGame2(data: any) {
 //協調性・積極性・慎重さを評価
 
 function calculateGame3(data: any) {
-  if (!data) return { cooperativeness: 50, positivity: 50, caution: 50 };
+  // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+  // アクセスして undefined がレスポンスに漏れるのを防ぐため）
+  if (!data) return {
+    cooperativeness: 50,
+    positivity: 50,
+    caution: 50,
+    conformCount: 0,
+    avgReact: 0,
+  };
 
   const stages = data.stages || [];
 

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -279,7 +279,7 @@ export function generateAnalysisResult(
     game1Raw,
     game2Raw,
     game3Raw,
-    { averageSpeed: g1.averageSpeed, reversalCount: g1.reversalCount }
+    { averageSpeed: g1.averageSpeed }
   );
 
   const scores = {
@@ -335,7 +335,7 @@ const feedback = generateFeedback(scores, gaps);
         // （仕様書上、FE は scrollEvents のみ送信する設計のため、raw_data には scrollMetrics は無い）
         metrics: [
           { label: "読了速度(px/s)", user: Math.round(g1.averageSpeed ?? 0), average: 800, category: "scroll" },
-          { label: "総滞在時間(秒)", user: Number(((game1Raw?.totalTime || 0) / 1000).toFixed(1)), average: 15.0, category: "time" },
+          { label: "総滞在時間(秒)", user: Number((game1Raw?.totalTime ?? 0).toFixed(1)), average: 15.0, category: "time" },
           { label: "決断前迷い(ms)", user: game1Raw?.agreeButtonHoverTimeMs ?? 0, average: 1200, category: "mouse" },
           { label: "チェック変更(回)", user: g1.changedCount, average: 3.2, category: "input" },
           { label: "逆行確認(回)", user: g1.reversalCount ?? 0, average: 2.1, category: "scroll" },

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -51,7 +51,16 @@ const sigmoidInv = (val: number, c: number, k = 0.4) =>
 //慎重さ・論理性・冷静さを評価
 
 function calculateGame1(data: any) {
-  if (!data) return { caution: 50, logic: 50, calmness: 50 };
+  // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+  // アクセスして undefined がレスポンスに漏れるのを防ぐため）
+  if (!data) return {
+    caution: 50,
+    logic: 50,
+    calmness: 50,
+    changedCount: 0,
+    averageSpeed: 0,
+    reversalCount: 0,
+  };
 
   const totalTimeMs = (data.totalTime || 0) * 1000;
 
@@ -77,7 +86,7 @@ function calculateGame1(data: any) {
   //慎重さ: 滞在時間・スクロール速度・迷い時間・チェック変更
   const sTime = logNorm(totalTimeMs, 2000, 30000);
   const sScroll = linearInv(speed, 800, 4000);
-  const sHover = logNorm(data.agreeButtonHoverTimeMs || 0, 100, 3000);
+  const sHover = logNorm(data.agreeButtonHoverTimeMs ?? 0, 100, 3000);
   const sCheckbox = linear(checkboxChanged, 0, 3);
 
   const caution = Math.round(
@@ -94,7 +103,7 @@ function calculateGame1(data: any) {
 
   const sHidden = linear(hiddenMatch, 0, 1);
   const sReversal = linear(reversalCount, 0, 5);
-  const sPopupDelay = logNorm(data.popupStats?.timeToClose || 0, 0, 2000);
+  const sPopupDelay = logNorm(data.popupStats?.timeToClose ?? 0, 0, 2000);
 
   const logic = Math.round(
     sHidden * 0.4 +
@@ -103,15 +112,22 @@ function calculateGame1(data: any) {
   );
 
   //冷静さ: マウスブレ・無駄クリック
-  const sJitter = linearInv(data.popupStats?.mouseJitter || 0, 10, 200);
-  const sClick = linearInv(data.popupStats?.clickCount || 1, 1, 5);
+  const sJitter = linearInv(data.popupStats?.mouseJitter ?? 0, 10, 200);
+  const sClick = linearInv(data.popupStats?.clickCount ?? 1, 1, 5);
 
   const calmness = Math.round(
     sJitter * 0.6 +
     sClick * 0.4
   );
 
-  return { caution, logic, calmness, changedCount: checkboxChanged };
+  return {
+    caution,
+    logic,
+    calmness,
+    changedCount: checkboxChanged,
+    averageSpeed: speed,
+    reversalCount,
+  };
 }
 
 //Game2 AIチャット
@@ -122,19 +138,23 @@ function calculateGame2(data: any) {
 
   const turns = data.turns || [];
 
+  // 以下の reducer の `?? 0` は NaN 伝播を防ぐ短期ガード。
+  // FE の型定義上 reactionTimeMs 等は `null`（= 発話なし/タイムアウトの正規値）が
+  // 来ることがあり、0 として扱うとスコアが歪む可能性がある。
+  // 根本対応（zod による入力検証と null の意味論的ハンドリング）は Issue #11 の派生で行う。
   const avgReact =
-    turns.reduce((a: number, t: any) => a + (t.reactionTimeMs || 0), 0) /
+    turns.reduce((a: number, t: any) => a + (t.reactionTimeMs ?? 0), 0) /
     (turns.length || 1);
 
   const totalSpeech =
-    turns.reduce((a: number, t: any) => a + (t.speechDurationMs || 0), 0);
+    turns.reduce((a: number, t: any) => a + (t.speechDurationMs ?? 0), 0);
 
   const avgVolume =
     turns.reduce((a: number, t: any) => a + (t.volumeDb ?? -30), 0) /
     (turns.length || 1);
 
   const silence =
-    turns.reduce((a: number, t: any) => a + (t.silenceDurationMs || 0), 0);
+    turns.reduce((a: number, t: any) => a + (t.silenceDurationMs ?? 0), 0);
 
   const silenceRate =
     totalSpeech > 0 ? silence / totalSpeech : 0;
@@ -157,7 +177,7 @@ function calculateGame2(data: any) {
   const sVolume = sigmoidInv(avgVolume, -15, 0.5);
   const sSilence = linearInv(silenceRate, 0.05, 0.5);
   const sTyping = linearInv(
-    data.textInputMetrics?.typingIntervalVariance || 200,
+    data.textInputMetrics?.typingIntervalVariance ?? 200,
     50,
     500
   );
@@ -202,21 +222,19 @@ function calculateGame3(data: any) {
     conformCount / (stages.length || 1);
 
   const avgReact =
-    stages.reduce((a: number, s: any) => a + s.reactionTimeMs, 0) /
+    stages.reduce((a: number, s: any) => a + (s.reactionTimeMs ?? 0), 0) /
     (stages.length || 1);
 
   const reactionVariance =
     stages.reduce((a: number, s: any) =>
-      a + Math.pow(s.reactionTimeMs - avgReact, 2), 0) /
+      a + Math.pow((s.reactionTimeMs ?? 0) - avgReact, 2), 0) /
     (stages.length || 1);
 
   //協調性: 同調率・譲り待機・本音葛藤
   const sConform = linear(conformRate, 0, 1);
-  const sWait = logNorm(data.typingIndicatorReactTimeMs || 0, 0, 5000);
+  const sWait = logNorm(data.typingIndicatorReactTimeMs ?? 0, 0, 5000);
 
-  const hoverCount = Array.isArray(data.hoveredOptions)
-    ? data.hoveredOptions.length
-    : (data.hoveredOptions || 0);
+  const hoverCount = data.hoveredOptions ?? 0;
 
   const sHover = linear(hoverCount, 0, 5);
 
@@ -232,7 +250,7 @@ function calculateGame3(data: any) {
   );
 
   //慎重さ: チュートリアル確認・反応安定
-  const sTutorial = logNorm(data.tutorialViewTime || 0, 1000, 15000);
+  const sTutorial = logNorm(data.tutorialViewTime ?? 0, 1000, 15000);
   const sVariance = linearInv(reactionVariance, 500, 5000);
 
   const caution = Math.round(
@@ -260,7 +278,8 @@ export function generateAnalysisResult(
   const phaseSummaries = buildPhaseSummaries(
     game1Raw,
     game2Raw,
-    game3Raw
+    game3Raw,
+    { averageSpeed: g1.averageSpeed, reversalCount: g1.reversalCount }
   );
 
   const scores = {
@@ -312,14 +331,16 @@ const feedback = generateFeedback(scores, gaps);
           { axis: "logic", name: "論理性", score: g1.logic },
           { axis: "calmness", name: "冷静さ", score: g1.calmness }
         ],
+        // g1.averageSpeed / g1.reversalCount は calculateGame1() 内で scrollEvents から算出済み
+        // （仕様書上、FE は scrollEvents のみ送信する設計のため、raw_data には scrollMetrics は無い）
         metrics: [
-          { label: "読了速度(px/s)", user: game1Raw?.scrollMetrics?.averageSpeed || 0, average: 800, category: "scroll" },
+          { label: "読了速度(px/s)", user: Math.round(g1.averageSpeed ?? 0), average: 800, category: "scroll" },
           { label: "総滞在時間(秒)", user: Number(((game1Raw?.totalTime || 0) / 1000).toFixed(1)), average: 15.0, category: "time" },
-          { label: "決断前迷い(ms)", user: game1Raw?.agreeButtonHoverTimeMs || 0, average: 1200, category: "mouse" },
+          { label: "決断前迷い(ms)", user: game1Raw?.agreeButtonHoverTimeMs ?? 0, average: 1200, category: "mouse" },
           { label: "チェック変更(回)", user: g1.changedCount, average: 3.2, category: "input" },
-          { label: "逆行確認(回)", user: game1Raw?.scrollMetrics?.reversalCount || 0, average: 2.1, category: "scroll" },
-          { label: "マウスブレ(px)", user: game1Raw?.popupStats?.mouseJitter || 0, average: 12.0, category: "mouse" },
-          { label: "無駄クリック(回)", user: game1Raw?.popupStats?.clickCount || 0, average: 1.5, category: "mouse" }
+          { label: "逆行確認(回)", user: g1.reversalCount ?? 0, average: 2.1, category: "scroll" },
+          { label: "マウスブレ(px)", user: game1Raw?.popupStats?.mouseJitter ?? 0, average: 12.0, category: "mouse" },
+          { label: "無駄クリック(回)", user: game1Raw?.popupStats?.clickCount ?? 0, average: 1.5, category: "mouse" }
         ]
       },
       game_2: {
@@ -331,10 +352,9 @@ const feedback = generateFeedback(scores, gaps);
         ],
         metrics: [
           { label: "反応潜時(ms)", user: Math.round(g2.avgReact ?? 0), average: 2500, category: "time" },
-          { label: "発話時間(秒)", user: Number((g2.totalSpeech / 1000).toFixed(1)), average: 4.2, category: "time" },
-          { label: "食い気味度(ms)", user: game2Raw?.interruptMs || 0, average: 800, category: "time" },
+          { label: "発話時間(秒)", user: Number(((g2.totalSpeech ?? 0) / 1000).toFixed(1)), average: 4.2, category: "time" },
           { label: "平均音量(dB)", user: Number((g2.avgVolume ?? 0).toFixed(1)), average: -25.0, category: "voice" },
-          { label: "論理的接続詞(回)", user: g2.logicWordsCount, average: 0.5, category: "logic" }
+          { label: "論理的接続詞(回)", user: g2.logicWordsCount ?? 0, average: 0.5, category: "logic" }
         ]
       },
       game_3: {
@@ -344,11 +364,10 @@ const feedback = generateFeedback(scores, gaps);
           { axis: "positivity", name: "積極性", score: g3.positivity }
         ],
         metrics: [
-          { label: "同調率(%)", user: Math.round((g3.conformCount / (game3Raw?.stages?.length || 1)) * 100), average: 75, category: "social" },
+          { label: "同調率(%)", user: Math.round(((g3.conformCount ?? 0) / (game3Raw?.stages?.length || 1)) * 100), average: 75, category: "social" },
           { label: "反応潜時(ms)", user: Math.round(g3.avgReact ?? 0), average: 3500, category: "time" },
-          { label: "本音ホバー(回)", user: game3Raw?.hoveredOptions || 0, average: 2.4, category: "mouse" },
-          { label: "譲り合い待機(ms)", user: game3Raw?.typingIndicatorReactTimeMs || 0, average: 2000, category: "time" },
-          { label: "過去ログ遡及(回)", user: game3Raw?.scrollBackCount || 0, average: 1.2, category: "scroll" }
+          { label: "本音ホバー(回)", user: game3Raw?.hoveredOptions ?? 0, average: 2.4, category: "mouse" },
+          { label: "譲り合い待機(ms)", user: game3Raw?.typingIndicatorReactTimeMs ?? 0, average: 2000, category: "time" }
         ]
       }
     }


### PR DESCRIPTION
## 概要

分析レイヤー（`scoreCalculator.ts` / `phaseSummaryBuilder.ts`）の死にコード 6 件と、欠損フィールドによる NaN 伝播で 500 エラーを返す脆弱性 1 件を一括で修正する。

closes #4

## 変更内容

すべて「仕様書に BE を合わせる」方向で修正（FE は仕様書通りのため変更不要）。

### 死にコード修正
- **Game1 scrollMetrics 参照バグ**: `calculateGame1()` の戻り値に `averageSpeed` / `reversalCount` を追加し、`phaseSummaryBuilder` と `details.metrics` の両方でそれを参照するように統一（scrollEvents からの計算は 1 箇所に集約）
- **Game1 checkboxStates.final**: 仕様書にない `.final` → 正しい `.checked` に修正
- **Game2 interruptMs**: `details.metrics` から該当行を削除
- **Game3 hoveredOptions**: 仕様書上 `number` なので `Array.isArray` 分岐を削除
- **Game3 reactionTime**: 仕様書どおりの `reactionTimeMs` に修正（タイポ）
- **Game3 scrollBackCount**: `details.metrics` から該当行を削除（Game3 にスクロール概念はない）

### NaN 伝播ガード
- `calculateGame1/2/3` 内の reducer とフォールバックに `?? 0` ガードを追加
- 目的: 欠損フィールドが `undefined` でも `NaN` を発生させず、`analysis_results` の NOT NULL 制約違反による 500 エラーを防ぐ
- これは短期の防御的コーディング。`null`（= 発話なし/タイムアウトの正規値）の意味論的ハンドリングなど根本対応は Issue #11 の派生で行う（該当箇所にコメントあり）

### 品質・整合性の小修正（レビュー指摘対応）
- `calculateGame1()` の早期 return の shape を通常 return と揃え、`details.metrics` 側で欠損プロパティにアクセスするのを防止
- 同ファイル内で `||` / `??` の使い分けを意図ある箇所に統一

## 動作確認

- `npx tsc --noEmit` ✅
- `npm run build` ✅
- 手動動作確認（デモユーザーでの Game1〜3 プレイと `/api/results/:user_id` 応答確認）は dev 環境で実施予定

## 補足

### スコープ外で発見した懸念（別途判断待ち）

- `scoreCalculator.ts:324` の `"総滞在時間(秒)"` が `(totalTime || 0) / 1000` となっており、同関数内の `totalTimeMs = totalTime * 1000` と単位扱いが食い違っている可能性あり。`details` 表示のみの影響（スコア計算は一貫）。Issue 化は別途判断。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ゲームメトリクス（速度、反応時間、反転回数など）の集計とフォールバック処理を改善し、欠損値やゼロ値の扱いによる誤差を減らしました。
  * フェーズごとの合計時間やメールトラップ判定の安定性を向上しました。
  * 一部不要だった指標を削除し、読み取り速度や反転回数などの重要指標を常に取得できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->