### PR TITLE
refactor: gameRepository の JSONB を unknown 化し service で zod 検証

### DIFF
--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,8 +1,17 @@
 import { supabase } from '../db/client';
-import { GameType } from '../types';
+import { GameLog, GameType } from '../types';
+import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
+
+/**
+ * 各 game_type に対応する raw_data の型 union。
+ *
+ * saveLog の引数に渡す前提で、呼び出し元（service 層）が zod スキーマで parse して
+ * narrow 済みであることを型レベルで担保する。repositories 層では構造検証を行わない。
+ */
+export type GameRawData = Game1Data | Game2Data | Game3Data;
 
 export const gameRepository = {
-    async saveLog(userId: string, gameType: GameType, rawData: Record<string, any>) {
+    async saveLog(userId: string, gameType: GameType, rawData: GameRawData) {
         const { error } = await supabase
             .from('game_logs')
             .insert({
@@ -14,7 +23,13 @@ export const gameRepository = {
         if (error) throw error;
     },
 
-    async findLogsByUserId(userId: string) {
+    /**
+     * ユーザーのゲームログを game_type 昇順で取得する。
+     *
+     * 戻り値の `raw_data` は `unknown`（GameLog.raw_data の定義どおり）。
+     * 構造の検証は呼び出し元（resultService）が zod スキーマで parse して行う。
+     */
+    async findLogsByUserId(userId: string): Promise<GameLog[]> {
         const { data, error } = await supabase
             .from('game_logs')
             .select('*')
@@ -22,7 +37,9 @@ export const gameRepository = {
             .order('game_type', { ascending: true });
 
         if (error) throw error;
-        return data || [];
+        // Supabase は select('*') の戻り値を `any` で返すため、ここで明示的に GameLog[] に寄せる。
+        // 構造の妥当性は呼び出し元の zod parse で担保する。
+        return (data ?? []) as GameLog[];
     },
 
     async existsLog(userId: string, gameType: GameType): Promise<boolean> {

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -1,7 +1,50 @@
 import { userRepository } from '../repositories/userRepository';
-import { gameRepository } from '../repositories/gameRepository';
-import { GameType } from '../types';
+import { gameRepository, GameRawData } from '../repositories/gameRepository';
+import { GAME_TYPES, GameType } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
+import {
+    game1DataSchema,
+    game2DataSchema,
+    game3DataSchema,
+} from '../schemas/gameData';
+
+/**
+ * game_type に応じて、受け取った data を対応する zod スキーマで parse する。
+ *
+ * route 層の `gameDataSchema`（= `record(string, unknown)` + 「空でない」refine）では
+ * data の中身までは検証されないため、ここで game_type に応じた構造検証を行うことで
+ * `gameRepository.saveLog` の引数（`GameRawData` union）に narrow した値を渡す。
+ *
+ * 構造違反（必須フィールド欠落・型違い等）はクライアント起因の不正リクエストとして
+ * 400 `invalid_request` を throw する。詳細な issue は warn ログに残し、
+ * クライアントへの message は固定文言にして内部構造の漏洩を防ぐ。
+ */
+function parseGameData(gameType: GameType, data: Record<string, unknown>): GameRawData {
+    const result = (() => {
+        switch (gameType) {
+            case GAME_TYPES.TERMS_GAME:
+                return game1DataSchema.safeParse(data);
+            case GAME_TYPES.AI_CHAT:
+                return game2DataSchema.safeParse(data);
+            case GAME_TYPES.GROUP_CHAT:
+                return game3DataSchema.safeParse(data);
+        }
+    })();
+
+    if (!result.success) {
+        console.warn('Game data validation failed:', {
+            gameType,
+            issues: result.error.issues,
+        });
+        throw {
+            status: 400,
+            code: ERROR_CODES.INVALID_REQUEST,
+            message: 'Invalid game data structure',
+        };
+    }
+
+    return result.data;
+}
 
 export const gameService = {
     /**
@@ -10,7 +53,8 @@ export const gameService = {
      * リクエスト形状の検証（必須・型・game_type の範囲・data が空でないこと）は
      * route 層の zod ミドルウェアで完了している前提。
      * ここでは DB を参照しないと判定できない業務ルール
-     * （ユーザー存在確認・同一ゲーム重複送信）のみを行う。
+     * （ユーザー存在確認・同一ゲーム重複送信）と、game_type に応じた data 構造の
+     * 検証（parseGameData）を行う。
      */
     async submitGame(userId: string, gameType: GameType, data: Record<string, unknown>) {
         // ユーザー存在確認
@@ -25,7 +69,8 @@ export const gameService = {
             throw { status: 409, code: ERROR_CODES.DUPLICATE_SUBMISSION, message: `Game ${gameType} is already submitted` };
         }
 
-        // 保存
-        await gameRepository.saveLog(userId, gameType, data);
+        // game_type に応じた構造検証 → narrow した値を保存
+        const parsedData = parseGameData(gameType, data);
+        await gameRepository.saveLog(userId, gameType, parsedData);
     }
 };

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -28,6 +28,12 @@ function parseGameData(gameType: GameType, data: Record<string, unknown>): GameR
                 return game2DataSchema.safeParse(data);
             case GAME_TYPES.GROUP_CHAT:
                 return game3DataSchema.safeParse(data);
+            default: {
+                // 網羅性チェック: GameType に新しい値を追加した際、ここで型エラーを出して
+                // case 追加を強制する（型システム上は到達不能なため、ランタイム throw も保険として残す）
+                const _exhaustive: never = gameType;
+                throw new Error(`Unknown game type: ${_exhaustive}`);
+            }
         }
     })();
 

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -13,7 +13,7 @@ import {
 } from '../schemas/gameData';
 
 import { getMbtiScores } from '../analysis/mbtiScoreTable';
-import { BaselineScores, GameLog, ResultResponse } from '../types';
+import { BaselineScores, GAME_TYPES, GameLog, ResultResponse } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
 
 /**
@@ -85,9 +85,9 @@ export const resultService = {
         }
 
         // 分析（analysis/ に委譲）
-        const game1Log = gameLogs.find(log => log.game_type === 1);
-        const game2Log = gameLogs.find(log => log.game_type === 2);
-        const game3Log = gameLogs.find(log => log.game_type === 3);
+        const game1Log = gameLogs.find(log => log.game_type === GAME_TYPES.TERMS_GAME);
+        const game2Log = gameLogs.find(log => log.game_type === GAME_TYPES.AI_CHAT);
+        const game3Log = gameLogs.find(log => log.game_type === GAME_TYPES.GROUP_CHAT);
 
         // raw_data は GameLog.raw_data: unknown のため、scoreCalculator に渡す前に
         // game_type ごとの zod スキーマで parse する。DB 整合性が壊れていた場合は

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -1,12 +1,51 @@
+import { ZodType } from 'zod';
 import { userRepository } from '../repositories/userRepository';
 import { gameRepository } from '../repositories/gameRepository';
 import { generateAnalysisResult } from '../analysis/scoreCalculator';
 import { analysisResultRepository, AnalysisResultRow } from '../repositories/analysisResultRepository';
-import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
+import {
+    Game1Data,
+    Game2Data,
+    Game3Data,
+    game1DataSchema,
+    game2DataSchema,
+    game3DataSchema,
+} from '../schemas/gameData';
 
 import { getMbtiScores } from '../analysis/mbtiScoreTable';
-import { BaselineScores, ResultResponse } from '../types';
+import { BaselineScores, GameLog, ResultResponse } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
+
+/**
+ * DB から取り出した GameLog.raw_data（unknown）を、対応する zod スキーマで parse する。
+ *
+ * ゲームログが見つからない場合は undefined を返す。parse 失敗時は DB 整合性エラーとして
+ * 500 `server_error` を throw する（運用上ほぼ起きない異常系。ログに詳細を残し、
+ * クライアントへの message は固定文言にして内部情報の漏洩を防ぐ）。
+ */
+function parseGameLogOrThrow<T>(
+    log: GameLog | undefined,
+    schema: ZodType<T>,
+    gameLabel: string,
+    userId: string,
+): T | undefined {
+    if (!log) return undefined;
+
+    const result = schema.safeParse(log.raw_data);
+    if (!result.success) {
+        console.error('Corrupted game data in DB:', {
+            gameLabel,
+            userId,
+            issues: result.error.issues,
+        });
+        throw {
+            status: 500,
+            code: ERROR_CODES.SERVER_ERROR,
+            message: 'Stored game data is corrupted',
+        };
+    }
+    return result.data;
+}
 
 export const resultService = {
     async getResult(userId: string): Promise<ResultResponse> {
@@ -46,19 +85,23 @@ export const resultService = {
         }
 
         // 分析（analysis/ に委譲）
-        const game1Data = gameLogs.find(log => log.game_type === 1);
-        const game2Data = gameLogs.find(log => log.game_type === 2);
-        const game3Data = gameLogs.find(log => log.game_type === 3);
+        const game1Log = gameLogs.find(log => log.game_type === 1);
+        const game2Log = gameLogs.find(log => log.game_type === 2);
+        const game3Log = gameLogs.find(log => log.game_type === 3);
 
-        // gameRepository.findLogsByUserId の戻り値型は現状 raw_data: any のため、
-        // ここで scoreCalculator が期待する型へキャストする。repositories の戻り値型整備は
-        // 別 Issue で扱う（Issue #28 実装計画のスコープ外）。
+        // raw_data は GameLog.raw_data: unknown のため、scoreCalculator に渡す前に
+        // game_type ごとの zod スキーマで parse する。DB 整合性が壊れていた場合は
+        // 500 `server_error` で明示的に失敗させる（parseGameLogOrThrow 内で throw）。
+        const game1Data: Game1Data | undefined = parseGameLogOrThrow(game1Log, game1DataSchema, 'game1', userId);
+        const game2Data: Game2Data | undefined = parseGameLogOrThrow(game2Log, game2DataSchema, 'game2', userId);
+        const game3Data: Game3Data | undefined = parseGameLogOrThrow(game3Log, game3DataSchema, 'game3', userId);
+
         const analysisResult = generateAnalysisResult(
             userId,
             user.self_mbti ?? undefined,
-            game1Data?.raw_data as Game1Data | undefined,
-            game2Data?.raw_data as Game2Data | undefined,
-            game3Data?.raw_data as Game3Data | undefined,
+            game1Data,
+            game2Data,
+            game3Data,
             baseline_scores
         );
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -61,7 +61,10 @@ export interface GameLog {
   id: number;
   user_id: string;
   game_type: number;
-  raw_data: any;
+  // raw_data は JSONB カラム。型は Game1Data / Game2Data / Game3Data のいずれかで、
+  // game_type に応じて分かれるが、DB 読み出し時点では構造の整合性は未検証のため `unknown` とする。
+  // service 境界（resultService）で zod スキーマ（schemas/gameData.ts）により parse する。
+  raw_data: unknown;
   played_at: string;
 }
 


### PR DESCRIPTION
## 概要

`backend/src/repositories/gameRepository.ts` および `GameLog.raw_data` の型を `any` から
`unknown` に変更し、`gameService` / `resultService` の境界で zod スキーマ（Issue #27）
による parse を行うようにする。これにより JSONB 由来の型安全性を取り戻し、壊れたデータを早期検知できる。

## 変更内容

- `GameLog.raw_data: any` → `unknown`
- `gameRepository.saveLog` の引数を `Game1Data | Game2Data | Game3Data` の union（`GameRawData`）に厳密化
- `gameRepository.findLogsByUserId` の戻り値型を `Promise<GameLog[]>` に明示
- `gameService.submitGame` で `game_type` に応じた zod parse を追加
  - 構造違反は 400 `invalid_request` を throw、`console.warn` に詳細を残す
  - `switch` に `never` exhaustive check を追加し、将来の `GameType` 追加時の case 漏れを型エラーで検知
- `resultService.getResult` で `findLogsByUserId` の結果を `game_type` ごとに parse してから `generateAnalysisResult` に渡す
  - DB 整合性違反は 500 `server_error` を throw、`console.error` に詳細を残す
  - クライアントへの `message` は固定文言にして内部構造の漏洩を防ぐ

## 実装メモ

Issue #30 の本文には「保存時の呼び出し元（POST /api/games/submit）はすでに zod 検証済み」と記載されていたが、
実際の route 層スキーマ `gameDataSchema`（`schemas/games.ts`）は `record(string, unknown)` + 「空でない」refine のみで、
Game1/2/3 の構造までは検証していなかった。
そのため `saveLog` 引数を union 型に narrow する目的で `gameService` 内に `parseGameData` を新設している。
これは route 層の入力検証ロジックを変更するものではなく、業務層での型 narrowing として追加したもの。

closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ゲームデータの構造検証を強化し、無効なデータの処理を防止
  * データ整合性チェック機能を改善し、エラーハンドリングを向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->