### PR TITLE
fix: Game 1 calmness の popupStats フォールバック値を worst 値に修正

### DIFF
--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -155,8 +155,12 @@ function calculateGame1(data: Game1Data | undefined): Game1Result {
   );
 
   //冷静さ: マウスブレ・無駄クリック
-  const sJitter = linearInv(data.popupStats?.mouseJitter ?? 0, 10, 200);
-  const sClick = linearInv(data.popupStats?.clickCount ?? 1, 1, 5);
+  // 仕様書「分析ロジック → エッジケースの扱い → Game 1 の個別フォールバック」に従い、
+  // popupStats 欠損時は worst 値（linearInv の第 3 引数）にフォールバックする。
+  // popupStats はポップアップが timeout で表示されない場合（高速スクロール時）や送信失敗時に欠損するが、
+  // どちらも「測定不能 / 冷静ではない」として 0 点扱いとする（best 値だと 100 点になり不当に高得点となる）。
+  const sJitter = linearInv(data.popupStats?.mouseJitter ?? 200, 10, 200);
+  const sClick = linearInv(data.popupStats?.clickCount ?? 5, 1, 5);
 
   const calmness = Math.round(
     sJitter * 0.6 +


### PR DESCRIPTION
## 概要

`popupStats` 欠損時に Game 1 の冷静さスコアが 100 点（最高）になる不当挙動を、仕様書「分析ロジック → エッジケースの扱い → Game 1 の個別フォールバック」に従って 0 点（worst）扱いに修正する。

## 変更内容

`backend/src/analysis/scoreCalculator.ts` の `calculateGame1` 内、冷静さスコアのフォールバック値を変更:

- `data.popupStats?.mouseJitter ?? 0` → `?? 200`（`linearInv` の worst 値）
- `data.popupStats?.clickCount ?? 1` → `?? 5`（`linearInv` の worst 値）

合わせて、フォールバックの根拠（仕様書参照と「測定不能 / 冷静ではない」として 0 点扱いとする意図）をコメントで明記した。

## 動作確認

- `popupStats` が `undefined` の場合: `linearInv(200, 10, 200) = 0`、`linearInv(5, 1, 5) = 0` となり、冷静さ（`sJitter * 0.6 + sClick * 0.4`）が 0 点になることを計算で確認

closes #26