### PR TITLE
fix: run_api_tests.sh の payload を仕様書準拠に修正

### DIFF
--- a/backend/run_api_tests.sh
+++ b/backend/run_api_tests.sh
@@ -65,7 +65,8 @@ GAME1_PAYLOAD='{
       "mailMagazine": {"checked": false, "changed": true},
       "thirdPartyShare": {"checked": false, "changed": true}
     },
-    "popupStats": {"timeToClose": 1200, "clickCount": 1}
+    "popupStats": {"timeToClose": 1200, "clickCount": 1, "mouseJitter": 30},
+    "agreeButtonHoverTimeMs": 800
   }
 }'
 
@@ -110,7 +111,8 @@ GAME2_PAYLOAD='{
         "volumeDb": null,
         "transcribedText": "別の方法を試します"
       }
-    ]
+    ],
+    "textInputMetrics": {"typingIntervalVariance": 120}
   }
 }'
 
@@ -135,12 +137,14 @@ GAME3_PAYLOAD='{
   "game_type": 3,
   "data": {
     "tutorialViewTime": 5200,
+    "hoveredOptions": 4,
+    "typingIndicatorReactTimeMs": 1500,
     "stages": [
-      {"stageId": 1, "selectedOptionId": 2, "reactionTime": 3400, "isTimeout": false},
-      {"stageId": 2, "selectedOptionId": 1, "reactionTime": 1800, "isTimeout": false},
-      {"stageId": 3, "selectedOptionId": 3, "reactionTime": 4500, "isTimeout": false},
-      {"stageId": 4, "selectedOptionId": 0, "reactionTime": 10000, "isTimeout": true},
-      {"stageId": 5, "selectedOptionId": 1, "reactionTime": 2200, "isTimeout": false}
+      {"stageId": 1, "selectedOptionId": 2, "reactionTimeMs": 3400, "isTimeout": false},
+      {"stageId": 2, "selectedOptionId": 1, "reactionTimeMs": 1800, "isTimeout": false},
+      {"stageId": 3, "selectedOptionId": 3, "reactionTimeMs": 4500, "isTimeout": false},
+      {"stageId": 4, "selectedOptionId": 0, "reactionTimeMs": 10000, "isTimeout": true},
+      {"stageId": 5, "selectedOptionId": 1, "reactionTimeMs": 2200, "isTimeout": false}
     ]
   }
 }'


### PR DESCRIPTION
## 概要

`backend/run_api_tests.sh` の game_1 / game_2 / game_3 payload を仕様書「データ構造」と zod スキーマ（`backend/src/schemas/gameData.ts`）に準拠させる。PR #37 で submit に zod 検証が追加されたことで顕在化したバグ。

## 変更内容

- Game 1: `popupStats.mouseJitter` と `agreeButtonHoverTimeMs` を追加
- Game 2: `textInputMetrics`（`typingIntervalVariance`）を追加
- Game 3: `hoveredOptions` と `typingIndicatorReactTimeMs` を追加、`stages[*].reactionTime` を `reactionTimeMs` にリネーム（5 箇所）

## 動作確認

- `bash -n backend/run_api_tests.sh`: 構文 OK
- `npx tsc --noEmit` / `npm run build` (backend): OK
- 各 payload は `gameData.ts` の zod スキーマ（`game1DataSchema` / `game2DataSchema` / `game3DataSchema`）の必須フィールドを全て満たす構成

closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * API テストペイロードを更新。ゲームのユーザーインタラクションメトリクス収集機能を拡張しました。マウス操作、テキスト入力、ホバー動作などの新たなデータポイントを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->