### PR TITLE
refactor: BE 共通 zod スキーマを registry.register() で名前付きコンポーネント化

### DIFF
--- a/backend/src/schemas/common.ts
+++ b/backend/src/schemas/common.ts
@@ -2,6 +2,7 @@
 // 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
 import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 
 /**
  * 複数エンドポイントで使い回す横断スキーマ。
@@ -61,18 +62,21 @@ export const mbtiSchema = z
 const ANSWER_OPTIONS = ['A', 'B', 'C', 'D'] as const;
 export type AnswerOption = typeof ANSWER_OPTIONS[number];
 
-export const answerOptionSchema = z
-    .string({ error: '回答は必須です' })
-    .refine(
-        (val): val is AnswerOption =>
-            (ANSWER_OPTIONS as readonly string[]).includes(val),
-        { error: '回答は A / B / C / D のいずれかで指定してください' },
-    )
-    .openapi({
-        description: '基準値アンケートの回答選択肢（A / B / C / D のいずれか）',
-        enum: [...ANSWER_OPTIONS],
-        example: 'A',
-    });
+export const answerOptionSchema = registry.register(
+    'AnswerOption',
+    z
+        .string({ error: '回答は必須です' })
+        .refine(
+            (val): val is AnswerOption =>
+                (ANSWER_OPTIONS as readonly string[]).includes(val),
+            { error: '回答は A / B / C / D のいずれかで指定してください' },
+        )
+        .openapi({
+            description: '基準値アンケートの回答選択肢（A / B / C / D のいずれか）',
+            enum: [...ANSWER_OPTIONS],
+            example: 'A',
+        }),
+);
 
 /**
  * 5 軸各軸のスコア値（0-100 の整数）。
@@ -97,26 +101,30 @@ const boundedScoreSchema = z.number().int().min(0).max(100);
  * - `z.infer` の結果型は `number` のままで既存コードへの影響はない
  *   （`.min/.max` はランタイム検証にのみ作用）
  */
