### PR TITLE
refactor: 各ゲームの data 構造の zod スキーマを定義

### DIFF
--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -42,7 +42,7 @@ const checkboxStateSchema = z.object({
  */
 const popupStatsSchema = z.object({
     timeToClose: z.number(),
-    clickCount: z.number(),
+    clickCount: z.number().int(),
     mouseJitter: z.number(),
 });
 
@@ -82,7 +82,7 @@ const game2InputMethodSchema = z.enum(['voice', 'text']);
  * silenceDurationMs / volumeDb）が取得できないため `nullable`。
  */
 const game2TurnSchema = z.object({
-    turnIndex: z.number(),
+    turnIndex: z.number().int(),
     inputMethod: game2InputMethodSchema,
     reactionTimeMs: z.number().nullable(),
     speechDurationMs: z.number().nullable(),
@@ -105,7 +105,7 @@ const game2TextInputMetricsSchema = z.object({
  */
 export const game2DataSchema = z.object({
     inputMethod: game2InputMethodSchema,
-    turnCount: z.number(),
+    turnCount: z.number().int(),
     turns: z.array(game2TurnSchema),
     textInputMetrics: game2TextInputMetricsSchema.nullable(),
 });
@@ -114,11 +114,12 @@ export const game2DataSchema = z.object({
  * Game3 の 1 ステージ分のメトリクス。
  *
  * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0（仕様書準拠）。
- * 値の細かい範囲制約は本スキーマでは表現しない（analysis 層で個別に扱う）。
+ * 意味的に整数のフィールドには `.int()` を付けて型レベルで小数を弾く。
+ * `min/max` 等の値の範囲制約は本スキーマでは表現せず、analysis 層で個別に扱う。
  */
 const game3StageSchema = z.object({
-    stageId: z.number(),
-    selectedOptionId: z.number(),
+    stageId: z.number().int(),
+    selectedOptionId: z.number().int(),
     reactionTimeMs: z.number(),
     isTimeout: z.boolean(),
 });
@@ -130,7 +131,7 @@ const game3StageSchema = z.object({
  */
 export const game3DataSchema = z.object({
     tutorialViewTime: z.number(),
-    hoveredOptions: z.number(),
+    hoveredOptions: z.number().int(),
     typingIndicatorReactTimeMs: z.number().nullable(),
     stages: z.array(game3StageSchema),
 });

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -54,7 +54,7 @@ const popupStatsSchema = z.object({
  */
 export const game1DataSchema = z.object({
     totalTime: z.number(),
-    finalAction: z.union([z.literal('agree'), z.literal('disagree')]),
+    finalAction: z.enum(['agree', 'disagree']),
     reachedBottom: z.boolean(),
     scrollEvents: z.array(scrollEventSchema),
     hiddenInput: z.string().nullable(),
@@ -73,10 +73,7 @@ export const game1DataSchema = z.object({
  * Game2Data 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
  * 使うため、共通サブスキーマとして定義する。
  */
-const game2InputMethodSchema = z.union([
-    z.literal('voice'),
-    z.literal('text'),
-]);
+const game2InputMethodSchema = z.enum(['voice', 'text']);
 
 /**
  * Game2 の 1 ターン分のメトリクス。
@@ -116,12 +113,12 @@ export const game2DataSchema = z.object({
 /**
  * Game3 の 1 ステージ分のメトリクス。
  *
- * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0 または null（仕様書準拠）。
+ * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0（仕様書準拠）。
  * 値の細かい範囲制約は本スキーマでは表現しない（analysis 層で個別に扱う）。
  */
 const game3StageSchema = z.object({
     stageId: z.number(),
-    selectedOptionId: z.number().nullable(),
+    selectedOptionId: z.number(),
     reactionTimeMs: z.number(),
     isTimeout: z.boolean(),
 });

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+
+/**
+ * 各ゲーム（Game1 / Game2 / Game3）の行動データ（raw_data）の zod スキーマ群。
+ *
+ * 設計方針:
+ * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
+ *   スキーマを唯一の真実とし、TS 型は `z.infer` で導出する
+ * - 本ファイルのスキーマは内部用（analysis 層 / repositories 層の型付け）であり、
+ *   API 入出力には直接出ないため `.openapi()` メタデータは付けない
+ * - 入口の API バリデーションは `schemas/games.ts` の `submitGameRequestSchema.data`
+ *   （汎用 record）が引き続き担う
+ */
+
+/**
+ * Game1 のスクロールイベント（200ms 間隔のサンプリングログ）。
+ */
+const scrollEventSchema = z.object({
+    position: z.number(),
+    timestamp: z.number(),
+});
+
+/**
+ * Game1 のチェックボックス状態。
+ *
+ * - `checked`: 最終的なチェック状態
+ * - `changed`: ユーザーが初期状態から変更したか
+ *
+ * 仕様書「データ構造 → Game1Data → checkboxStates」では readConfirm / mailMagazine /
+ * thirdPartyShare の 3 つに同形が使われるため、共通サブスキーマとして定義する。
+ */
+const checkboxStateSchema = z.object({
+    checked: z.boolean(),
+    changed: z.boolean(),
+});
+
+/**
+ * Game1 のポップアップ統計。
+ *
+ * ポップアップは滞在時間 timeout で出る仕様のため、高速スクロール時は
+ * クライアントから送信されない（→ Game1Data 側で `optional`）。
+ */
+const popupStatsSchema = z.object({
+    timeToClose: z.number(),
+    clickCount: z.number(),
+    mouseJitter: z.number(),
+});
+
+/**
+ * Game1Data（利用規約ゲーム）。
+ *
+ * 仕様書「データ構造 → Game1Data」と完全に一致させること。
+ * `popupStats` のみ optional、それ以外は必須。
+ */
+export const game1DataSchema = z.object({
+    totalTime: z.number(),
+    finalAction: z.union([z.literal('agree'), z.literal('disagree')]),
+    reachedBottom: z.boolean(),
+    scrollEvents: z.array(scrollEventSchema),
+    hiddenInput: z.string().nullable(),
+    checkboxStates: z.object({
+        readConfirm: checkboxStateSchema,
+        mailMagazine: checkboxStateSchema,
+        thirdPartyShare: checkboxStateSchema,
+    }),
+    popupStats: popupStatsSchema.optional(),
+    agreeButtonHoverTimeMs: z.number(),
+});
+
+/**
+ * Game2 の入力方式（音声 / テキスト）。
+ *
+ * Game2Data 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
+ * 使うため、共通サブスキーマとして定義する。
+ */
+const game2InputMethodSchema = z.union([
+    z.literal('voice'),
+    z.literal('text'),
+]);
+
+/**
+ * Game2 の 1 ターン分のメトリクス。
+ *
+ * テキスト入力時は音声系メトリクス（reactionTimeMs / speechDurationMs /
+ * silenceDurationMs / volumeDb）が取得できないため `nullable`。
+ */
+const game2TurnSchema = z.object({
+    turnIndex: z.number(),
+    inputMethod: game2InputMethodSchema,
+    reactionTimeMs: z.number().nullable(),
+    speechDurationMs: z.number().nullable(),
+    silenceDurationMs: z.number().nullable(),
+    volumeDb: z.number().nullable(),
+    transcribedText: z.string(),
+});
+
+/**
+ * Game2 のテキスト入力メトリクス。
+ *
+ * テキスト入力が一度も発生しなかった場合（全ターン音声）は null。
+ */
+const game2TextInputMetricsSchema = z.object({
+    typingIntervalVariance: z.number(),
+});
+
+/**
+ * Game2Data（AI カスタマーサポート）。
+ */
+export const game2DataSchema = z.object({
+    inputMethod: game2InputMethodSchema,
+    turnCount: z.number(),
+    turns: z.array(game2TurnSchema),
+    textInputMetrics: game2TextInputMetricsSchema.nullable(),
+});
+
+/**
+ * Game3 の 1 ステージ分のメトリクス。
+ *
+ * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0 または null（仕様書準拠）。
+ * 値の細かい範囲制約は本スキーマでは表現しない（analysis 層で個別に扱う）。
+ */
+const game3StageSchema = z.object({
+    stageId: z.number(),
+    selectedOptionId: z.number().nullable(),
+    reactionTimeMs: z.number(),
+    isTimeout: z.boolean(),
+});
+
+/**
+ * Game3Data（グループチャット）。
+ *
+ * `typingIndicatorReactTimeMs` はステージ 3 / 5 のみで計測される値のため `nullable`。
+ */
+export const game3DataSchema = z.object({
+    tutorialViewTime: z.number(),
+    hoveredOptions: z.number(),
+    typingIndicatorReactTimeMs: z.number().nullable(),
+    stages: z.array(game3StageSchema),
+});
+
+export type Game1Data = z.infer<typeof game1DataSchema>;
+export type Game2Data = z.infer<typeof game2DataSchema>;
+export type Game3Data = z.infer<typeof game3DataSchema>;


### PR DESCRIPTION
## 概要

仕様書「データ構造」の `Game1Data` / `Game2Data` / `Game3Data` を zod スキーマとして `backend/src/schemas/gameData.ts` に定義し、`z.infer` で TS 型を導出する単一ソースを用意する。

呼び出し側（`scoreCalculator` / `phaseSummaryBuilder` / `gameRepository` 等）の改修は本 PR では行わず、後続の派生 Issue（#28 / #29 / #30 等）が本スキーマを参照する形で any 排除を進める基盤となる。

closes #27

## 変更内容

- `backend/src/schemas/gameData.ts` を新規作成
- 以下の zod スキーマと `z.infer` 由来の TS 型を export:
  - `game1DataSchema` / `Game1Data`
  - `game2DataSchema` / `Game2Data`
  - `game3DataSchema` / `Game3Data`
- 仕様書「データ構造」通りに optional / nullable を反映:
  - `Game1Data.popupStats` は optional（高速スクロール時はクライアントから未送信）
  - `Game2Data.turns[].reactionTimeMs / speechDurationMs / silenceDurationMs / volumeDb` は nullable（テキスト入力時は計測不能）
  - `Game2Data.textInputMetrics` は nullable（全ターン音声時）
  - `Game3Data.typingIndicatorReactTimeMs` は nullable（ステージ 3, 5 のみ計測）
- 内部用スキーマのため `.openapi()` メタデータは付けない
- 内部用スキーマでの literal 列挙は `z.enum` を使用（`schemas/voice.ts` の既存パターンに合わせる）

## スコープ外

- `scoreCalculator.ts` / `phaseSummaryBuilder.ts` の引数型変更
- `gameRepository.ts` / `analysisResultRepository.ts` の戻り値型変更
- `schemas/games.ts` の `gameDataSchema`（汎用 record）の置き換え
- `submitGameRequestSchema.data` の discriminated union 化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ゲームデータの検証機構を強化し、複数のゲーム形式に対応した検証スキーマを導入しました。データの正確性と整合性を向上させ、必須フィールドとオプショナルフィールドの処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->