### PR TITLE
fix: Phase 2 サマリーを仕様書準拠の null 除外集計に修正

### DIFF
--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -37,20 +37,35 @@ export function buildPhaseSummaries(
     // --- Phase 2: AIチャットの要約 ---
     let phase2Text = 'データなし';
     if (game2Raw) {
-        const method = game2Raw.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
         const turns = game2Raw.turns || [];
 
-        // サマリーテキスト用の平均反応速度。`?? 2000` は未測定時の中立値（「慎重側」と「即応側」の境界）。
-        // scoreCalculator.ts は同じフィールドを `?? 0` で扱うため、reactionTimeMs が null（= 無発話/
-        // タイムアウトの正規値）のペイロードではテキストとスコアで評価が食い違う可能性がある。
-        // 根本対応（null を集計対象外として扱う統一ロジック）は Issue #11 の派生で行う。
-        const avgReaction = turns.length > 0
-            ? turns.reduce((sum, t) => sum + (t.reactionTimeMs ?? 2000), 0) / turns.length
-            : 2000;
+        // 仕様書「分析ロジック → Game 2 → Null 値（テキスト入力時）の扱い → サマリーテキスト
+        // （phase_summaries）も同じ方針」に従い、null（= テキスト入力ターン）を除外して平均を取る。
+        // scoreCalculator.ts L202-208 と同じ集計方針で揃え、テキストとスコアで評価が食い違わないようにする。
+        const reactValues = turns
+            .map((t) => t.reactionTimeMs)
+            .filter((v): v is number => v !== null);
 
-        const reactionText = avgReaction < 800 ? 'AIの理不尽な対応に即座に反応し' : 'AIの対応に対して一呼吸おいてから';
-        
-        phase2Text = `${reactionText}、${method}反論を展開しました。`;
+        // turns 0 件の場合も「反応速度を測定していない」状態として全ターンテキスト相当に扱う
+        // （scoreCalculator も avgReact=2000 にフォールバックする方針）。
+        const allTextOrEmpty = reactValues.length === 0;
+        const allVoice = turns.length > 0 && reactValues.length === turns.length;
+
+        if (allTextOrEmpty) {
+            // 全ターンテキスト: 反応速度に言及しない（仕様書例文に準拠）
+            phase2Text = 'テキストで冷静に反論を展開しました。';
+        } else {
+            const avgReaction = reactValues.reduce((a, v) => a + v, 0) / reactValues.length;
+            const reactionText = avgReaction < 800 ? 'AIの理不尽な対応に即座に反応し' : 'AIの対応に対して一呼吸おいてから';
+
+            if (allVoice) {
+                phase2Text = `${reactionText}、音声で堂々と反論を展開しました。`;
+            } else {
+                // 混在: null 除外平均で反応速度を判定し、method は Game2Data 直下の inputMethod を採用
+                const method = game2Raw.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
+                phase2Text = `${reactionText}、${method}反論を展開しました。`;
+            }
+        }
     }
 
     // --- Phase 3: グループチャットの要約 ---

--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -91,8 +91,9 @@ export function buildPhaseSummaries(
         
         const socialText = conformRate >= 60 ? 'グループの空気を敏感に察知して周りに合わせ' : '周りに流されず我が道をゆく選択肢を取り';
         
-        // サマリーテキスト用の平均反応速度。`?? 2000` は中立値（Phase 2 と同じ方針）。
-        // scoreCalculator.ts 側は `?? 0` のため、null 混入時の挙動差は Issue #11 派生で整合化する。
+        // 平均反応速度から速度感を表現する。
+        // Phase 3 の reactionTimeMs は仕様上 null が来ない（タイムアウト時も実時間 ≈ 10000ms で記録される）。
+        // 防御的に `?? 2000`（中立値）でフォールバックし、stages 0 件のときも 2000ms を使う。
         const avgReaction = stages.length > 0
             ? stages.reduce((sum, s) => sum + (s.reactionTimeMs ?? 2000), 0) / stages.length
             : 2000;

--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -41,13 +41,21 @@ export function buildPhaseSummaries(
 
         // 仕様書「分析ロジック → Game 2 → Null 値（テキスト入力時）の扱い → サマリーテキスト
         // （phase_summaries）も同じ方針」に従い、null（= テキスト入力ターン）を除外して平均を取る。
-        // scoreCalculator.ts L202-208 と同じ集計方針で揃え、テキストとスコアで評価が食い違わないようにする。
+        // scoreCalculator の calculateGame2 内 reactValues 集計部分と同じ集計方針で揃え、
+        // テキストとスコアで評価が食い違わないようにする。
+        //
+        // 判定軸として `turns[i].inputMethod === 'text'` は使わず `reactionTimeMs === null`
+        // のみで判定する。これは仕様書「Game 2 Null 値の扱い → 注: ターン単位の
+        // `Game2Turn.inputMethod` について」で「現状の集計ロジックは "null 判定" で同等の効果が
+        // 得られるため、スコア計算では inputMethod を直接参照しない」と明記された方針に揃えた
+        // ためで、scoreCalculator と同じ判定基準になる。
         const reactValues = turns
             .map((t) => t.reactionTimeMs)
             .filter((v): v is number => v !== null);
 
-        // turns 0 件の場合も「反応速度を測定していない」状態として全ターンテキスト相当に扱う
-        // （scoreCalculator も avgReact=2000 にフォールバックする方針）。
+        // turns 0 件のケース（ゲーム未プレイ等）は仕様書未定義のため、便宜上「全ターンテキスト
+        // 相当」に統一して反応速度に言及しないテキストを返す。scoreCalculator も同条件で
+        // avgReact=2000 にフォールバックする方針で整合している。
         const allTextOrEmpty = reactValues.length === 0;
         const allVoice = turns.length > 0 && reactValues.length === turns.length;
 
@@ -61,7 +69,11 @@ export function buildPhaseSummaries(
             if (allVoice) {
                 phase2Text = `${reactionText}、音声で堂々と反論を展開しました。`;
             } else {
-                // 混在: null 除外平均で反応速度を判定し、method は Game2Data 直下の inputMethod を採用
+                // 混在: null 除外平均で反応速度を判定し、method は Game2Data 直下の inputMethod を採用。
+                // 直下フィールドを使う根拠は scoreCalculator の sVoice 算出と同じ方針（音声選択を 0/100
+                // で評価する積極性スコアが Game2Data.inputMethod を参照しているため、サマリー側もそろえる）。
+                // 「主に音声/テキストどちらだったか」をターン多数決で決める方が正確という議論はあるが、
+                // 仕様書未定義のためスコアと同じ判定軸に揃える。
                 const method = game2Raw.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
                 phase2Text = `${reactionText}、${method}反論を展開しました。`;
             }


### PR DESCRIPTION
## 概要

`backend/src/analysis/phaseSummaryBuilder.ts` の Phase 2 サマリー生成を仕様書「分析ロジック → サマリーテキスト（phase_summaries）も同じ方針」に揃え、テキスト入力ユーザーに対して「測定していない反応速度の評価」が表示される問題を解消する。

## 変更内容

- `reactionTimeMs` を `?? 2000` で中立値にフォールバックするのをやめ、`null` を除外して平均を取る方式に変更（`scoreCalculator` の `calculateGame2` と同じ集計方針）
- 入力方式の構成に応じて 3 分岐:
  - **全ターンテキスト**（`reactionTimeMs !== null` のターン 0 件、turns 0 件も同じ扱い）→ `'テキストで冷静に反論を展開しました。'`（反応速度の言及なし）
  - **全ターン音声** → 既存どおり `'${reactionText}、音声で堂々と反論を展開しました。'`
  - **混在** → `null` 除外平均で `reactionText` を判定、`method` は `game2Raw.inputMethod` 直下を参照
- 判定軸選択・`turns` 0 件の扱い・混在 `method` 決定根拠をコメントで明記（仕様書「Game 2 Null 値の扱い」の注記を引用）
- `scoreCalculator.ts` への参照を行番号から関数名（`calculateGame2 内 reactValues 集計部分`）に変更し、陳腐化を防止

## 動作確認

3 パターンの payload で Phase 2 サマリーの出力を手動確認する想定:

| パターン | turns 例 | 期待出力 |
|---|---|---|
| 全テキスト | 全ターン `reactionTimeMs: null` | `テキストで冷静に反論を展開しました。` |
| 全音声 | 全ターン `reactionTimeMs: 600` | `AIの理不尽な対応に即座に反応し、音声で堂々と反論を展開しました。` |
| 混在 | `[null, 1500, null, 900]` | `AIの対応に対して一呼吸おいてから、{音声/テキスト}反論を展開しました。`（`game2Raw.inputMethod` 次第） |

## スコープ外

- `scoreCalculator.ts` の null 集計修正（既に仕様書準拠の実装になっていることを確認）
- `phaseSummaryBuilder.ts` の `any` 排除（→ #29）
- Phase 1 / Phase 3 のロジック・コメント更新（仕様上 `null` が来ない or 別 Issue）

closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ゲームフェーズサマリーの反応時間分析が改善されました。無効なデータを適切に除外することで、より正確な分析結果を提供します。データの利用可能性に応じて、分析結果の表示形式が最適化されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->