### PR TITLE
fix: mbti_scores の壊れた交差型を解消 (closes #61)

### DIFF
--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -214,7 +214,14 @@ export const resultsResponseSchema = registry.register(
             self_mbti: mbtiSchema.nullable().openapi({
                 description: '自己申告の MBTI タイプ。登録時にスキップした場合は null',
             }),
-            mbti_scores: baselineScoresSchema.nullable().openapi({
+            // baselineScoresSchema.nullable() ではなく z.union を使う理由:
+            // zod-to-openapi は `$ref` を持つスキーマに `.nullable()` を後付けすると
+            // `allOf: [{$ref}, {type:[object,null], description}]` を出力する。
+            // openapi-typescript はこれを `BaselineScores & (Record<string, never> | null)`
+            // という壊れた交差型に変換してしまう（Issue #61）。
+            // `z.union([X, z.null()])` にすると `oneOf: [{$ref}, {type:null}]` になり、
+            // 生成型も `BaselineScores | null` で期待通りとなる。
+            mbti_scores: z.union([baselineScoresSchema, z.null()]).openapi({
                 description: 'MBTI 理論値（self_mbti から導出）。self_mbti が null の場合は null',
             }),
             scores: baselineScoresSchema.openapi({

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -987,7 +987,8 @@ export interface components {
              * @example INTJ
              */
             self_mbti: string | null;
-            mbti_scores: components["schemas"]["BaselineScores"] & (Record<string, never> | null);
+            /** @description MBTI 理論値（self_mbti から導出）。self_mbti が null の場合は null */
+            mbti_scores: components["schemas"]["BaselineScores"] | null;
             scores: components["schemas"]["BaselineScores"] & unknown;
             baseline_scores: components["schemas"]["BaselineScores"] & unknown;
             gaps: components["schemas"]["GapScores"] & unknown;


### PR DESCRIPTION
## 概要

`ResultResponse.mbti_scores` の生成型が `BaselineScores & (Record<string, never> | null)` という壊れた交差型になっていた問題を修正する。

closes #61

## 変更内容

### `backend/src/schemas/results.ts`
- `mbti_scores` を `baselineScoresSchema.nullable()` から `z.union([baselineScoresSchema, z.null()])` に変更
- なぜ `.nullable()` ではなく `z.union` を使うのかをコメントで明記

### `frontend/src/lib/api/generated.ts`
- `npm run gen:api-types` の再実行結果。`mbti_scores: components["schemas"]["BaselineScores"] | null` で期待通りの型になる

## 検証

| 項目 | 結果 |
|---|---|
| OpenAPI ダンプで `mbti_scores` が `oneOf: [{$ref}, {type:null}]` になる | OK |
| 生成型 `mbti_scores: BaselineScores \| null` | OK |

## スコープ外（本 PR では対応しない）

- `scores` / `baseline_scores` / `gaps` の `& unknown` 解消
  - 型システム上 `BaselineScores` と完全等価で実害なし（`Eq<ResultResponse['scores'], BaselineScores>` が `true`）
  - 生成型を実コードで使っている箇所もまだ無いため、ノイズとしての影響もゼロ
  - 必要になったら `gen-api-types.mjs` の後処理として別 Issue で対応する
  - 詳細は Issue #61 のコメント参照

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * MBTI スコアフィールドのAPI スキーマ定義を最適化し、型定義の精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->