### PR TITLE
fix: PopupAd の z-index を上げて規約モーダルとの重なりを解消

### DIFF
--- a/frontend/src/features/games/terms/components/PopupAd.tsx
+++ b/frontend/src/features/games/terms/components/PopupAd.tsx
@@ -66,7 +66,8 @@ export default function PopupAd({ onClose, appearedAt }: PopupAdProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      // 規約モーダル (PopupTerms) と重なるため z-[60] で上層に表示する
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
       onClick={handleOverlayClick}
     >
       <div


### PR DESCRIPTION
## 概要

closes #54

利用規約画面で 15 秒経過後に表示されるはずのポップアップ広告 (`PopupAd`) が、規約モーダル (`PopupTerms`) の下に隠れて視覚的に表示されない問題を修正する。

## 原因

`PopupAd` と `PopupTerms` の最上位 div が共に `z-50` で、CSS 仕様上 z-index が同値の場合は DOM 順序で後にマウントされた方が上に重なる。`TermsGameFlow.tsx` では `PopupTerms` が `PopupAd` より後に書かれており、かつ `PopupTerms` は `fixed inset-0 bg-black/30` で全画面を覆うため、広告ポップアップが完全に隠される状態だった。

## 変更内容

`frontend/src/features/games/terms/components/PopupAd.tsx`
- 最上位 div の z-index を `z-50` → `z-[60]` に変更
- 重なり解消の意図がわかるようコメントを追加

## 動作確認方法

- [ ] `/games/terms` で 15 秒経過後にポップアップ広告が画面中央に表示される
- [ ] ポップアップの ✕ ボタンで閉じられる
- [ ] 閉じた後、規約モーダルで同意/不同意の操作ができる

## 関連

- このバグは PR #53 のシナリオ ② / ③ 動作確認をブロックしていたため、本 PR マージ後に PR #53 の残りの確認を実施可能になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ポップアップ広告のオーバーレイ表示が他のモーダルの背後に隠れていた問題を修正しました。これにより、ポップアップが正しく画面上に表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->