### PR TITLE
feat: FE に openapi-typescript を導入して API 型を OpenAPI から自動生成

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
         "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "ts-node-dev": "^2.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       }
     },
@@ -55,6 +56,448 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google/generative-ai": {
@@ -832,6 +1275,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1045,6 +1530,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -1655,6 +2153,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -2080,6 +2588,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "dump:openapi": "tsx scripts/dump-openapi.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -33,6 +34,7 @@
     "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "ts-node-dev": "^2.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }
 }

--- a/backend/scripts/dump-openapi.ts
+++ b/backend/scripts/dump-openapi.ts
@@ -1,0 +1,27 @@
+/**
+ * OpenAPI ドキュメントを JSON 形式で stdout に出力する。
+ *
+ * 用途:
+ * - FE の `openapi-typescript` への入力ソースとして利用される（Issue #51）
+ * - BE 起動・DB 接続不要で OpenAPI スキーマだけを取り出すため、本スクリプトを
+ *   `tsx` で直接実行する設計とした
+ *
+ * 使い方:
+ *   npm run dump:openapi > path/to/openapi.json
+ *   （または FE 側の `gen:api-types` から呼び出す）
+ *
+ * 設計上の注意:
+ * - `buildOpenApiDocument()` は OpenAPIRegistry を引いてくるだけで副作用は持たない
+ *   （registry への登録は `document.ts` の副作用 import で完結する）
+ * - 本スクリプトは stdout に JSON を出力するだけに留め、エラー時は process.exit(1)
+ *   で異常終了させる（パイプ先のリダイレクトで空ファイルが生成されないようにする）
+ */
+import { buildOpenApiDocument } from '../src/openapi/document';
+
+try {
+    const doc = buildOpenApiDocument();
+    process.stdout.write(JSON.stringify(doc, null, 2) + '\n');
+} catch (error) {
+    console.error('Failed to build OpenAPI document:', error);
+    process.exit(1);
+}

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -3,3 +3,6 @@ out
 node_modules
 *.min.js
 package-lock.json
+
+# `npm run gen:api-types` で OpenAPI から自動生成（手で整形しない）
+src/lib/api/generated.ts

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     'out/**',
     'build/**',
     'next-env.d.ts',
+    // `npm run gen:api-types` で OpenAPI から自動生成（手で整形しない）
+    'src/lib/api/generated.ts',
   ]),
 ]);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "eslint-config-prettier": "^10",
+        "openapi-typescript": "^7.13.0",
         "prettier": "^3",
         "tailwindcss": "^4",
         "typescript": "^5"