-export const baselineScoresSchema = z
-    .object({
-        caution: boundedScoreSchema.openapi({ description: '慎重さ（0-100）' }),
-        calmness: boundedScoreSchema.openapi({ description: '冷静さ（0-100）' }),
-        logic: boundedScoreSchema.openapi({ description: '論理性（0-100）' }),
-        cooperativeness: boundedScoreSchema.openapi({
-            description: '協調性（0-100）',
+export const baselineScoresSchema = registry.register(
+    'BaselineScores',
+    z
+        .object({
+            caution: boundedScoreSchema.openapi({ description: '慎重さ（0-100）' }),
+            calmness: boundedScoreSchema.openapi({ description: '冷静さ（0-100）' }),
+            logic: boundedScoreSchema.openapi({ description: '論理性（0-100）' }),
+            cooperativeness: boundedScoreSchema.openapi({
+                description: '協調性（0-100）',
+            }),
+            positivity: boundedScoreSchema.openapi({ description: '積極性（0-100）' }),
+        })
+        .openapi({
+            description:
+                '5 軸スコア（0-100 の整数）。baseline_scores / scores / mbti_scores で共通利用',
+            example: {
+                caution: 60,
+                calmness: 55,
+                logic: 70,
+                cooperativeness: 45,
+                positivity: 65,
+            },
         }),
-        positivity: boundedScoreSchema.openapi({ description: '積極性（0-100）' }),
-    })
-    .openapi({
-        description: '5 軸スコア（0-100 の整数）。baseline_scores / scores / mbti_scores で共通利用',
-        example: {
-            caution: 60,
-            calmness: 55,
-            logic: 70,
-            cooperativeness: 45,
-            positivity: 65,
-        },
-    });
+);
 
 export type BaselineScores = z.infer<typeof baselineScoresSchema>;
 
@@ -127,23 +135,26 @@ export type BaselineScores = z.infer<typeof baselineScoresSchema>;
  * 範囲制約（0-100）を付けない別スキーマとして分離している。
  * 整数制約は維持する（仕様書「DB 設計書」で gap_* カラムは `INT` 型）。
  */
-export const gapScoresSchema = z
-    .object({
-        caution: z.number().int().openapi({ description: '慎重さのギャップ（実測 - 自己申告）' }),
-        calmness: z.number().int().openapi({ description: '冷静さのギャップ' }),
-        logic: z.number().int().openapi({ description: '論理性のギャップ' }),
-        cooperativeness: z.number().int().openapi({ description: '協調性のギャップ' }),
-        positivity: z.number().int().openapi({ description: '積極性のギャップ' }),
-    })
-    .openapi({
-        description: '5 軸ギャップ（実測 - 自己申告）。負値を取りうる整数',
-        example: {
-            caution: -5,
-            calmness: 10,
-            logic: 0,
-            cooperativeness: 15,
-            positivity: -8,
-        },
-    });
+export const gapScoresSchema = registry.register(
+    'GapScores',
+    z
+        .object({
+            caution: z.number().int().openapi({ description: '慎重さのギャップ（実測 - 自己申告）' }),
+            calmness: z.number().int().openapi({ description: '冷静さのギャップ' }),
+            logic: z.number().int().openapi({ description: '論理性のギャップ' }),
+            cooperativeness: z.number().int().openapi({ description: '協調性のギャップ' }),
+            positivity: z.number().int().openapi({ description: '積極性のギャップ' }),
+        })
+        .openapi({
+            description: '5 軸ギャップ（実測 - 自己申告）。負値を取りうる整数',
+            example: {
+                caution: -5,
+                calmness: 10,
+                logic: 0,
+                cooperativeness: 15,
+                positivity: -8,
+            },
+        }),
+);
 
 export type GapScores = z.infer<typeof gapScoresSchema>;

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -2,6 +2,7 @@
 // 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
 import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 import { userIdSchema } from './common';
 import { GAME_TYPES } from '../types';
 import {
@@ -35,22 +36,25 @@ import {
  * OpenAPI では `.openapi({ enum: [...] })` で enum 情報を補う
  * （z.union<z.literal> のままだと OpenAPI 側で `anyOf` に落ちてしまうため）。
  */
-export const gameTypeSchema = z
-    .union([
-        z.literal(GAME_TYPES.TERMS_GAME),
-        z.literal(GAME_TYPES.AI_CHAT),
-        z.literal(GAME_TYPES.GROUP_CHAT),
-    ])
-    .openapi({
-        description:
-            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット',
-        enum: [
-            GAME_TYPES.TERMS_GAME,
-            GAME_TYPES.AI_CHAT,
-            GAME_TYPES.GROUP_CHAT,
-        ],
-        example: GAME_TYPES.TERMS_GAME,
-    });
+export const gameTypeSchema = registry.register(
+    'GameType',
+    z
+        .union([
+            z.literal(GAME_TYPES.TERMS_GAME),
+            z.literal(GAME_TYPES.AI_CHAT),
+            z.literal(GAME_TYPES.GROUP_CHAT),
+        ])
+        .openapi({
+            description:
+                'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット',
+            enum: [
+                GAME_TYPES.TERMS_GAME,
+                GAME_TYPES.AI_CHAT,
+                GAME_TYPES.GROUP_CHAT,
+            ],
+            example: GAME_TYPES.TERMS_GAME,
+        }),
+);
 
 /**
  * ゲーム固有の行動データ。
@@ -74,36 +78,42 @@ export const gameDataSchema = z
 /**
  * POST /api/games/submit のリクエストボディ。
  */
-export const submitGameRequestSchema = z
-    .object({
-        user_id: userIdSchema,
-        game_type: gameTypeSchema,
-        data: gameDataSchema,
-    })
-    .openapi({
-        description:
-            '各ゲーム終了時に行動データを送信するリクエスト。' +
-            '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
-        example: submitGameRequestExampleGame1,
-    });
+export const submitGameRequestSchema = registry.register(
+    'SubmitGameRequest',
+    z
+        .object({
+            user_id: userIdSchema,
+            game_type: gameTypeSchema,
+            data: gameDataSchema,
+        })
+        .openapi({
+            description:
+                '各ゲーム終了時に行動データを送信するリクエスト。' +
+                '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
+            example: submitGameRequestExampleGame1,
+        }),
+);
 
 /**
  * POST /api/games/submit のレスポンス（200 OK）。
  */
-export const submitGameResponseSchema = z
-    .object({
-        status: z.literal('success').openapi({
-            description: '固定値 "success"',
+export const submitGameResponseSchema = registry.register(
+    'SubmitGameResponse',
+    z
+        .object({
+            status: z.literal('success').openapi({
+                description: '固定値 "success"',
+            }),
+            message: z.string().openapi({
+                description: '保存されたゲームを示す運用向けメッセージ',
+                example: submitGameResponseExample.message,
+            }),
+        })
+        .openapi({
+            description: 'ゲームデータ保存成功レスポンス（200 OK）',
+            example: submitGameResponseExample,
         }),
-        message: z.string().openapi({
-            description: '保存されたゲームを示す運用向けメッセージ',
-            example: submitGameResponseExample.message,
-        }),
-    })
-    .openapi({
-        description: 'ゲームデータ保存成功レスポンス（200 OK）',
-        example: submitGameResponseExample,
-    });
+);
 
 /**
  * ゲーム種別（1/2/3）の TS 型。

--- a/backend/src/schemas/register.ts
+++ b/backend/src/schemas/register.ts
@@ -2,6 +2,7 @@
 // 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
 import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 import { answerOptionSchema, mbtiSchema } from './common';
 import {
     registerRequestExample,
@@ -21,54 +22,63 @@ import {
  * 5 軸の基準値アンケート回答（A/B/C/D）。
  * 5 設問すべて必須。未知プロパティは zod v4 のデフォルト挙動で strip される。
  */
-export const baselineAnswersSchema = z
-    .object({
-        q1_caution: answerOptionSchema,
-        q2_calmness: answerOptionSchema,
-        q3_logic: answerOptionSchema,
-        q4_cooperativeness: answerOptionSchema,
-        q5_positivity: answerOptionSchema,
-    })
-    .openapi({
-        description:
-            '5 軸の基準値アンケート回答。各軸（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）に ' +
-            'A / B / C / D のいずれかで回答する（A=100, B=75, C=25, D=0 点に内部変換される）',
-        example: registerRequestExample.baseline_answers,
-    });
+export const baselineAnswersSchema = registry.register(
+    'BaselineAnswers',
+    z
+        .object({
+            q1_caution: answerOptionSchema,
+            q2_calmness: answerOptionSchema,
+            q3_logic: answerOptionSchema,
+            q4_cooperativeness: answerOptionSchema,
+            q5_positivity: answerOptionSchema,
+        })
+        .openapi({
+            description:
+                '5 軸の基準値アンケート回答。各軸（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）に ' +
+                'A / B / C / D のいずれかで回答する（A=100, B=75, C=25, D=0 点に内部変換される）',
+            example: registerRequestExample.baseline_answers,
+        }),
+);
 
 /**
  * POST /api/register のリクエストボディ。
  * mbti は省略・null 許容（自己診断スキップに対応）。指定された場合は MBTI 形式に従う。
  */
-export const registerRequestSchema = z
-    .object({
-        mbti: mbtiSchema.nullish(),
-        baseline_answers: baselineAnswersSchema,
-    })
-    .openapi({
-        description:
-            'MBTI 選択 + 基準値アンケート（5 設問）完了時に送信する登録リクエスト。' +
-            'mbti は任意（null / 省略でスキップ扱い）、baseline_answers は全 5 設問必須',
-        example: registerRequestExample,
-    });
+export const registerRequestSchema = registry.register(
+    'RegisterRequest',
+    z
+        .object({
+            mbti: mbtiSchema.nullish(),
+            baseline_answers: baselineAnswersSchema,
+        })
+        .openapi({
+            description:
+                'MBTI 選択 + 基準値アンケート（5 設問）完了時に送信する登録リクエスト。' +
+                'mbti は任意（null / 省略でスキップ扱い）、baseline_answers は全 5 設問必須',
+            example: registerRequestExample,
+        }),
+);
 
 /**
  * POST /api/register のレスポンス（201 Created）。
  */
-export const registerResponseSchema = z
-    .object({
-        user_id: z.uuid().openapi({
-            description: '新規発行されたユーザー識別子（UUID v4）',
-            example: registerResponseExample.user_id,
+export const registerResponseSchema = registry.register(
+    'RegisterResponse',
+    z
+        .object({
+            user_id: z.uuid().openapi({
+                description: '新規発行されたユーザー識別子（UUID v4）',
+                example: registerResponseExample.user_id,
+            }),
+            status: z.literal('success').openapi({
+                description: '固定値 "success"',
+            }),
+        })
+        .openapi({
+            description: '登録成功レスポンス（201 Created）',
+            example: registerResponseExample,
         }),
-        status: z.literal('success').openapi({
-            description: '固定値 "success"',
-        }),
-    })
-    .openapi({
-        description: '登録成功レスポンス（201 Created）',
-        example: registerResponseExample,
-    });
+);
 
 export type BaselineAnswers = z.infer<typeof baselineAnswersSchema>;
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -2,6 +2,7 @@
 // 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
 import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 import {
     baselineScoresSchema,
     gapScoresSchema,
@@ -48,61 +49,70 @@ const partialBaselineScoresSchema = baselineScoresSchema.partial();
  * ゲームごとのスコア内訳。
  * 各ゲームキー（game_1 / game_2 / game_3）は optional。
  */
-export const gameBreakdownSchema = z
-    .object({
-        game_1: partialBaselineScoresSchema.optional(),
-        game_2: partialBaselineScoresSchema.optional(),
-        game_3: partialBaselineScoresSchema.optional(),
-    })
-    .openapi({
-        description:
-            'ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため ' +
-            '5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）',
-        example: resultsResponseExample.game_breakdown,
-    });
+export const gameBreakdownSchema = registry.register(
+    'GameBreakdown',
+    z
+        .object({
+            game_1: partialBaselineScoresSchema.optional(),
+            game_2: partialBaselineScoresSchema.optional(),
+            game_3: partialBaselineScoresSchema.optional(),
+        })
+        .openapi({
+            description:
+                'ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため ' +
+                '5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）',
+            example: resultsResponseExample.game_breakdown,
+        }),
+);
 
 /**
  * 診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）。
  */
-export const diagnosisFeedbackSchema = z
-    .object({
-        title: z.string().openapi({
-            description: '診断タイプの見出し（最大ギャップ軸に基づく）',
-            example: resultsResponseExample.feedback.title,
+export const diagnosisFeedbackSchema = registry.register(
+    'DiagnosisFeedback',
+    z
+        .object({
+            title: z.string().openapi({
+                description: '診断タイプの見出し（最大ギャップ軸に基づく）',
+                example: resultsResponseExample.feedback.title,
+            }),
+            description: z.string().openapi({
+                description: '診断タイプの説明文',
+                example: resultsResponseExample.feedback.description,
+            }),
+            gap_point: z.string().openapi({
+                description: '自己認識と実測の乖離が最大だった軸名（日本語ラベル）',
+                example: resultsResponseExample.feedback.gap_point,
+            }),
+        })
+        .openapi({
+            description: '診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）',
+            example: resultsResponseExample.feedback,
         }),
-        description: z.string().openapi({
-            description: '診断タイプの説明文',
-            example: resultsResponseExample.feedback.description,
-        }),
-        gap_point: z.string().openapi({
-            description: '自己認識と実測の乖離が最大だった軸名（日本語ラベル）',
-            example: resultsResponseExample.feedback.gap_point,
-        }),
-    })
-    .openapi({
-        description: '診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）',
-        example: resultsResponseExample.feedback,
-    });
+);
 
 /**
  * 各フェーズ（ゲーム）の振り返りテキスト。
  */
-export const phaseSummariesSchema = z
-    .object({
-        phase_1: z.string().openapi({
-            description: 'Game 1（利用規約）の行動要約',
+export const phaseSummariesSchema = registry.register(
+    'PhaseSummaries',
+    z
+        .object({
+            phase_1: z.string().openapi({
+                description: 'Game 1（利用規約）の行動要約',
+            }),
+            phase_2: z.string().openapi({
+                description: 'Game 2（AI カスタマーサポート）の行動要約',
+            }),
+            phase_3: z.string().openapi({
+                description: 'Game 3（グループチャット）の行動要約',
+            }),
+        })
+        .openapi({
+            description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリー',
+            example: resultsResponseExample.phase_summaries,
         }),
-        phase_2: z.string().openapi({
-            description: 'Game 2（AI カスタマーサポート）の行動要約',
-        }),
-        phase_3: z.string().openapi({
-            description: 'Game 3（グループチャット）の行動要約',
-        }),
-    })
-    .openapi({
-        description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリー',
-        example: resultsResponseExample.phase_summaries,
-    });
+);
 
 /**
  * 各ゲーム固有の詳細情報（タイトル / 特徴スコア / 比較メトリクス）。
@@ -120,53 +130,56 @@ export const phaseSummariesSchema = z
  * 単位を取りうるため、整数制約や正値制約は付けない（仕様書「データ構造」も
  * `number` 規定）。
  */
-export const gameDetailSchema = z
-    .object({
-        title: z.string().openapi({
-            description: 'ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット）',
+export const gameDetailSchema = registry.register(
+    'GameDetail',
+    z
+        .object({
+            title: z.string().openapi({
+                description: 'ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット）',
+            }),
+            feature_scores: z
+                .array(
+                    z.object({
+                        axis: z.string().openapi({
+                            description: '軸キー（caution / calmness / logic / cooperativeness / positivity）',
+                        }),
+                        name: z.string().openapi({
+                            description: '軸の日本語ラベル（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）',
+                        }),
+                        score: z.number().int().min(0).max(100).openapi({
+                            description: '当該軸のゲーム単位スコア（0-100 整数）',
+                        }),
+                    }),
+                )
+                .openapi({
+                    description: '当該ゲームで測定した軸ごとのスコア配列（測定軸数はゲームごとに異なる）',
+                }),
+            metrics: z
+                .array(
+                    z.object({
+                        label: z.string().openapi({
+                            description: '指標の表示ラベル（例: 読了速度(px/s) / 反応潜時(ms)）',
+                        }),
+                        user: z.number().openapi({
+                            description: 'ユーザーの実測値（単位は label に依存）',
+                        }),
+                        average: z.number().openapi({
+                            description: '比較対象の平均値（単位は label に依存）',
+                        }),
+                        category: z.string().openapi({
+                            description: '指標のカテゴリ（scroll / time / mouse / input / voice / logic / message / social 等）',
+                        }),
+                    }),
+                )
+                .openapi({
+                    description: 'ユーザー値と平均値を並べた比較指標の配列',
+                }),
+        })
+        .openapi({
+            description: 'ゲーム単位の詳細情報。仕様書「データ構造」→ GameDetail 参照',
+            example: resultsResponseExample.details.game_1,
         }),
-        feature_scores: z
-            .array(
-                z.object({
-                    axis: z.string().openapi({
-                        description: '軸キー（caution / calmness / logic / cooperativeness / positivity）',
-                    }),
-                    name: z.string().openapi({
-                        description: '軸の日本語ラベル（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）',
-                    }),
-                    score: z.number().int().min(0).max(100).openapi({
-                        description: '当該軸のゲーム単位スコア（0-100 整数）',
-                    }),
-                }),
-            )
-            .openapi({
-                description: '当該ゲームで測定した軸ごとのスコア配列（測定軸数はゲームごとに異なる）',
-            }),
-        metrics: z
-            .array(
-                z.object({
-                    label: z.string().openapi({
-                        description: '指標の表示ラベル（例: 読了速度(px/s) / 反応潜時(ms)）',
-                    }),
-                    user: z.number().openapi({
-                        description: 'ユーザーの実測値（単位は label に依存）',
-                    }),
-                    average: z.number().openapi({
-                        description: '比較対象の平均値（単位は label に依存）',
-                    }),
-                    category: z.string().openapi({
-                        description: '指標のカテゴリ（scroll / time / mouse / input / voice / logic / message / social 等）',
-                    }),
-                }),
-            )
-            .openapi({
-                description: 'ユーザー値と平均値を並べた比較指標の配列',
-            }),
-    })
-    .openapi({
-        description: 'ゲーム単位の詳細情報。仕様書「データ構造」→ GameDetail 参照',
-        example: resultsResponseExample.details.game_1,
-    });
+);
 
 /**
  * 全 3 ゲームの詳細情報をまとめたオブジェクト。
@@ -174,54 +187,60 @@ export const gameDetailSchema = z
  * 全フィールド必須（3 ゲーム完了が `incomplete_games` でガードされているため、
  * results レスポンス到達時には必ず 3 ゲーム分の details が揃う前提）。
  */
-export const detailsSchema = z
-    .object({
-        game_1: gameDetailSchema,
-        game_2: gameDetailSchema,
-        game_3: gameDetailSchema,
-    })
-    .openapi({
-        description:
-            '各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）。' +
-            '構造は仕様書「データ構造」→ GameDetail を参照',
-        example: resultsResponseExample.details,
-    });
+export const detailsSchema = registry.register(
+    'Details',
+    z
+        .object({
+            game_1: gameDetailSchema,
+            game_2: gameDetailSchema,
+            game_3: gameDetailSchema,
+        })
+        .openapi({
+            description:
+                '各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）。' +
+                '構造は仕様書「データ構造」→ GameDetail を参照',
+            example: resultsResponseExample.details,
+        }),
+);
 
 /**
  * GET /api/results/:user_id のレスポンス（200 OK）。
  */
-export const resultsResponseSchema = z
-    .object({
-        user_id: userIdSchema,
-        self_mbti: mbtiSchema.nullable().openapi({
-            description: '自己申告の MBTI タイプ。登録時にスキップした場合は null',
+export const resultsResponseSchema = registry.register(
+    'ResultResponse',
+    z
+        .object({
+            user_id: userIdSchema,
+            self_mbti: mbtiSchema.nullable().openapi({
+                description: '自己申告の MBTI タイプ。登録時にスキップした場合は null',
+            }),
+            mbti_scores: baselineScoresSchema.nullable().openapi({
+                description: 'MBTI 理論値（self_mbti から導出）。self_mbti が null の場合は null',
+            }),
+            scores: baselineScoresSchema.openapi({
+                description: '3 ゲームから算出された実測の 5 軸スコア',
+            }),
+            baseline_scores: baselineScoresSchema.openapi({
+                description:
+                    'ベースライン（アンケート由来）。self_mbti があれば MBTI 理論値と 70:30 でブレンド済み',
+            }),
+            gaps: gapScoresSchema.openapi({
+                description: '実測 - ベースライン の差分。負値はベースラインを下回ったことを意味する',
+            }),
+            game_breakdown: gameBreakdownSchema,
+            feedback: diagnosisFeedbackSchema,
+            accuracy_score: z.number().int().min(0).max(100).openapi({
+                description: '自己認識精度（0-100 の整数）。100 - |平均ギャップ|',
+                example: resultsResponseExample.accuracy_score,
+            }),
+            phase_summaries: phaseSummariesSchema,
+            details: detailsSchema,
+        })
+        .openapi({
+            description: '診断結果レスポンス（200 OK）',
+            example: resultsResponseExample,
         }),
-        mbti_scores: baselineScoresSchema.nullable().openapi({
-            description: 'MBTI 理論値（self_mbti から導出）。self_mbti が null の場合は null',
-        }),
-        scores: baselineScoresSchema.openapi({
-            description: '3 ゲームから算出された実測の 5 軸スコア',
-        }),
-        baseline_scores: baselineScoresSchema.openapi({
-            description:
-                'ベースライン（アンケート由来）。self_mbti があれば MBTI 理論値と 70:30 でブレンド済み',
-        }),
-        gaps: gapScoresSchema.openapi({
-            description: '実測 - ベースライン の差分。負値はベースラインを下回ったことを意味する',
-        }),
-        game_breakdown: gameBreakdownSchema,
-        feedback: diagnosisFeedbackSchema,
-        accuracy_score: z.number().int().min(0).max(100).openapi({
-            description: '自己認識精度（0-100 の整数）。100 - |平均ギャップ|',
-            example: resultsResponseExample.accuracy_score,
-        }),
-        phase_summaries: phaseSummariesSchema,
-        details: detailsSchema,
-    })
-    .openapi({
-        description: '診断結果レスポンス（200 OK）',
-        example: resultsResponseExample,
-    });
+);
 
 export type ResultsParams = z.infer<typeof resultsParamsSchema>;
 export type GameBreakdown = z.infer<typeof gameBreakdownSchema>;

--- a/backend/src/schemas/voice.ts
+++ b/backend/src/schemas/voice.ts
@@ -2,6 +2,7 @@
 // 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
 import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 import { userIdSchema } from './common';
 import {
     voiceRespondRequestExample,
@@ -45,28 +46,31 @@ export const conversationMessageSchema = z
  * - `message` は仕様書で「空文字不可」のため `.min(1)` を付ける
  * - `conversation_history` は任意。未指定時は service 層で空配列扱い
  */
-export const voiceRespondRequestSchema = z
-    .object({
-        user_id: userIdSchema,
-        message: z
-            .string({ error: 'message は文字列で指定してください' })
-            .min(1, { error: 'message は空文字にできません' })
-            .openapi({
-                description: 'ユーザーの発話テキスト。空文字不可',
-                example: voiceRespondRequestExample.message,
-            }),
-        conversation_history: z
-            .array(conversationMessageSchema)
-            .optional()
-            .openapi({
-                description:
-                    '会話履歴（任意）。サーバ側では直近 1 件のみ使用する（仕様書「API 設計書」参照）',
-            }),
-    })
-    .openapi({
-        description: 'Game 2（AI カスタマーサポート）で AI 応答を生成するリクエスト',
-        example: voiceRespondRequestExample,
-    });
+export const voiceRespondRequestSchema = registry.register(
+    'VoiceRespondRequest',
+    z
+        .object({
+            user_id: userIdSchema,
+            message: z
+                .string({ error: 'message は文字列で指定してください' })
+                .min(1, { error: 'message は空文字にできません' })
+                .openapi({
+                    description: 'ユーザーの発話テキスト。空文字不可',
+                    example: voiceRespondRequestExample.message,
+                }),
+            conversation_history: z
+                .array(conversationMessageSchema)
+                .optional()
+                .openapi({
+                    description:
+                        '会話履歴（任意）。サーバ側では直近 1 件のみ使用する（仕様書「API 設計書」参照）',
+                }),
+        })
+        .openapi({
+            description: 'Game 2（AI カスタマーサポート）で AI 応答を生成するリクエスト',
+            example: voiceRespondRequestExample,
+        }),
+);
 
 /**
  * 応答の感情ラベル。
@@ -90,23 +94,26 @@ export const voiceEmotionSchema = z
  * 0-1 の範囲制約を付ける（範囲違反は実装バグなのでランタイム検証目的ではなく
  * 将来の OpenAPI の minimum/maximum 反映を見越した制約）。
  */
-export const voiceRespondResponseSchema = z
-    .object({
-        response: z.string().openapi({
-            description: 'AI の返答テキスト',
-            example: voiceRespondResponseExample.response,
+export const voiceRespondResponseSchema = registry.register(
+    'VoiceRespondResponse',
+    z
+        .object({
+            response: z.string().openapi({
+                description: 'AI の返答テキスト',
+                example: voiceRespondResponseExample.response,
+            }),
+            emotion: voiceEmotionSchema,
+            confidence: z.number().min(0).max(1).openapi({
+                description:
+                    '応答の確信度（0-1）。Gemini 成功時は 0.6、フォールバック時は 0.2-0.3',
+                example: voiceRespondResponseExample.confidence,
+            }),
+        })
+        .openapi({
+            description: 'AI 応答生成レスポンス（200 OK）',
+            example: voiceRespondResponseExample,
         }),
-        emotion: voiceEmotionSchema,
-        confidence: z.number().min(0).max(1).openapi({
-            description:
-                '応答の確信度（0-1）。Gemini 成功時は 0.6、フォールバック時は 0.2-0.3',
-            example: voiceRespondResponseExample.confidence,
-        }),
-    })
-    .openapi({
-        description: 'AI 応答生成レスポンス（200 OK）',
-        example: voiceRespondResponseExample,
-    });
+);
 
 export type ConversationMessage = z.infer<typeof conversationMessageSchema>;
 export type VoiceEmotion = z.infer<typeof voiceEmotionSchema>;


### PR DESCRIPTION
## 概要

closes #50

BE の zod スキーマのうち API 入出力に出るものを `registry.register('Name', schema)` で名前付きコンポーネント化し、Swagger UI / OpenAPI ドキュメントの `components.schemas` から参照可能にする。後段の OpenAPI 由来型生成（#51 / #52）で named type を得るための前提整備。

## 変更内容

`backend/src/schemas/errorCodes.ts` の `apiErrorSchema` と同じパターンで以下 17 スキーマをコンポーネント化:

| ファイル | 追加した名前付きコンポーネント |
|---|---|
| `schemas/common.ts` | `BaselineScores`, `GapScores`, `AnswerOption` |
| `schemas/register.ts` | `BaselineAnswers`, `RegisterRequest`, `RegisterResponse` |
| `schemas/games.ts` | `GameType`, `SubmitGameRequest`, `SubmitGameResponse` |
| `schemas/voice.ts` | `VoiceRespondRequest`, `VoiceRespondResponse` |
| `schemas/results.ts` | `ResultResponse`, `GameBreakdown`, `DiagnosisFeedback`, `PhaseSummaries`, `Details`, `GameDetail` |

- 各 schema ファイルに `import { registry } from '../openapi/registry';` を追加
- 既存の export 名・`z.infer` 由来 TS 型は変更していないため、`services/` `routes/` `middleware/` 側への影響なし
- `gameData.ts` の `Game1Data` / `Game2Data` / `Game3Data`（内部用、`.openapi()` 未付与）は対象外

## 動作確認

- `npx tsc --noEmit` / `npm run build` 通過
- `buildOpenApiDocument()` を直接実行し、`components.schemas` に対象 17 件 + 既存 `ApiError` の計 18 件が出力されることを確認
- 各エンドポイントのリクエスト/レスポンスが `$ref: '#/components/schemas/...'` で参照される形になることを確認
  - 例: `/api/results/{user_id}` 200 → `$ref: '#/components/schemas/ResultResponse'`
  - 例: `ResultResponse.scores` → `allOf: [{ $ref: BaselineScores }, { description: '...' }]`（フィールド固有 description を保持しつつコンポーネント参照を維持）

## 完了条件

- [x] Swagger UI (`/api-docs`) の Schemas タブに対象スキーマがコンポーネントとして表示される
- [x] 既存テスト・サーバ起動が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクター**
  * API スキーマの登録管理を統一し、ドキュメント生成の一貫性と保守性を向上させました。複数のスキーマが改善されたシステムで管理されるようになり、今後の API 機能開発がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->