### PR TITLE
fix: Game 2 の null 集計を仕様書準拠の null 除外集計に修正

### DIFF
--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -191,23 +191,35 @@ function calculateGame2(data: Game2Data | undefined): Game2Result {
 
   const turns = data.turns || [];
 
-  // 以下の reducer の `?? 0` は NaN 伝播を防ぐ短期ガード。
-  // FE の型定義上 reactionTimeMs 等は `null`（= 発話なし/タイムアウトの正規値）が
-  // 来ることがあり、0 として扱うとスコアが歪む可能性がある。
-  // 根本対応（zod による入力検証と null の意味論的ハンドリング）は Issue #11 の派生で行う。
+  // 仕様書「分析ロジック → Game 2 → Null 値（テキスト入力時）の扱い」に従い、
+  // null フィールドを集計対象から除外する。全ターン null（= 全ターンテキスト入力）の
+  // 場合は仕様書の代替値（avgReact=2000, totalSpeech=0, avgVolume=-30, silence=0）を返す。
+  // null 検出には `filter((v): v is number => v !== null)` で型ナローイング。
+  const reactValues = turns
+    .map((t) => t.reactionTimeMs)
+    .filter((v): v is number => v !== null);
   const avgReact =
-    turns.reduce((a, t) => a + (t.reactionTimeMs ?? 0), 0) /
-    (turns.length || 1);
+    reactValues.length > 0
+      ? reactValues.reduce((a, v) => a + v, 0) / reactValues.length
+      : 2000;
 
-  const totalSpeech =
-    turns.reduce((a, t) => a + (t.speechDurationMs ?? 0), 0);
+  const totalSpeech = turns
+    .map((t) => t.speechDurationMs)
+    .filter((v): v is number => v !== null)
+    .reduce((a, v) => a + v, 0);
 
+  const volumeValues = turns
+    .map((t) => t.volumeDb)
+    .filter((v): v is number => v !== null);
   const avgVolume =
-    turns.reduce((a, t) => a + (t.volumeDb ?? -30), 0) /
-    (turns.length || 1);
+    volumeValues.length > 0
+      ? volumeValues.reduce((a, v) => a + v, 0) / volumeValues.length
+      : -30;
 
-  const silence =
-    turns.reduce((a, t) => a + (t.silenceDurationMs ?? 0), 0);
+  const silence = turns
+    .map((t) => t.silenceDurationMs)
+    .filter((v): v is number => v !== null)
+    .reduce((a, v) => a + v, 0);
 
   const silenceRate =
     totalSpeech > 0 ? silence / totalSpeech : 0;


### PR DESCRIPTION
## 概要

`backend/src/analysis/scoreCalculator.ts` の `calculateGame2()` で、`turns[]` の null フィールドを `?? 0` / `?? -30` でフォールバックして平均に混入させていた集計ロジックを、仕様書「分析ロジック → Game 2 → Null 値（テキスト入力時）の扱い」通りに **null 除外集計** へ修正した。

これにより、全ターンテキスト入力時に `avgReact = 0` となって積極性スコアが不当に高く出ていたバグ（修正前: `linearInv(0, 200, 4000) = 100` → positivity ≒ 40 点）が解消され、仕様書の中立値（`avgReact = 2000` → ≒ 53 点 → positivity ≒ 21 点）で評価されるようになる。

closes #33

## 変更内容

`scoreCalculator.ts` の Game 2 集計を以下に置き換え:

| 指標 | 集計対象 | 全ターン null 時の代替値 |
|---|---|---|
| `avgReact` | `reactionTimeMs !== null` のターンの平均 | `2000ms` |
| `totalSpeech` | `speechDurationMs !== null` のターンの合計 | `0ms` |
| `avgVolume` | `volumeDb !== null` のターンの平均 | `-30dB` |
| `silence` | `silenceDurationMs !== null` のターンの合計 | `0ms` |

- null 検出には `filter((v): v is number => v !== null)` で型ナローイング（`any` 不使用）
- `silenceRate` 側は既存の `totalSpeech > 0` ガードで 0 除算を回避（変更なし）
- 仕様書セクションをコメントで参照し、再発見性を確保

## 検証

- 全ターンテキスト入力時の手計算: `avgReact = 2000` → `sReact ≒ 53`、`sSpeech = 0`、`sVoice = 0` → `positivity ≒ 21` 点。修正前の 40 点から正常に低下することを確認
- `npx tsc --noEmit` / `npm run build` 通過

## スコープ外

- `phaseSummaryBuilder.ts` の同種の集計 → #34 で対応
- Game 3 の `?? 0`（仕様上 null は来ないため不要）
- 集計式・閾値・正規化関数の変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ゲーム2のスコア計算ロジックを改善し、無効なデータの処理方法を最適化しました。これにより、反応時間、音声の長さ、音量などのメトリクス計算がより正確かつ堅牢になり、最終スコアの精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->