### PR TITLE
refactor: voiceService の any を排除（Content 型 + unknown ナロイング）

### DIFF
--- a/backend/src/services/voiceService.ts
+++ b/backend/src/services/voiceService.ts
@@ -6,6 +6,7 @@
  * 2. 失敗時はエラーをスロー（モック/フォールバックは使用しない）
  */
 
+import { Content } from '@google/generative-ai';
 import {
     ConversationMessage,
     VoiceEmotion,
@@ -33,7 +34,7 @@ function estimateEmotion(text: string): VoiceEmotion {
  */
 async function requestToModel(
     modelName: string,
-    contents: any[],
+    contents: Content[],
     apiKey: string,
     signal: AbortSignal,
 ): Promise<VoiceRespondResponse> {
@@ -77,7 +78,7 @@ async function callGeminiSequential(
 ): Promise<VoiceRespondResponse> {
     // 会話履歴は直近1件のみ（速度優先）
     const recentHistory = conversationHistory.slice(-1);
-    const contents: any[] = [];
+    const contents: Content[] = [];
     for (const msg of recentHistory) {
         contents.push({
             role: msg.role === 'assistant' ? 'model' : 'user',
@@ -95,9 +96,10 @@ async function callGeminiSequential(
         clearTimeout(timer);
         console.log(`[voiceService] Gemini (${PRIMARY_MODEL}) OK`);
         return result;
-    } catch (err: any) {
+    } catch (err: unknown) {
         clearTimeout(timer);
-        console.error(`[voiceService] Gemini failed. Inner error:`, err.errors || err.message);
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error(`[voiceService] Gemini failed. Inner error:`, detail);
         throw err;
     }
 }
@@ -121,8 +123,13 @@ export const voiceService = {
 
         try {
             return await callGeminiSequential(message, conversationHistory ?? [], apiKey);
-        } catch (err: any) {
-            const reason = err?.name === 'AbortError' ? 'タイムアウト' : err?.message || '不明なエラー';
+        } catch (err: unknown) {
+            let reason: string;
+            if (err instanceof Error) {
+                reason = err.name === 'AbortError' ? 'タイムアウト' : err.message || '不明なエラー';
+            } else {
+                reason = '不明なエラー';
+            }
             console.warn('[voiceService] Gemini failed:', reason, '- Using fallback response.');
             return getKeywordFallback(message);
         }


### PR DESCRIPTION
## 概要

`backend/src/services/voiceService.ts` 内の `any` 型使用（4 箇所）を排除する。

closes #31

## 変更内容

- `@google/generative-ai` から `Content` 型を import
- `requestToModel` 引数 `contents: any[]` を `Content[]` に変更
- `callGeminiSequential` 内の `const contents: any[]` を `Content[]` に変更
- 2 箇所の `catch (err: any)` を `catch (err: unknown)` + `instanceof Error` ナロイングに変更
  - `err.errors || err.message` のアドホックなプロパティアクセスを `instanceof Error ? err.message : String(err)` ベースに置換
  - `err?.name === 'AbortError' ? 'タイムアウト' : err?.message` も `instanceof Error` ベースに置換

## スコープ外（変更していないこと）

- Gemini SDK の高レベル API への切り替え（fetch 直叩きを維持）
- フォールバック処理（`getKeywordFallback`）
- プロンプト・モデル名・タイムアウト挙動

## 動作確認

- `npx tsc --noEmit`: ✅
- `npm run build`: ✅
- `voiceService.ts` 内の `any` 残存: 0 件（grep 確認済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * エラーハンドリングを強化し、サービスの安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->