@@ -1232,6 +1233,82 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.13",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.13.tgz",
+      "integrity": "sha512-4Tm4ysZkexx6ZTX7knqSZTqPlNgIvXc7Ha0pd30I694/GD0KtJE2xrElycfPds0vCLFAqoKyIzBtOF1xrLo8KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -2272,6 +2349,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2287,6 +2374,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-styles": {
@@ -2706,6 +2803,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2738,6 +2842,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4227,6 +4338,20 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4272,6 +4397,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/internal-slot": {
@@ -4782,6 +4920,16 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -5587,6 +5735,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5668,6 +5850,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5712,6 +5912,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5959,6 +6169,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -6681,6 +6901,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -6899,6 +7132,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -7051,6 +7291,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "gen:api-types": "node scripts/gen-api-types.mjs"
   },
   "dependencies": {
     "framer-motion": "^12.34.2",
@@ -27,6 +28,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10",
+    "openapi-typescript": "^7.13.0",
     "prettier": "^3",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/frontend/scripts/gen-api-types.mjs
+++ b/frontend/scripts/gen-api-types.mjs
@@ -31,6 +31,9 @@ console.log('[gen:api-types] Building OpenAPI document from backend...');
 const openapiJson = execSync('npm run --silent dump:openapi', {
   cwd: backendDir,
   encoding: 'utf-8',
+  // execSync のデフォルト maxBuffer (1MB) は将来 OpenAPI スキーマが拡大した際に
+  // 突破する可能性があるため、明示的に大きめに確保しておく。
+  maxBuffer: 10 * 1024 * 1024,
 });
 
 console.log('[gen:api-types] Generating TypeScript types...');

--- a/frontend/scripts/gen-api-types.mjs
+++ b/frontend/scripts/gen-api-types.mjs
@@ -1,0 +1,51 @@
+/**
+ * BE の OpenAPI ドキュメントから FE の API 型を生成する。
+ *
+ * 動作:
+ * 1. `cd ../backend && npm run dump:openapi` を実行し、OpenAPI JSON を取得
+ * 2. `openapi-typescript` の API で TypeScript 型を生成
+ * 3. `src/lib/api/generated.ts` に書き出す
+ *
+ * 設計上の注意:
+ * - openapi-typescript v7 の CLI は stdin (`-`) をファイル名として解釈してしまうため、
+ *   シェルパイプ（`dump | openapi-typescript -`）は使えない。代わりに本スクリプトで
+ *   API を直接呼ぶことで、一時ファイル不要・クロスプラットフォーム対応にしている
+ * - execSync は shell 経由で実行するため、Windows でも `npm run` が解決される
+ *
+ * 使い方:
+ *   npm run gen:api-types
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import openapiTS, { astToString } from 'openapi-typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const frontendDir = resolve(__dirname, '..');
+const backendDir = resolve(frontendDir, '..', 'backend');
+const outputPath = resolve(frontendDir, 'src', 'lib', 'api', 'generated.ts');
+
+console.log('[gen:api-types] Building OpenAPI document from backend...');
+const openapiJson = execSync('npm run --silent dump:openapi', {
+  cwd: backendDir,
+  encoding: 'utf-8',
+});
+
+console.log('[gen:api-types] Generating TypeScript types...');
+const ast = await openapiTS(JSON.parse(openapiJson));
+
+const banner = [
+  '/**',
+  ' * このファイルは `npm run gen:api-types` で自動生成されています。',
+  ' * 直接編集せず、生成元の zod スキーマ（backend/src/schemas/*.ts）を変更してください。',
+  ' */',
+  '',
+  '',
+].join('\n');
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, banner + astToString(ast));
+
+console.log(`[gen:api-types] Wrote: ${outputPath}`);

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -1,0 +1,1012 @@
+/**
+ * このファイルは `npm run gen:api-types` で自動生成されています。
+ * 直接編集せず、生成元の zod スキーマ（backend/src/schemas/*.ts）を変更してください。
+ */
+
+export interface paths {
+    "/api/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ユーザー登録
+         * @description MBTI 選択 + 基準値アンケート（5 設問）完了時にユーザーを新規登録する。mbti は null / 省略で MBTI 診断スキップ扱いになる。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["RegisterRequest"];
+                };
+            };
+            responses: {
+                /** @description ユーザー登録成功 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RegisterResponse"];
+                    };
+                };
+                /** @description リクエスト不正。主な業務エラーコード: invalid_mbti（MBTI 形式違反）/ invalid_answers（A-D 以外の回答）/ invalid_request（必須フィールド欠落） */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/games/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ゲームプレイデータ送信
+         * @description 各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["SubmitGameRequest"];
+                };
+            };
+            responses: {
+                /** @description ゲームデータ保存成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SubmitGameResponse"];
+                    };
+                };
+                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / data が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ invalid_game_type（game_type が 1-3 の範囲外） */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+                /** @description 同一ユーザー × 同一 game_type の重複送信 */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/voice/respond": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * AI 応答生成（Game 2 用）
+         * @description Game 2（AI カスタマーサポート）のユーザー発話に対し、Gemini API で AI 応答を生成する。Gemini 失敗時はキーワードマッチングのフォールバックに切り替わる（confidence が下がる）。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["VoiceRespondRequest"];
+                };
+            };
+            responses: {
+                /** @description AI 応答生成成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["VoiceRespondResponse"];
+                    };
+                };
+                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / message が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない） */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/results/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 診断結果取得
+         * @description 3 ゲーム完了後に呼び出す。analysis_results にキャッシュがあればそれを、なければゲームログから計算して UPSERT した結果を返す。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description ユーザー識別子（UUID v4） */
+                    user_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 診断結果取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ResultResponse"];
+                    };
+                };
+                /** @description リクエスト不正。主な業務エラーコード: invalid_user_id（UUID 形式違反。path params の validate ミドルウェアで検出し errorHandler が 400 にマップ） / incomplete_games（3 ゲーム全て完了していない。resultService で throw） */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+                /** @description 指定された user_id のユーザーが存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ApiError"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ヘルスチェック
+         * @description Supabase への疎通確認を含む死活監視用エンドポイント。200 と 503 で独自レスポンス形を返す（他エンドポイントの ApiError とは別形）。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description DB 接続 OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description 固定値 "ok"（DB 接続成功時）
+                             * @enum {string}
+                             */
+                            status: "ok";
+                            /**
+                             * Format: date-time
+                             * @description レスポンス生成時刻（ISO 8601 UTC）
+                             * @example 2026-04-16T10:00:00.000Z
+                             */
+                            timestamp: string;
+                            /**
+                             * @description 固定値 "connected"（Supabase への疎通成功）
+                             * @enum {string}
+                             */
+                            database: "connected";
+                            /**
+                             * @description プロセス起動からの経過秒数（整数）
+                             * @example 3600
+                             */
+                            uptime: number;
+                        };
+                    };
+                };
+                /** @description DB 切断（Supabase への疎通失敗） */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            /**
+                             * @description 固定値 "error"（DB 切断時）
+                             * @enum {string}
+                             */
+                            status: "error";
+                            /**
+                             * Format: date-time
+                             * @description レスポンス生成時刻（ISO 8601 UTC）
+                             * @example 2026-04-16T10:00:00.000Z
+                             */
+                            timestamp: string;
+                            /**
+                             * @description 固定値 "disconnected"（Supabase への疎通失敗）
+                             * @enum {string}
+                             */
+                            database: "disconnected";
+                            /**
+                             * @description プロセス起動からの経過秒数（整数）
+                             * @example 3600
+                             */
+                            uptime: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+}
+export type webhooks = Record<string, never>;
+export interface components {
+    schemas: {
+        /**
+         * @description 基準値アンケートの回答選択肢（A / B / C / D のいずれか）
+         * @example A
+         * @enum {string}
+         */
+        AnswerOption: "A" | "B" | "C" | "D";
+        /**
+         * @description 5 軸スコア（0-100 の整数）。baseline_scores / scores / mbti_scores で共通利用
+         * @example {
+         *       "caution": 60,
+         *       "calmness": 55,
+         *       "logic": 70,
+         *       "cooperativeness": 45,
+         *       "positivity": 65
+         *     }
+         */
+        BaselineScores: {
+            /** @description 慎重さ（0-100） */
+            caution: number;
+            /** @description 冷静さ（0-100） */
+            calmness: number;
+            /** @description 論理性（0-100） */
+            logic: number;
+            /** @description 協調性（0-100） */
+            cooperativeness: number;
+            /** @description 積極性（0-100） */
+            positivity: number;
+        };
+        /**
+         * @description 5 軸ギャップ（実測 - 自己申告）。負値を取りうる整数
+         * @example {
+         *       "caution": -5,
+         *       "calmness": 10,
+         *       "logic": 0,
+         *       "cooperativeness": 15,
+         *       "positivity": -8
+         *     }
+         */
+        GapScores: {
+            /** @description 慎重さのギャップ（実測 - 自己申告） */
+            caution: number;
+            /** @description 冷静さのギャップ */
+            calmness: number;
+            /** @description 論理性のギャップ */
+            logic: number;
+            /** @description 協調性のギャップ */
+            cooperativeness: number;
+            /** @description 積極性のギャップ */
+            positivity: number;
+        };
+        /**
+         * @description API 共通エラーレスポンス形式
+         * @example {
+         *       "status": "error",
+         *       "error": "invalid_mbti",
+         *       "message": "mbti は INTJ / ESFP などの 4 文字で指定してください"
+         *     }
+         */
+        ApiError: {
+            /**
+             * @description 固定値 "error"（成功時は各レスポンスが個別に status を返す）
+             * @enum {string}
+             */
+            status: "error";
+            /**
+             * @description API 設計書「エラーレスポンス」で規定された業務エラーコード。 400: invalid_mbti / invalid_answers / invalid_request / invalid_user_id / invalid_game_type / incomplete_games、404: user_not_found、409: duplicate_submission、500: server_error。
+             * @example invalid_request
+             * @enum {unknown}
+             */
+            error: "invalid_request" | "invalid_mbti" | "invalid_answers" | "invalid_user_id" | "invalid_game_type" | "incomplete_games" | "user_not_found" | "duplicate_submission" | "server_error";
+            /**
+             * @description 開発者向けの日本語説明（エンドユーザー向け文言ではない）
+             * @example mbti は INTJ / ESFP などの 4 文字で指定してください
+             */
+            message: string;
+        };
+        /**
+         * @description 5 軸の基準値アンケート回答。各軸（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性）に A / B / C / D のいずれかで回答する（A=100, B=75, C=25, D=0 点に内部変換される）
+         * @example {
+         *       "q1_caution": "A",
+         *       "q2_calmness": "B",
+         *       "q3_logic": "A",
+         *       "q4_cooperativeness": "C",
+         *       "q5_positivity": "A"
+         *     }
+         */
+        BaselineAnswers: {
+            q1_caution: components["schemas"]["AnswerOption"];
+            q2_calmness: components["schemas"]["AnswerOption"];
+            q3_logic: components["schemas"]["AnswerOption"];
+            q4_cooperativeness: components["schemas"]["AnswerOption"];
+            q5_positivity: components["schemas"]["AnswerOption"];
+        };
+        /**
+         * @description MBTI 選択 + 基準値アンケート（5 設問）完了時に送信する登録リクエスト。mbti は任意（null / 省略でスキップ扱い）、baseline_answers は全 5 設問必須
+         * @example {
+         *       "mbti": "ENTP",
+         *       "baseline_answers": {
+         *         "q1_caution": "A",
+         *         "q2_calmness": "B",
+         *         "q3_logic": "A",
+         *         "q4_cooperativeness": "C",
+         *         "q5_positivity": "A"
+         *       }
+         *     }
+         */
+        RegisterRequest: {
+            /**
+             * @description MBTI タイプ（I/E + S/N + T/F + J/P の 4 文字、大文字小文字不問）
+             * @example INTJ
+             */
+            mbti?: string | null;
+            baseline_answers: components["schemas"]["BaselineAnswers"];
+        };
+        /**
+         * @description 登録成功レスポンス（201 Created）
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "status": "success"
+         *     }
+         */
+        RegisterResponse: {
+            /**
+             * Format: uuid
+             * @description 新規発行されたユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /**
+             * @description 固定値 "success"
+             * @enum {string}
+             */
+            status: "success";
+        };
+        /**
+         * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット
+         * @example 1
+         * @enum {unknown}
+         */
+        GameType: 1 | 2 | 3;
+        /**
+         * @description 各ゲーム終了時に行動データを送信するリクエスト。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "game_type": 1,
+         *       "data": {
+         *         "totalTime": 42.5,
+         *         "finalAction": "agree",
+         *         "reachedBottom": true,
+         *         "scrollEvents": [
+         *           {
+         *             "position": 0,
+         *             "timestamp": 0
+         *           },
+         *           {
+         *             "position": 1200,
+         *             "timestamp": 2500
+         *           }
+         *         ],
+         *         "hiddenInput": null,
+         *         "checkboxStates": {
+         *           "readConfirm": {
+         *             "checked": true,
+         *             "changed": true
+         *           },
+         *           "mailMagazine": {
+         *             "checked": true,
+         *             "changed": false
+         *           },
+         *           "thirdPartyShare": {
+         *             "checked": false,
+         *             "changed": true
+         *           }
+         *         },
+         *         "popupStats": {
+         *           "timeToClose": 850,
+         *           "clickCount": 1,
+         *           "mouseJitter": 42.3
+         *         },
+         *         "agreeButtonHoverTimeMs": 1200
+         *       }
+         *     }
+         */
+        SubmitGameRequest: {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            game_type: components["schemas"]["GameType"];
+            /**
+             * @description ゲーム固有の行動データ。game_type ごとに構造が異なる（仕様書「データ構造」参照）。空オブジェクト不可
+             * @example {
+             *       "totalTime": 42.5,
+             *       "finalAction": "agree",
+             *       "reachedBottom": true,
+             *       "scrollEvents": [
+             *         {
+             *           "position": 0,
+             *           "timestamp": 0
+             *         },
+             *         {
+             *           "position": 1200,
+             *           "timestamp": 2500
+             *         }
+             *       ],
+             *       "hiddenInput": null,
+             *       "checkboxStates": {
+             *         "readConfirm": {
+             *           "checked": true,
+             *           "changed": true
+             *         },
+             *         "mailMagazine": {
+             *           "checked": true,
+             *           "changed": false
+             *         },
+             *         "thirdPartyShare": {
+             *           "checked": false,
+             *           "changed": true
+             *         }
+             *       },
+             *       "popupStats": {
+             *         "timeToClose": 850,
+             *         "clickCount": 1,
+             *         "mouseJitter": 42.3
+             *       },
+             *       "agreeButtonHoverTimeMs": 1200
+             *     }
+             */
+            data: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * @description ゲームデータ保存成功レスポンス（200 OK）
+         * @example {
+         *       "status": "success",
+         *       "message": "Game 1 data saved"
+         *     }
+         */
+        SubmitGameResponse: {
+            /**
+             * @description 固定値 "success"
+             * @enum {string}
+             */
+            status: "success";
+            /**
+             * @description 保存されたゲームを示す運用向けメッセージ
+             * @example Game 1 data saved
+             */
+            message: string;
+        };
+        /**
+         * @description Game 2（AI カスタマーサポート）で AI 応答を生成するリクエスト
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "message": "パスワードを忘れました",
+         *       "conversation_history": [
+         *         {
+         *           "role": "user",
+         *           "content": "ログインできません"
+         *         },
+         *         {
+         *           "role": "assistant",
+         *           "content": "どのような問題でしょうか？"
+         *         }
+         *       ]
+         *     }
+         */
+        VoiceRespondRequest: {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /**
+             * @description ユーザーの発話テキスト。空文字不可
+             * @example パスワードを忘れました
+             */
+            message: string;
+            /** @description 会話履歴（任意）。サーバ側では直近 1 件のみ使用する（仕様書「API 設計書」参照） */
+            conversation_history?: {
+                /**
+                 * @description 発話者。user=エンドユーザー / assistant=AI
+                 * @example user
+                 * @enum {string}
+                 */
+                role: "user" | "assistant";
+                /**
+                 * @description 発話テキスト
+                 * @example ログインできません
+                 */
+                content: string;
+            }[];
+        };
+        /**
+         * @description AI 応答生成レスポンス（200 OK）
+         * @example {
+         *       "response": "パスワードリセットは設定画面から行えます。",
+         *       "emotion": "confident",
+         *       "confidence": 0.6
+         *     }
+         */
+        VoiceRespondResponse: {
+            /**
+             * @description AI の返答テキスト
+             * @example パスワードリセットは設定画面から行えます。
+             */
+            response: string;
+            /**
+             * @description 応答の感情ラベル。confident=自信あり / apologetic=謝罪的 / confused=困惑 / neutral=中立
+             * @example confident
+             * @enum {string}
+             */
+            emotion: "confident" | "apologetic" | "confused" | "neutral";
+            /**
+             * @description 応答の確信度（0-1）。Gemini 成功時は 0.6、フォールバック時は 0.2-0.3
+             * @example 0.6
+             */
+            confidence: number;
+        };
+        /**
+         * @description ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）
+         * @example {
+         *       "game_1": {
+         *         "caution": 45,
+         *         "logic": 75,
+         *         "calmness": 55
+         *       },
+         *       "game_2": {
+         *         "positivity": 70,
+         *         "calmness": 55,
+         *         "logic": 75
+         *       },
+         *       "game_3": {
+         *         "cooperativeness": 60,
+         *         "positivity": 70,
+         *         "caution": 45
+         *       }
+         *     }
+         */
+        GameBreakdown: {
+            game_1?: {
+                /** @description 慎重さ（0-100） */
+                caution?: number;
+                /** @description 冷静さ（0-100） */
+                calmness?: number;
+                /** @description 論理性（0-100） */
+                logic?: number;
+                /** @description 協調性（0-100） */
+                cooperativeness?: number;
+                /** @description 積極性（0-100） */
+                positivity?: number;
+            };
+            game_2?: {
+                /** @description 慎重さ（0-100） */
+                caution?: number;
+                /** @description 冷静さ（0-100） */
+                calmness?: number;
+                /** @description 論理性（0-100） */
+                logic?: number;
+                /** @description 協調性（0-100） */
+                cooperativeness?: number;
+                /** @description 積極性（0-100） */
+                positivity?: number;
+            };
+            game_3?: {
+                /** @description 慎重さ（0-100） */
+                caution?: number;
+                /** @description 冷静さ（0-100） */
+                calmness?: number;
+                /** @description 論理性（0-100） */
+                logic?: number;
+                /** @description 協調性（0-100） */
+                cooperativeness?: number;
+                /** @description 積極性（0-100） */
+                positivity?: number;
+            };
+        };
+        /**
+         * @description 診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）
+         * @example {
+         *       "title": "直感ドリブン",
+         *       "description": "あなたは論理よりも直感を優先して意思決定する傾向があります。",
+         *       "gap_point": "論理性"
+         *     }
+         */
+        DiagnosisFeedback: {
+            /**
+             * @description 診断タイプの見出し（最大ギャップ軸に基づく）
+             * @example 直感ドリブン
+             */
+            title: string;
+            /**
+             * @description 診断タイプの説明文
+             * @example あなたは論理よりも直感を優先して意思決定する傾向があります。
+             */
+            description: string;
+            /**
+             * @description 自己認識と実測の乖離が最大だった軸名（日本語ラベル）
+             * @example 論理性
+             */
+            gap_point: string;
+        };
+        /**
+         * @description 各ゲーム終了後の行動を日本語テキストで振り返ったサマリー
+         * @example {
+         *       "phase_1": "規約を爆速でスクロールし、最後まで読まずに同意しました。",
+         *       "phase_2": "AI の理不尽な対応に感情的に反応する場面が見られました。",
+         *       "phase_3": "グループの空気を読みつつ、自分の意見も主張していました。"
+         *     }
+         */
+        PhaseSummaries: {
+            /** @description Game 1（利用規約）の行動要約 */
+            phase_1: string;
+            /** @description Game 2（AI カスタマーサポート）の行動要約 */
+            phase_2: string;
+            /** @description Game 3（グループチャット）の行動要約 */
+            phase_3: string;
+        };
+        /**
+         * @description ゲーム単位の詳細情報。仕様書「データ構造」→ GameDetail 参照
+         * @example {
+         *       "title": "利用規約ゲーム",
+         *       "feature_scores": [
+         *         {
+         *           "axis": "caution",
+         *           "name": "慎重さ",
+         *           "score": 45
+         *         }
+         *       ],
+         *       "metrics": [
+         *         {
+         *           "label": "読了速度(px/s)",
+         *           "user": 2500,
+         *           "average": 800,
+         *           "category": "scroll"
+         *         }
+         *       ]
+         *     }
+         */
+        GameDetail: {
+            /** @description ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット） */
+            title: string;
+            /** @description 当該ゲームで測定した軸ごとのスコア配列（測定軸数はゲームごとに異なる） */
+            feature_scores: {
+                /** @description 軸キー（caution / calmness / logic / cooperativeness / positivity） */
+                axis: string;
+                /** @description 軸の日本語ラベル（慎重さ / 冷静さ / 論理性 / 協調性 / 積極性） */
+                name: string;
+                /** @description 当該軸のゲーム単位スコア（0-100 整数） */
+                score: number;
+            }[];
+            /** @description ユーザー値と平均値を並べた比較指標の配列 */
+            metrics: {
+                /** @description 指標の表示ラベル（例: 読了速度(px/s) / 反応潜時(ms)） */
+                label: string;
+                /** @description ユーザーの実測値（単位は label に依存） */
+                user: number;
+                /** @description 比較対象の平均値（単位は label に依存） */
+                average: number;
+                /** @description 指標のカテゴリ（scroll / time / mouse / input / voice / logic / message / social 等） */
+                category: string;
+            }[];
+        };
+        /**
+         * @description 各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）。構造は仕様書「データ構造」→ GameDetail を参照
+         * @example {
+         *       "game_1": {
+         *         "title": "利用規約ゲーム",
+         *         "feature_scores": [
+         *           {
+         *             "axis": "caution",
+         *             "name": "慎重さ",
+         *             "score": 45
+         *           }
+         *         ],
+         *         "metrics": [
+         *           {
+         *             "label": "読了速度(px/s)",
+         *             "user": 2500,
+         *             "average": 800,
+         *             "category": "scroll"
+         *           }
+         *         ]
+         *       },
+         *       "game_2": {
+         *         "title": "AIカスタマーサポート",
+         *         "feature_scores": [
+         *           {
+         *             "axis": "positivity",
+         *             "name": "積極性",
+         *             "score": 70
+         *           }
+         *         ],
+         *         "metrics": [
+         *           {
+         *             "label": "発話数",
+         *             "user": 8,
+         *             "average": 5,
+         *             "category": "message"
+         *           }
+         *         ]
+         *       },
+         *       "game_3": {
+         *         "title": "空気読みグループチャット",
+         *         "feature_scores": [
+         *           {
+         *             "axis": "cooperativeness",
+         *             "name": "協調性",
+         *             "score": 60
+         *           }
+         *         ],
+         *         "metrics": [
+         *           {
+         *             "label": "発言数",
+         *             "user": 4,
+         *             "average": 3,
+         *             "category": "message"
+         *           }
+         *         ]
+         *       }
+         *     }
+         */
+        Details: {
+            game_1: components["schemas"]["GameDetail"];
+            game_2: components["schemas"]["GameDetail"];
+            game_3: components["schemas"]["GameDetail"];
+        };
+        /**
+         * @description 診断結果レスポンス（200 OK）
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "self_mbti": "ENTP",
+         *       "mbti_scores": {
+         *         "caution": 40,
+         *         "calmness": 50,
+         *         "logic": 70,
+         *         "cooperativeness": 55,
+         *         "positivity": 85
+         *       },
+         *       "scores": {
+         *         "caution": 45,
+         *         "calmness": 55,
+         *         "logic": 75,
+         *         "cooperativeness": 60,
+         *         "positivity": 70
+         *       },
+         *       "baseline_scores": {
+         *         "caution": 50,
+         *         "calmness": 60,
+         *         "logic": 65,
+         *         "cooperativeness": 55,
+         *         "positivity": 75
+         *       },
+         *       "gaps": {
+         *         "caution": -5,
+         *         "calmness": -5,
+         *         "logic": 10,
+         *         "cooperativeness": 5,
+         *         "positivity": -5
+         *       },
+         *       "game_breakdown": {
+         *         "game_1": {
+         *           "caution": 45,
+         *           "logic": 75,
+         *           "calmness": 55
+         *         },
+         *         "game_2": {
+         *           "positivity": 70,
+         *           "calmness": 55,
+         *           "logic": 75
+         *         },
+         *         "game_3": {
+         *           "cooperativeness": 60,
+         *           "positivity": 70,
+         *           "caution": 45
+         *         }
+         *       },
+         *       "feedback": {
+         *         "title": "直感ドリブン",
+         *         "description": "あなたは論理よりも直感を優先して意思決定する傾向があります。",
+         *         "gap_point": "論理性"
+         *       },
+         *       "accuracy_score": 78,
+         *       "phase_summaries": {
+         *         "phase_1": "規約を爆速でスクロールし、最後まで読まずに同意しました。",
+         *         "phase_2": "AI の理不尽な対応に感情的に反応する場面が見られました。",
+         *         "phase_3": "グループの空気を読みつつ、自分の意見も主張していました。"
+         *       },
+         *       "details": {
+         *         "game_1": {
+         *           "title": "利用規約ゲーム",
+         *           "feature_scores": [
+         *             {
+         *               "axis": "caution",
+         *               "name": "慎重さ",
+         *               "score": 45
+         *             }
+         *           ],
+         *           "metrics": [
+         *             {
+         *               "label": "読了速度(px/s)",
+         *               "user": 2500,
+         *               "average": 800,
+         *               "category": "scroll"
+         *             }
+         *           ]
+         *         },
+         *         "game_2": {
+         *           "title": "AIカスタマーサポート",
+         *           "feature_scores": [
+         *             {
+         *               "axis": "positivity",
+         *               "name": "積極性",
+         *               "score": 70
+         *             }
+         *           ],
+         *           "metrics": [
+         *             {
+         *               "label": "発話数",
+         *               "user": 8,
+         *               "average": 5,
+         *               "category": "message"
+         *             }
+         *           ]
+         *         },
+         *         "game_3": {
+         *           "title": "空気読みグループチャット",
+         *           "feature_scores": [
+         *             {
+         *               "axis": "cooperativeness",
+         *               "name": "協調性",
+         *               "score": 60
+         *             }
+         *           ],
+         *           "metrics": [
+         *             {
+         *               "label": "発言数",
+         *               "user": 4,
+         *               "average": 3,
+         *               "category": "message"
+         *             }
+         *           ]
+         *         }
+         *       }
+         *     }
+         */
+        ResultResponse: {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /**
+             * @description 自己申告の MBTI タイプ。登録時にスキップした場合は null
+             * @example INTJ
+             */
+            self_mbti: string | null;
+            mbti_scores: components["schemas"]["BaselineScores"] & (Record<string, never> | null);
+            scores: components["schemas"]["BaselineScores"] & unknown;
+            baseline_scores: components["schemas"]["BaselineScores"] & unknown;
+            gaps: components["schemas"]["GapScores"] & unknown;
+            game_breakdown: components["schemas"]["GameBreakdown"];
+            feedback: components["schemas"]["DiagnosisFeedback"];
+            /**
+             * @description 自己認識精度（0-100 の整数）。100 - |平均ギャップ|
+             * @example 78
+             */
+            accuracy_score: number;
+            phase_summaries: components["schemas"]["PhaseSummaries"];
+            details: components["schemas"]["Details"];
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export type operations = Record<string, never>;


### PR DESCRIPTION
## 概要

BE の zod スキーマを Single Source of Truth とし、`openapi-typescript` で FE の TS 型を自動生成する基盤を整える。本 PR では型生成の仕組みのみを導入し、既存手書き型の置き換えは Issue #52 で対応する。

closes #51

## 変更内容

### BE（OpenAPI JSON ダンプ）
- `backend/scripts/dump-openapi.ts` を新設し、`buildOpenApiDocument()` の結果を JSON として stdout に出力
- `backend/package.json` に `dump:openapi` スクリプトを追加
- `tsx` を devDependency に追加（BE 起動・DB 接続なしで OpenAPI スキーマを取り出すため）

### FE（型生成）
- `frontend/scripts/gen-api-types.mjs` を新設し、BE の `dump:openapi` を呼び出して型を生成
- `frontend/package.json` に `gen:api-types` スクリプトを追加
- `openapi-typescript` を devDependency に追加
- 生成物 `frontend/src/lib/api/generated.ts` を初回コミット（PR で型変化を diff として確認できるよう git 管理に含める）
- `.prettierignore` / `eslint.config.mjs` に generated.ts を追加（自動生成物は整形対象外）

## 設計判断

- **入力ソース**: 案 B（`tsx` 経由で `buildOpenApiDocument()` を直接実行）を採用。BE 起動・DB 接続不要で OpenAPI JSON を取り出せる
- **CLI / API**: openapi-typescript v7 の CLI は stdin (`-`) をファイル名と解釈する仕様のため、Node スクリプトから API を直接呼ぶ形式にした（クロスプラットフォーム対応）
- **生成物の git 管理**: 一旦コミット方針。PR で型変化が diff として見え、新メンバーが clone してすぐ動く

## 動作確認

- `cd backend && npm run dump:openapi` で OpenAPI JSON が stdout 出力される
- `cd frontend && npm run gen:api-types` で `frontend/src/lib/api/generated.ts` が生成される
- 既存コード（`lib/api.ts` / `features/*/types`）は未変更

## 関連 Issue

- 親: #45（API 型管理の方針整理）
- 後続: #52（既存手書き型を生成型に置き換え）
- 後続: #58（ゲームデータの zod スキーマを OpenAPI に公開）
- 後続: #59（ApiError 型と業務エラーコードを活用したエラーハンドリング刷新）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * バックエンドの OpenAPI スキーマからフロントエンドの TypeScript 型定義を自動生成できるようになりました。新しいスクリプトにより、API 型の更新プロセスが簡素化されます。

* **開発環境**
  * TypeScript 実行環境と OpenAPI 型生成ツールが開発依存関係に追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->