### PR TITLE
refactor: gameRepository.saveLog を判別可能 union 引数に変更

### DIFF
--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,23 +1,28 @@
 import { supabase } from '../db/client';
-import { GameLog, GameType } from '../types';
+import { GAME_TYPES, GameLog, GameType } from '../types';
 import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
 
 /**
- * 各 game_type に対応する raw_data の型 union。
+ * 各 game_type に対応する raw_data の組（判別可能 union）。
  *
- * saveLog の引数に渡す前提で、呼び出し元（service 層）が zod スキーマで parse して
- * narrow 済みであることを型レベルで担保する。repositories 層では構造検証を行わない。
+ * saveLog の引数として `gameType` と `rawData` を一緒に受け取ることで、
+ * 「Game1 の gameType に Game2 の rawData が渡る」といったミスマッチを
+ * コンパイル時に弾ける。呼び出し元（service 層）が zod スキーマで parse して
+ * narrow 済みであることを型レベルで担保する想定で、repositories 層では構造検証しない。
  */
-export type GameRawData = Game1Data | Game2Data | Game3Data;
+export type GameRawDataPayload =
+    | { gameType: typeof GAME_TYPES.TERMS_GAME; rawData: Game1Data }
+    | { gameType: typeof GAME_TYPES.AI_CHAT;    rawData: Game2Data }
+    | { gameType: typeof GAME_TYPES.GROUP_CHAT; rawData: Game3Data };
 
 export const gameRepository = {
-    async saveLog(userId: string, gameType: GameType, rawData: GameRawData) {
+    async saveLog(userId: string, payload: GameRawDataPayload) {
         const { error } = await supabase
             .from('game_logs')
             .insert({
                 user_id: userId,
-                game_type: gameType,
-                raw_data: rawData,
+                game_type: payload.gameType,
+                raw_data: payload.rawData,
             });
 
         if (error) throw error;

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -1,5 +1,5 @@
 import { userRepository } from '../repositories/userRepository';
-import { gameRepository, GameRawData } from '../repositories/gameRepository';
+import { gameRepository, GameRawDataPayload } from '../repositories/gameRepository';
 import { GAME_TYPES, GameType } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
 import {
@@ -12,44 +12,54 @@ import {
  * game_type に応じて、受け取った data を対応する zod スキーマで parse する。
  *
  * route 層の `gameDataSchema`（= `record(string, unknown)` + 「空でない」refine）では
- * data の中身までは検証されないため、ここで game_type に応じた構造検証を行うことで
- * `gameRepository.saveLog` の引数（`GameRawData` union）に narrow した値を渡す。
+ * data の中身までは検証されないため、ここで game_type に応じた構造検証を行ったうえで
+ * `gameType` と `rawData` を組（判別可能 union `GameRawDataPayload`）として返す。
+ * これにより `gameRepository.saveLog` の引数で gameType と rawData のミスマッチを
+ * 型レベルで弾ける。
  *
  * 構造違反（必須フィールド欠落・型違い等）はクライアント起因の不正リクエストとして
  * 400 `invalid_request` を throw する。詳細な issue は warn ログに残し、
  * クライアントへの message は固定文言にして内部構造の漏洩を防ぐ。
  */
-function parseGameData(gameType: GameType, data: Record<string, unknown>): GameRawData {
-    const result = (() => {
-        switch (gameType) {
-            case GAME_TYPES.TERMS_GAME:
-                return game1DataSchema.safeParse(data);
-            case GAME_TYPES.AI_CHAT:
-                return game2DataSchema.safeParse(data);
-            case GAME_TYPES.GROUP_CHAT:
-                return game3DataSchema.safeParse(data);
-            default: {
-                // 網羅性チェック: GameType に新しい値を追加した際、ここで型エラーを出して
-                // case 追加を強制する（型システム上は到達不能なため、ランタイム throw も保険として残す）
-                const _exhaustive: never = gameType;
-                throw new Error(`Unknown game type: ${_exhaustive}`);
-            }
+function parseGameData(gameType: GameType, data: Record<string, unknown>): GameRawDataPayload {
+    switch (gameType) {
+        case GAME_TYPES.TERMS_GAME: {
+            const result = game1DataSchema.safeParse(data);
+            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
+            return { gameType, rawData: result.data };
         }
-    })();
-
-    if (!result.success) {
-        console.warn('Game data validation failed:', {
-            gameType,
-            issues: result.error.issues,
-        });
-        throw {
-            status: 400,
-            code: ERROR_CODES.INVALID_REQUEST,
-            message: 'Invalid game data structure',
-        };
+        case GAME_TYPES.AI_CHAT: {
+            const result = game2DataSchema.safeParse(data);
+            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
+            return { gameType, rawData: result.data };
+        }
+        case GAME_TYPES.GROUP_CHAT: {
+            const result = game3DataSchema.safeParse(data);
+            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
+            return { gameType, rawData: result.data };
+        }
+        default: {
+            // 網羅性チェック: GameType に新しい値を追加した際、ここで型エラーを出して
+            // case 追加を強制する（型システム上は到達不能なため、ランタイム throw も保険として残す）
+            const _exhaustive: never = gameType;
+            throw new Error(`Unknown game type: ${_exhaustive}`);
+        }
     }
+}
 
-    return result.data;
+/**
+ * Game data の zod parse 失敗時に throw する API エラーオブジェクトを生成する。
+ *
+ * `parseGameData` の各 case で同じ形のエラーを throw するため、ヘルパに切り出して
+ * 詳細な issue は warn ログに残し、クライアントには固定文言だけを返す。
+ */
+function invalidGameDataError(gameType: GameType, issues: unknown) {
+    console.warn('Game data validation failed:', { gameType, issues });
+    return {
+        status: 400,
+        code: ERROR_CODES.INVALID_REQUEST,
+        message: 'Invalid game data structure',
+    };
 }
 
 export const gameService = {
@@ -75,8 +85,8 @@ export const gameService = {
             throw { status: 409, code: ERROR_CODES.DUPLICATE_SUBMISSION, message: `Game ${gameType} is already submitted` };
         }
 
-        // game_type に応じた構造検証 → narrow した値を保存
-        const parsedData = parseGameData(gameType, data);
-        await gameRepository.saveLog(userId, gameType, parsedData);
+        // game_type に応じた構造検証 → 判別可能 union として保存
+        const parsedPayload = parseGameData(gameType, data);
+        await gameRepository.saveLog(userId, parsedPayload);
     }
 };


### PR DESCRIPTION
## 概要

`gameRepository.saveLog` の引数 `(userId, gameType, rawData)` を、判別可能 union（discriminated union）`GameRawDataPayload` の単一引数 `(userId, payload)` に変更する。これにより `gameType` と `rawData` のミスマッチをコンパイル時に弾けるようにする。

closes #38

## 変更内容

- `backend/src/repositories/gameRepository.ts`
  - `GameRawData = Game1Data | Game2Data | Game3Data` を除去し、判別可能 union 型 `GameRawDataPayload` を新規定義
    ```ts
    export type GameRawDataPayload =
        | { gameType: typeof GAME_TYPES.TERMS_GAME; rawData: Game1Data }
        | { gameType: typeof GAME_TYPES.AI_CHAT;    rawData: Game2Data }
        | { gameType: typeof GAME_TYPES.GROUP_CHAT; rawData: Game3Data };
    ```
  - `saveLog(userId, gameType, rawData)` → `saveLog(userId, payload)` にシグネチャ変更
  - DB に渡す `user_id` / `game_type` / `raw_data` の値は変更なし（既存動作は同一）

- `backend/src/services/gameService.ts`
  - `parseGameData` の戻り値型を `GameRawData` → `GameRawDataPayload` に変更し、各 case で `{ gameType, rawData: result.data }` を返すように再構成
  - 各 case で重複する zod parse 失敗時のエラー throw を `invalidGameDataError` ヘルパに切り出し
  - `submitGame` の呼び出しを `gameRepository.saveLog(userId, parsedPayload)` に変更

## 効果

`saveLog(uid, { gameType: TERMS_GAME, rawData: game2Data })` のような不整合な呼び出しが型エラーになる。現状の呼び出し元は `gameService.submitGame` の 1 箇所のみで実害は薄いが、将来 `saveLog` の呼び出し元が追加された場合の事故防止のための型レベルガード。

## スコープ外

- `Game1Data` / `Game2Data` / `Game3Data` の zod スキーマ自体は変更しない
- `findLogsByUserId` の戻り値型変更（PR #37 で対応済み）
- `analysisResultRepository.details: any` の改修 → Issue #32

## 完了条件チェック

- [x] `gameRepository.saveLog` の引数が `GameRawDataPayload` の単一引数になっている
- [x] gameType と rawData のミスマッチがコンパイル時に検知される（判別可能 union）
- [x] 既存の動作（POST /api/games/submit の保存処理）は変わっていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ゲームデータの保存と処理パイプラインを改善しました。データ検証の堅牢性が向上し、エラーハンドリングがより一貫性のあるものになります。型安全性の向上により、より安定したデータ処理を実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->