### PR TITLE
refactor: Gemini レスポンスを zod スキーマでランタイム検証

### DIFF
--- a/backend/src/services/voiceService.ts
+++ b/backend/src/services/voiceService.ts
@@ -33,8 +33,10 @@ const GeminiResponseSchema = z.object({
         .array(
             z.object({
                 content: z.object({
+                    // text は SAFETY ブロックや maxOutputTokens 切り詰めで空文字になり得る。
+                    // 空文字をそのままユーザーに返さないよう min(1) で弾き、フォールバックに落とす
                     parts: z
-                        .array(z.object({ text: z.string() }))
+                        .array(z.object({ text: z.string().min(1) }))
                         .min(1),
                 }),
             }),

--- a/backend/src/services/voiceService.ts
+++ b/backend/src/services/voiceService.ts
@@ -7,6 +7,7 @@
  */
 
 import { Content } from '@google/generative-ai';
+import { z } from 'zod';
 import {
     ConversationMessage,
     VoiceEmotion,
@@ -15,6 +16,31 @@ import {
 import { getKeywordFallback } from './fallbackService';
 
 const GEMINI_TIMEOUT_MS = 5000;
+
+/**
+ * Gemini generateContent レスポンスの最小限スキーマ。
+ *
+ * `Response.json()` は lib.dom 定義で `Promise<any>` 固定のため、any 伝染を
+ * 防ぐには受け側で検証する必要がある。voiceService からしか使わない内部用
+ * スキーマなので schemas/ には置かず本ファイル内にローカル定義する。
+ *
+ * SAFETY フィルター発動時など `candidates` が空 / `parts` が空のケースでは
+ * parse が失敗するため、requestToModel 側で ZodError を明示エラーに包んで
+ * スローし、既存 catch のフォールバック挙動を維持する。
+ */
+const GeminiResponseSchema = z.object({
+    candidates: z
+        .array(
+            z.object({
+                content: z.object({
+                    parts: z
+                        .array(z.object({ text: z.string() }))
+                        .min(1),
+                }),
+            }),
+        )
+        .min(1),
+});
 
 // プロンプトは短く・速く
 const SYSTEM_PROMPT = `あなたはカスタマーサポート担当です。少し知識が中途半端で、ピントのずれた回答をします。回答は必ず「～かもしれません」「～だと思います」といった曖昧な文章で終わらせてください。短く、1〜2文（50文字程度）で返答してください。`;
@@ -58,8 +84,18 @@ async function requestToModel(
         throw new Error(`${modelName}: HTTP ${response.status}`);
     }
 
-    const data = await response.json();
-    const text: string = data.candidates[0].content.parts[0].text;
+    // Response.json() は any を返すため、ここで zod により型・ランタイム検証する
+    const parseResult = GeminiResponseSchema.safeParse(await response.json());
+    if (!parseResult.success) {
+        // ZodError の詳細はログに残しつつ、上位 catch には簡潔なメッセージで伝える
+        console.error(
+            `[voiceService] ${modelName}: invalid response shape`,
+            parseResult.error.issues,
+        );
+        throw new Error(`${modelName}: invalid response`);
+    }
+
+    const text = parseResult.data.candidates[0].content.parts[0].text;
 
     return {
         response: text.trim(),

--- a/backend/src/services/voiceService.ts
+++ b/backend/src/services/voiceService.ts
@@ -33,10 +33,20 @@ const GeminiResponseSchema = z.object({
         .array(
             z.object({
                 content: z.object({
-                    // text は SAFETY ブロックや maxOutputTokens 切り詰めで空文字になり得る。
-                    // 空文字をそのままユーザーに返さないよう min(1) で弾き、フォールバックに落とす
+                    // text は SAFETY ブロックや maxOutputTokens 切り詰めで空文字 / 空白のみに
+                    // なり得る。スキーマ側で trim までやり、trim 後に空ならフォールバックへ。
+                    // 検証と正規化を 1 箇所に集約し、後段の trim 忘れ事故も防ぐ。
                     parts: z
-                        .array(z.object({ text: z.string().min(1) }))
+                        .array(
+                            z.object({
+                                text: z
+                                    .string()
+                                    .transform((s) => s.trim())
+                                    .refine((s) => s.length > 0, {
+                                        message: 'text is empty after trim',
+                                    }),
+                            }),
+                        )
                         .min(1),
                 }),
             }),
@@ -97,10 +107,11 @@ async function requestToModel(
         throw new Error(`${modelName}: invalid response`);
     }
 
+    // text はスキーマ側で trim 済み・空チェック済みなのでそのまま使う
     const text = parseResult.data.candidates[0].content.parts[0].text;
 
     return {
-        response: text.trim(),
+        response: text,
         emotion: estimateEmotion(text),
         confidence: 0.6,
     };


### PR DESCRIPTION
## 概要

`voiceService.ts` の `requestToModel` で `await response.json()` の戻りが `any` のまま `data.candidates[0].content.parts[0].text` をチェーンアクセスしていた問題を、zod スキーマでランタイム検証することで解消する。

`Response.json()` の戻り値型は lib.dom 定義で `Promise<any>` 固定のため、受け側で対処する。

## 変更内容

- `GeminiResponseSchema` を `voiceService.ts` 内に内部用スキーマとして定義
  - 検証範囲: `candidates[0].content.parts[0].text`（最低限）
  - 配置場所: voiceService からしか使わないので `schemas/` には置かずローカル定義
- `requestToModel` 内で `safeParse` により Gemini レスポンスを検証
  - 検証成功時: `parseResult.data.candidates[0].content.parts[0].text` が `string` にナロイングされ、any 伝染を解消
  - 検証失敗時: `Error('${modelName}: invalid response')` でスロー（既存 catch のフォールバック挙動を維持）
  - ZodError の `issues` は `console.error` に残し、ログから原因（SAFETY ブロック / レスポンス形式変更等）を特定できるようにする
- `text` を `z.string().min(1)` で検証し、空文字列もフォールバックに落とす
  - SAFETY ブロックや `maxOutputTokens` 切り詰めで空文字になったケースで、空応答をそのままユーザーに返さない

## 動作への影響

- 正常時: 変更なし
- タイムアウト: 変更なし
- フォールバック挙動: 変更なし（不正レスポンス検知時もこれまで同様 `getKeywordFallback` に落ちる）
- ログ: 不正レスポンス時に `[voiceService] ${modelName}: invalid response shape` が `console.error` に出るようになる

closes #42