### PR TITLE
fix: Game 1 ポップアップ未表示/操作中断時に popupStats を未送信にする

### DIFF
--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -3,7 +3,11 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
-import type { Game1Data, ScrollEvent } from '@/features/games/types';
+import type {
+  Game1Data,
+  PopupStats,
+  ScrollEvent,
+} from '@/features/games/types';
 import { game1DataAtom } from '@/stores/games';
 import PopupAd from './PopupAd';
 import PopupTerms from './PopupTerms';
@@ -52,12 +56,10 @@ export default function TermsGameFlow() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // ポップアップが表示された時刻（timeToClose算出用）。レンダー時にJSXへ渡すためstateで管理
   const [popupAppearedAt, setPopupAppearedAt] = useState(0);
-  // ポップアップへの対応データ
-  const popupStatsRef = useRef({
-    timeToClose: 0,
-    clickCount: 0,
-    mouseJitter: 0,
-  });
+  // ポップアップへの対応データ。
+  // 未表示・操作中断（閉じる前に同意/不同意）の場合は null のまま残し、
+  // 送信ペイロードから popupStats フィールドを省略する（BE 側で worst 値扱いとなる）。
+  const popupStatsRef = useRef<PopupStats | null>(null);
   // 「同意する」ボタンにホバーし始めた時刻
   const agreeHoverStartRef = useRef(0);
   // 各チェックボックスがユーザーによって変更されたかの追跡
@@ -190,7 +192,8 @@ export default function TermsGameFlow() {
             changed: checkboxChangedRef.current.thirdPartyShare,
           },
         },
-        popupStats: popupStatsRef.current,
+        // null の場合はフィールド自体を未送信にする（JSON.stringify が undefined を省略）。
+        popupStats: popupStatsRef.current ?? undefined,
         agreeButtonHoverTimeMs: getAgreeButtonHoverTimeMs(),
       };
     },

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -45,7 +45,9 @@ export interface Game1Data {
     mailMagazine: CheckboxState;
     thirdPartyShare: CheckboxState;
   };
-  popupStats: PopupStats;
+  // ポップアップ広告が表示されかつ閉じられた場合にのみ送信する。
+  // 未表示・操作中断時は未送信（undefined）とし、BE 側で worst 値フォールバックさせる。
+  popupStats?: PopupStats;
   // 「同意する」ボタンにホバーしてからクリックするまでの時間（ms）
   agreeButtonHoverTimeMs: number;
 }


### PR DESCRIPTION
## 概要

closes #48

PR #47 で BE 側 (`scoreCalculator.ts`) の `popupStats` 欠損時フォールバックを worst 値（冷静さ 0 点扱い）に修正したが、FE 側で `popupStats` が常に初期値 `{ timeToClose: 0, clickCount: 0, mouseJitter: 0 }` のオブジェクトとして送信されているため、BE の `?? 200` / `?? 5` が効かず冷静さが満点になる状態だった。FE の送信ロジックを修正し、ポップアップ未表示・操作中断時に `popupStats` フィールドを未送信にする。

## 変更内容

### `frontend/src/features/games/types/index.ts`
- `Game1Data.popupStats` をオプショナル (`popupStats?: PopupStats`) に変更
- 未送信 (`undefined`) を表現できるようにし、用途コメントを追加

### `frontend/src/features/games/terms/components/TermsGameFlow.tsx`
- `popupStatsRef` の型を `useRef<PopupStats | null>(null)` に変更し、初期値を `null` に
- `handlePopupClose` でポップアップを閉じた時にのみ値をセットする経路は維持
- `buildGame1Data` で `popupStats: popupStatsRef.current ?? undefined` とし、`null` の場合はフィールドを未送信にする（`JSON.stringify` が `undefined` プロパティを省略）

## 動作シナリオ

| シナリオ | 発生条件 | 修正後の挙動 |
|---|---|---|
| ① ポップアップ未表示 | 規約読了 < 15 秒で同意/不同意 | `popupStats` 未送信 → BE 側 worst 値で冷静さ 0 点 |
| ② 正常 | ポップアップを閉じてから同意/不同意 | 現状通り `popupStats` を送信 |
| ③ 操作中断 | ポップアップ表示中に同意/不同意 | `popupStats` 未送信 → BE 側 worst 値で冷静さ 0 点 |

## 動作確認方法（手動）

- [ ] シナリオ ①: 規約モーダル表示後 15 秒未満で同意/不同意 → ペイロードに `popupStats` フィールドが含まれない
- [ ] シナリオ ②: ポップアップを閉じてから同意/不同意 → 現状通り `popupStats` が送信される
- [ ] シナリオ ③: ポップアップ表示中に同意/不同意 → ペイロードに `popupStats` フィールドが含まれない

## 関連

- BE 側のフォールバック修正: PR #47 で完了済み
- 仕様書「分析ロジック → エッジケースの扱い → Game 1」

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ポップアップ統計データの送信処理を改善しました。ポップアップが表示されない、またはユーザーのやり取りが中断された場合、デフォルト値を含まない正確なデータを送信するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->