### PR TITLE
refactor: ゲームデータスキーマを OpenAPI 公開し SubmitGameRequest を discriminatedUnion 化

### DIFF
--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -160,6 +160,74 @@ export const submitGameRequestExampleGame1 = {
 } as const;
 
 /**
+ * game_type = 2（AI カスタマーサポート）の data サンプル。
+ *
+ * 仕様書「データ構造」→ Game2Data を参照。turns は最小 2 件（音声 1 件 + テキスト 1 件）で
+ * 構造を示し、テキスト入力時は音声系メトリクスが null になる例を載せる。
+ */
+export const submitGameRequestExampleGame2 = {
+    user_id: SAMPLE_USER_ID,
+    game_type: 2,
+    data: {
+        inputMethod: 'voice',
+        turnCount: 2,
+        turns: [
+            {
+                turnIndex: 1,
+                inputMethod: 'voice',
+                reactionTimeMs: 850,
+                speechDurationMs: 3200,
+                silenceDurationMs: 400,
+                volumeDb: -18.5,
+                transcribedText: 'パスワードを忘れました',
+            },
+            {
+                turnIndex: 2,
+                inputMethod: 'text',
+                reactionTimeMs: null,
+                speechDurationMs: null,
+                silenceDurationMs: null,
+                volumeDb: null,
+                transcribedText: 'メールアドレスは abc@example.com です',
+            },
+        ],
+        textInputMetrics: {
+            typingIntervalVariance: 120.5,
+        },
+    },
+} as const;
+
+/**
+ * game_type = 3（グループチャット）の data サンプル。
+ *
+ * 仕様書「データ構造」→ Game3Data を参照。stages は 5 ステージのうち代表 2 件を載せ、
+ * `selectedOptionId: 0` でタイムアウト例も含める（仕様書準拠）。
+ */
+export const submitGameRequestExampleGame3 = {
+    user_id: SAMPLE_USER_ID,
+    game_type: 3,
+    data: {
+        tutorialViewTime: 8500,
+        hoveredOptions: 7,
+        typingIndicatorReactTimeMs: 1450,
+        stages: [
+            {
+                stageId: 1,
+                selectedOptionId: 2,
+                reactionTimeMs: 3200,
+                isTimeout: false,
+            },
+            {
+                stageId: 2,
+                selectedOptionId: 0,
+                reactionTimeMs: 10000,
+                isTimeout: true,
+            },
+        ],
+    },
+} as const;
+
+/**
  * POST /api/games/submit のレスポンス例（200 OK）。
  * message はサーバ側で `Game ${game_type} data saved` を返す（games.ts 参照）。
  */

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -1,4 +1,8 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../openapi/registry';
 import { z } from 'zod';
+import { registry } from '../openapi/registry';
 
 /**
  * 各ゲーム（Game1 / Game2 / Game3）の行動データ（raw_data）の zod スキーマ群。
@@ -6,19 +10,33 @@ import { z } from 'zod';
  * 設計方針:
  * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
  *   スキーマを唯一の真実とし、TS 型は `z.infer` で導出する
- * - 本ファイルのスキーマは内部用（analysis 層 / repositories 層の型付け）であり、
- *   API 入出力には直接出ないため `.openapi()` メタデータは付けない
- * - 入口の API バリデーションは `schemas/games.ts` の `submitGameRequestSchema.data`
- *   （汎用 record）が引き続き担う
+ * - 本ファイルのスキーマは `submitGameRequestSchema`（schemas/games.ts）の
+ *   `data` フィールド（discriminatedUnion の各 branch）として API 入出力に出るため、
+ *   `.openapi()` でメタデータを付与し `registry.register()` で名前付きコンポーネント化する
+ *   （Issue #58 で OpenAPI に公開し、FE の生成型に取り込まれるようにした）
+ * - 内部サブスキーマも独立コンポーネント化することで、OpenAPI ドキュメント上の重複を避け
+ *   FE 生成型でも再利用可能な型として扱えるようにする
  */
 
 /**
  * Game1 のスクロールイベント（200ms 間隔のサンプリングログ）。
  */
-const scrollEventSchema = z.object({
-    position: z.number(),
-    timestamp: z.number(),
-});
+const scrollEventSchema = registry.register(
+    'ScrollEvent',
+    z
+        .object({
+            position: z.number().openapi({
+                description: 'スクロール位置（px）',
+            }),
+            timestamp: z.number().openapi({
+                description: 'ゲーム開始からの経過時間（ms）',
+            }),
+        })
+        .openapi({
+            description: 'Game1 のスクロールイベント（200ms 間隔のサンプリングログ）',
+            example: { position: 1200, timestamp: 2500 },
+        }),
+);
 
 /**
  * Game1 のチェックボックス状態。
@@ -29,10 +47,23 @@ const scrollEventSchema = z.object({
  * 仕様書「データ構造 → Game1Data → checkboxStates」では readConfirm / mailMagazine /
  * thirdPartyShare の 3 つに同形が使われるため、共通サブスキーマとして定義する。
  */
-const checkboxStateSchema = z.object({
-    checked: z.boolean(),
-    changed: z.boolean(),
-});
+const checkboxStateSchema = registry.register(
+    'CheckboxState',
+    z
+        .object({
+            checked: z.boolean().openapi({
+                description: '最終的なチェック状態',
+            }),
+            changed: z.boolean().openapi({
+                description: 'ユーザーが初期状態から変更したか',
+            }),
+        })
+        .openapi({
+            description:
+                'Game1 のチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）',
+            example: { checked: true, changed: true },
+        }),
+);
 
 /**
  * Game1 のポップアップ統計。
@@ -40,11 +71,26 @@ const checkboxStateSchema = z.object({
  * ポップアップは滞在時間 timeout で出る仕様のため、高速スクロール時は
  * クライアントから送信されない（→ Game1Data 側で `optional`）。
  */
-const popupStatsSchema = z.object({
-    timeToClose: z.number(),
-    clickCount: z.number().int(),
-    mouseJitter: z.number(),
-});
+const popupStatsSchema = registry.register(
+    'PopupStats',
+    z
+        .object({
+            timeToClose: z.number().openapi({
+                description: 'ポップアップ表示から閉じるまでの時間（ms）',
+            }),
+            clickCount: z.number().int().openapi({
+                description: 'ポップアップ閉じるまでのクリック回数',
+            }),
+            mouseJitter: z.number().openapi({
+                description: 'マウス余剰移動距離（px）',
+            }),
+        })
+        .openapi({
+            description:
+                'Game1 のポップアップ統計。高速スクロール時はポップアップ自体が出ないため Game1Data 側で optional',
+            example: { timeToClose: 850, clickCount: 1, mouseJitter: 42.3 },
+        }),
+);
 
 /**
  * Game1Data（利用規約ゲーム）。
@@ -52,28 +98,69 @@ const popupStatsSchema = z.object({
  * 仕様書「データ構造 → Game1Data」と完全に一致させること。
  * `popupStats` のみ optional、それ以外は必須。
  */
-export const game1DataSchema = z.object({
-    totalTime: z.number(),
-    finalAction: z.enum(['agree', 'disagree']),
-    reachedBottom: z.boolean(),
-    scrollEvents: z.array(scrollEventSchema),
-    hiddenInput: z.string().nullable(),
-    checkboxStates: z.object({
-        readConfirm: checkboxStateSchema,
-        mailMagazine: checkboxStateSchema,
-        thirdPartyShare: checkboxStateSchema,
-    }),
-    popupStats: popupStatsSchema.optional(),
-    agreeButtonHoverTimeMs: z.number(),
-});
+export const game1DataSchema = registry.register(
+    'Game1Data',
+    z
+        .object({
+            totalTime: z.number().openapi({
+                description: '滞在時間（秒）',
+            }),
+            finalAction: z
+                .union([z.literal('agree'), z.literal('disagree')])
+                .openapi({
+                    description: '最終アクション（同意 / 拒否）',
+                    enum: ['agree', 'disagree'],
+                }),
+            reachedBottom: z.boolean().openapi({
+                description: '規約の最下部までスクロールしたか',
+            }),
+            scrollEvents: z.array(scrollEventSchema).openapi({
+                description: 'スクロールイベントの時系列ログ',
+            }),
+            hiddenInput: z.string().nullable().openapi({
+                description: '隠しテキスト入力欄の値（未入力なら null）',
+            }),
+            checkboxStates: z
+                .object({
+                    readConfirm: checkboxStateSchema,
+                    mailMagazine: checkboxStateSchema,
+                    thirdPartyShare: checkboxStateSchema,
+                })
+                .openapi({
+                    description: '3 つのチェックボックスの最終状態と変更有無',
+                }),
+            popupStats: popupStatsSchema.optional().openapi({
+                description:
+                    'ポップアップが表示された場合の統計。高速スクロール等で表示されない場合は省略',
+            }),
+            agreeButtonHoverTimeMs: z.number().openapi({
+                description: '同意ボタンホバー → クリックの迷い時間（ms）',
+            }),
+        })
+        .openapi({
+            description:
+                'Game1（利用規約ゲーム）の行動データ。仕様書「データ構造 → Game1Data」準拠',
+        }),
+);
 
 /**
  * Game2 の入力方式（音声 / テキスト）。
  *
  * Game2Data 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
  * 使うため、共通サブスキーマとして定義する。
+ *
+ * OpenAPI では `.openapi({ enum: [...] })` で enum 情報を補う
+ * （z.union<z.literal> のままだと OpenAPI 側で `anyOf` に落ちてしまうため）。
  */
-const game2InputMethodSchema = z.enum(['voice', 'text']);
+const game2InputMethodSchema = registry.register(
+    'Game2InputMethod',
+    z
+        .union([z.literal('voice'), z.literal('text')])
+        .openapi({
+            description: 'Game2 の入力方式（voice: 音声 / text: テキスト）',
+            enum: ['voice', 'text'],
+        }),
+);
 
 /**
  * Game2 の 1 ターン分のメトリクス。
@@ -81,34 +168,79 @@ const game2InputMethodSchema = z.enum(['voice', 'text']);
  * テキスト入力時は音声系メトリクス（reactionTimeMs / speechDurationMs /
  * silenceDurationMs / volumeDb）が取得できないため `nullable`。
  */
-const game2TurnSchema = z.object({
-    turnIndex: z.number().int(),
-    inputMethod: game2InputMethodSchema,
-    reactionTimeMs: z.number().nullable(),
-    speechDurationMs: z.number().nullable(),
-    silenceDurationMs: z.number().nullable(),
-    volumeDb: z.number().nullable(),
-    transcribedText: z.string(),
-});
+const game2TurnSchema = registry.register(
+    'Game2Turn',
+    z
+        .object({
+            turnIndex: z.number().int().openapi({
+                description: 'ターン番号（1 始まり）',
+            }),
+            inputMethod: game2InputMethodSchema,
+            reactionTimeMs: z.number().nullable().openapi({
+                description: '喋り出しまでの反応速度（ms）。テキスト入力時は null',
+            }),
+            speechDurationMs: z.number().nullable().openapi({
+                description: '発話時間（ms）。テキスト入力時は null',
+            }),
+            silenceDurationMs: z.number().nullable().openapi({
+                description: '発話中の沈黙合計（ms）。テキスト入力時は null',
+            }),
+            volumeDb: z.number().nullable().openapi({
+                description: '平均音量（dB）。テキスト入力時は null',
+            }),
+            transcribedText: z.string().openapi({
+                description: '文字起こし結果 or テキスト入力内容',
+            }),
+        })
+        .openapi({
+            description:
+                'Game2 の 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null',
+        }),
+);
 
 /**
  * Game2 のテキスト入力メトリクス。
  *
  * テキスト入力が一度も発生しなかった場合（全ターン音声）は null。
  */
-const game2TextInputMetricsSchema = z.object({
-    typingIntervalVariance: z.number(),
-});
+const game2TextInputMetricsSchema = registry.register(
+    'Game2TextInputMetrics',
+    z
+        .object({
+            typingIntervalVariance: z.number().openapi({
+                description: 'タイピング間隔の分散',
+            }),
+        })
+        .openapi({
+            description:
+                'Game2 のテキスト入力メトリクス。全ターン音声入力の場合は Game2Data 側で null',
+        }),
+);
 
 /**
  * Game2Data（AI カスタマーサポート）。
  */
-export const game2DataSchema = z.object({
-    inputMethod: game2InputMethodSchema,
-    turnCount: z.number().int(),
-    turns: z.array(game2TurnSchema),
-    textInputMetrics: game2TextInputMetricsSchema.nullable(),
-});
+export const game2DataSchema = registry.register(
+    'Game2Data',
+    z
+        .object({
+            inputMethod: game2InputMethodSchema,
+            turnCount: z.number().int().openapi({
+                description: '実施ターン数',
+            }),
+            turns: z.array(game2TurnSchema).openapi({
+                description: '各ターンのメトリクス（turnCount 件）',
+            }),
+            textInputMetrics: game2TextInputMetricsSchema.nullable().openapi({
+                description:
+                    'テキスト入力メトリクス。全ターン音声入力の場合は null',
+            }),
+        })
+        .openapi({
+            description:
+                'Game2（AI カスタマーサポート）の行動データ。仕様書「データ構造 → Game2Data」準拠',
+        }),
+);
 
 /**
  * Game3 の 1 ステージ分のメトリクス。
@@ -117,24 +249,56 @@ export const game2DataSchema = z.object({
  * 意味的に整数のフィールドには `.int()` を付けて型レベルで小数を弾く。
  * `min/max` 等の値の範囲制約は本スキーマでは表現せず、analysis 層で個別に扱う。
  */
-const game3StageSchema = z.object({
-    stageId: z.number().int(),
-    selectedOptionId: z.number().int(),
-    reactionTimeMs: z.number(),
-    isTimeout: z.boolean(),
-});
+const game3StageSchema = registry.register(
+    'Game3Stage',
+    z
+        .object({
+            stageId: z.number().int().openapi({
+                description: 'ステージ ID（1-5）',
+            }),
+            selectedOptionId: z.number().int().openapi({
+                description: '選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0）',
+            }),
+            reactionTimeMs: z.number().openapi({
+                description: 'ステージ表示から選択までの反応時間（ms）',
+            }),
+            isTimeout: z.boolean().openapi({
+                description: 'タイムアウトしたか',
+            }),
+        })
+        .openapi({
+            description: 'Game3 の 1 ステージ分のメトリクス',
+        }),
+);
 
 /**
  * Game3Data（グループチャット）。
  *
  * `typingIndicatorReactTimeMs` はステージ 3 / 5 のみで計測される値のため `nullable`。
  */
-export const game3DataSchema = z.object({
-    tutorialViewTime: z.number(),
-    hoveredOptions: z.number().int(),
-    typingIndicatorReactTimeMs: z.number().nullable(),
-    stages: z.array(game3StageSchema),
-});
+export const game3DataSchema = registry.register(
+    'Game3Data',
+    z
+        .object({
+            tutorialViewTime: z.number().openapi({
+                description: 'チュートリアル閲覧時間（ms）',
+            }),
+            hoveredOptions: z.number().int().openapi({
+                description: '全ステージ通じた選択肢ホバー回数の合計',
+            }),
+            typingIndicatorReactTimeMs: z.number().nullable().openapi({
+                description:
+                    'ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null',
+            }),
+            stages: z.array(game3StageSchema).openapi({
+                description: '各ステージのメトリクス',
+            }),
+        })
+        .openapi({
+            description:
+                'Game3（空気読みグループチャット）の行動データ。仕様書「データ構造 → Game3Data」準拠',
+        }),
+);
 
 export type Game1Data = z.infer<typeof game1DataSchema>;
 export type Game2Data = z.infer<typeof game2DataSchema>;

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -129,10 +129,10 @@ export const game1DataSchema = registry.register(
                 .openapi({
                     description: '3 つのチェックボックスの最終状態と変更有無',
                 }),
-            popupStats: popupStatsSchema.optional().openapi({
-                description:
-                    'ポップアップが表示された場合の統計。高速スクロール等で表示されない場合は省略',
-            }),
+            // popupStats は popupStatsSchema 側に description を寄せている。
+            // ここで `.openapi({ description })` を付けると openapi-typescript の生成型で
+            // `PopupStats & unknown` という不自然な交差型が出るため、wrapper には description を付けない。
+            popupStats: popupStatsSchema.optional(),
             agreeButtonHoverTimeMs: z.number().openapi({
                 description: '同意ボタンホバー → クリックの迷い時間（ms）',
             }),
@@ -231,10 +231,13 @@ export const game2DataSchema = registry.register(
             turns: z.array(game2TurnSchema).openapi({
                 description: '各ターンのメトリクス（turnCount 件）',
             }),
-            textInputMetrics: game2TextInputMetricsSchema.nullable().openapi({
-                description:
-                    'テキスト入力メトリクス。全ターン音声入力の場合は null',
-            }),
+            // textInputMetrics は `z.union([..., z.null()])` で nullable にする。
+            // `.nullable()` を使うと OpenAPI 3.1 上で `allOf: [$ref, type: ['object','null']]`
+            // という形になり、openapi-typescript が `Game2TextInputMetrics & (Record<string, never> | null)`
+            // という壊れた交差型を生成する（null も具体値も代入できなくなる）。
+            // `z.union([schema, z.null()])` だと `oneOf: [$ref, type: 'null']` 形式になり、
+            // 生成型が `Game2TextInputMetrics | null` で正しく表現される。
+            textInputMetrics: z.union([game2TextInputMetricsSchema, z.null()]),
         })
         .openapi({
             description:

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -105,12 +105,13 @@ export const game1DataSchema = registry.register(
             totalTime: z.number().openapi({
                 description: '滞在時間（秒）',
             }),
-            finalAction: z
-                .union([z.literal('agree'), z.literal('disagree')])
-                .openapi({
-                    description: '最終アクション（同意 / 拒否）',
-                    enum: ['agree', 'disagree'],
-                }),
+            // 文字列リテラルかつエラーコードの個別マッピング（invalid_xxx 等）が不要なため、
+            // OpenAPI 出力をクリーンに保てる z.enum を採用する（voice.ts の voiceEmotionSchema と同方針）。
+            // data 配下のフィールドはすべて errorHandler で `invalid_request` に集約されるので、
+            // z.enum が「必須欠落と値違反を区別できない」点はここでは問題にならない。
+            finalAction: z.enum(['agree', 'disagree']).openapi({
+                description: '最終アクション（同意 / 拒否）',
+            }),
             reachedBottom: z.boolean().openapi({
                 description: '規約の最下部までスクロールしたか',
             }),
@@ -149,17 +150,15 @@ export const game1DataSchema = registry.register(
  * Game2Data 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
  * 使うため、共通サブスキーマとして定義する。
  *
- * OpenAPI では `.openapi({ enum: [...] })` で enum 情報を補う
- * （z.union<z.literal> のままだと OpenAPI 側で `anyOf` に落ちてしまうため）。
+ * 文字列リテラルかつエラーコードの個別マッピング（invalid_xxx 等）が不要なため
+ * z.enum で簡潔に書く（voice.ts の voiceEmotionSchema と同方針）。OpenAPI 出力は
+ * `{ type: 'string', enum: [...] }` のクリーンな形になる。
  */
 const game2InputMethodSchema = registry.register(
     'Game2InputMethod',
-    z
-        .union([z.literal('voice'), z.literal('text')])
-        .openapi({
-            description: 'Game2 の入力方式（voice: 音声 / text: テキスト）',
-            enum: ['voice', 'text'],
-        }),
+    z.enum(['voice', 'text']).openapi({
+        description: 'Game2 の入力方式（voice: 音声 / text: テキスト）',
+    }),
 );
 
 /**

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -69,60 +69,6 @@ export const gameTypeSchema = registry.register(
 );
 
 /**
- * POST /api/games/submit の game_type 別リクエスト branch。
- *
- * 各 branch を `registry.register()` で名前付きコンポーネント化することで、
- * zod-to-openapi が `discriminator: { propertyName: 'game_type', mapping }` を
- * OpenAPI ドキュメントに出力する（branch が登録されていないと discriminator が
- * 自動付与されないため。zod-to-openapi v8 のソース参照）。
- *
- * 各 branch は `SubmitGameRequest` の oneOf 要素として独立コンポーネント化されるが、
- * FE/BE どちらも基本は親の `SubmitGameRequest` 型を介して扱うため、ここで生成される
- * 個別型は OpenAPI ドキュメント表示と discriminator マッピング用の副産物と捉える。
- */
-const submitGameRequestGame1Schema = registry.register(
-    'SubmitGameRequestGame1',
-    z
-        .object({
-            user_id: userIdSchema,
-            game_type: z.literal(GAME_TYPES.TERMS_GAME),
-            data: game1DataSchema,
-        })
-        .openapi({
-            description: 'Game1（利用規約ゲーム）の終了時に送るリクエスト',
-            example: submitGameRequestExampleGame1,
-        }),
-);
-
-const submitGameRequestGame2Schema = registry.register(
-    'SubmitGameRequestGame2',
-    z
-        .object({
-            user_id: userIdSchema,
-            game_type: z.literal(GAME_TYPES.AI_CHAT),
-            data: game2DataSchema,
-        })
-        .openapi({
-            description: 'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
-            example: submitGameRequestExampleGame2,
-        }),
-);
-
-const submitGameRequestGame3Schema = registry.register(
-    'SubmitGameRequestGame3',
-    z
-        .object({
-            user_id: userIdSchema,
-            game_type: z.literal(GAME_TYPES.GROUP_CHAT),
-            data: game3DataSchema,
-        })
-        .openapi({
-            description: 'Game3（グループチャット）の終了時に送るリクエスト',
-            example: submitGameRequestExampleGame3,
-        }),
-);
-
-/**
  * POST /api/games/submit のリクエストボディ。
  *
  * `z.discriminatedUnion('game_type', [...])` で `game_type` × `data` の対応を
@@ -131,8 +77,8 @@ const submitGameRequestGame3Schema = registry.register(
  * - game_type === 2 のとき data は Game2Data
  * - game_type === 3 のとき data は Game3Data
  *
- * これにより OpenAPI 上は `oneOf` + `discriminator: { propertyName: 'game_type' }`
- * として表現され、Swagger UI / 生成型からも game_type 別の構造が見える。
+ * これにより OpenAPI 上は `oneOf` + discriminator として表現され、Swagger UI / 生成型
+ * からも game_type 別の構造が見える。
  *
  * 入口バリデーション（discriminatedUnion）で既に data 構造は検証済みだが、
  * 既存挙動の維持を優先して `gameService.parseGameData` 側でも safeParse を残す
@@ -142,9 +88,39 @@ export const submitGameRequestSchema = registry.register(
     'SubmitGameRequest',
     z
         .discriminatedUnion('game_type', [
-            submitGameRequestGame1Schema,
-            submitGameRequestGame2Schema,
-            submitGameRequestGame3Schema,
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.TERMS_GAME),
+                    data: game1DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game1（利用規約ゲーム）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame1,
+                }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.AI_CHAT),
+                    data: game2DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame2,
+                }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.GROUP_CHAT),
+                    data: game3DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game3（グループチャット）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame3,
+                }),
         ])
         .openapi({
             description:

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -77,8 +77,18 @@ export const gameTypeSchema = registry.register(
  * - game_type === 2 のとき data は Game2Data
  * - game_type === 3 のとき data は Game3Data
  *
- * これにより OpenAPI 上は `oneOf` + discriminator として表現され、Swagger UI / 生成型
- * からも game_type 別の構造が見える。
+ * OpenAPI 上は `oneOf` で表現され、各 branch の
+ * `game_type: { type: 'number', enum: [N] }` リテラル enum で判別する形になる。
+ * 明示的な `discriminator` キーは出力しない方針:
+ * - 各 branch を named component 化すると zod-to-openapi が
+ *   `discriminator: { mapping: { '1': ..., '2': ..., '3': ... } }` を出力する
+ * - OpenAPI 仕様上 `mapping` のキーは Map<string, string> のため数値リテラルでも
+ *   文字列化される。openapi-typescript v7 はこのキーをそのまま tsLiteral に渡すため、
+ *   FE 生成型の game_type が文字列リテラル "1" / "2" / "3" になり、BE の
+ *   z.literal(1|2|3) と矛盾する（PR #64 のレビュー経緯参照）。
+ *
+ * Swagger UI / 生成型からも各 branch の game_type literal で構造が見えるため、
+ * discriminator 等価の機能は維持される。
  *
  * 入口バリデーション（discriminatedUnion）で既に data 構造は検証済みだが、
  * 既存挙動の維持を優先して `gameService.parseGameData` 側でも safeParse を残す
@@ -125,7 +135,7 @@ export const submitGameRequestSchema = registry.register(
         .openapi({
             description:
                 '各ゲーム終了時に行動データを送信するリクエスト。' +
-                'game_type を discriminator として data 構造が決まる。' +
+                'game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。' +
                 '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
         }),
 );

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -6,7 +6,14 @@ import { registry } from '../openapi/registry';
 import { userIdSchema } from './common';
 import { GAME_TYPES } from '../types';
 import {
+    game1DataSchema,
+    game2DataSchema,
+    game3DataSchema,
+} from './gameData';
+import {
     submitGameRequestExampleGame1,
+    submitGameRequestExampleGame2,
+    submitGameRequestExampleGame3,
     submitGameResponseExample,
 } from '../openapi/examples';
 
@@ -33,6 +40,11 @@ import {
  * types/index.ts と本スキーマの両方を更新すること（将来的には
  * GAME_TYPES の値を自動展開する形にリファクタ可）。
  *
+ * `submitGameRequestSchema` は discriminatedUnion 化（Issue #58）したため
+ * `game_type` は各 branch で `z.literal(...)` に展開される。本 `gameTypeSchema`
+ * は OpenAPI 公開用の独立コンポーネント（GameType）として残し、他エンドポイントや
+ * FE 生成型から再利用可能にする。
+ *
  * OpenAPI では `.openapi({ enum: [...] })` で enum 情報を補う
  * （z.union<z.literal> のままだと OpenAPI 側で `anyOf` に落ちてしまうため）。
  */
@@ -57,40 +69,64 @@ export const gameTypeSchema = registry.register(
 );
 
 /**
- * ゲーム固有の行動データ。
- * 構造はゲームごとに大きく異なるため、スキーマ層では空でないオブジェクトであることのみを検証する。
- * 各ゲームの `data` 構造の検証は analysis 層の責務（別 Issue で型化予定）。
- *
- * OpenAPI 上は自由形式オブジェクト（`additionalProperties: true`）として表現される。
- * 具体的な各ゲームの data 構造は仕様書「データ構造」を参照（examples に game_1 の例を掲載）。
- */
-export const gameDataSchema = z
-    .record(z.string(), z.unknown())
-    .refine((d) => Object.keys(d).length > 0, {
-        error: 'data は空オブジェクトにできません',
-    })
-    .openapi({
-        description:
-            'ゲーム固有の行動データ。game_type ごとに構造が異なる（仕様書「データ構造」参照）。空オブジェクト不可',
-        example: submitGameRequestExampleGame1.data,
-    });
-
-/**
  * POST /api/games/submit のリクエストボディ。
+ *
+ * `z.discriminatedUnion('game_type', [...])` で `game_type` × `data` の対応を
+ * 型レベルで強制する（Issue #58）:
+ * - game_type === 1 のとき data は Game1Data
+ * - game_type === 2 のとき data は Game2Data
+ * - game_type === 3 のとき data は Game3Data
+ *
+ * これにより OpenAPI 上は `oneOf` + discriminator として表現され、Swagger UI / 生成型
+ * からも game_type 別の構造が見える。
+ *
+ * 入口バリデーション（discriminatedUnion）で既に data 構造は検証済みだが、
+ * 既存挙動の維持を優先して `gameService.parseGameData` 側でも safeParse を残す
+ * （多重防御 + 将来 service が他経路から呼ばれた場合の安全策）。
  */
 export const submitGameRequestSchema = registry.register(
     'SubmitGameRequest',
     z
-        .object({
-            user_id: userIdSchema,
-            game_type: gameTypeSchema,
-            data: gameDataSchema,
-        })
+        .discriminatedUnion('game_type', [
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.TERMS_GAME),
+                    data: game1DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game1（利用規約ゲーム）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame1,
+                }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.AI_CHAT),
+                    data: game2DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame2,
+                }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.GROUP_CHAT),
+                    data: game3DataSchema,
+                })
+                .openapi({
+                    description:
+                        'Game3（グループチャット）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleGame3,
+                }),
+        ])
         .openapi({
             description:
                 '各ゲーム終了時に行動データを送信するリクエスト。' +
+                'game_type を discriminator として data 構造が決まる。' +
                 '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
-            example: submitGameRequestExampleGame1,
         }),
 );
 

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -69,6 +69,60 @@ export const gameTypeSchema = registry.register(
 );
 
 /**
+ * POST /api/games/submit の game_type 別リクエスト branch。
+ *
+ * 各 branch を `registry.register()` で名前付きコンポーネント化することで、
+ * zod-to-openapi が `discriminator: { propertyName: 'game_type', mapping }` を
+ * OpenAPI ドキュメントに出力する（branch が登録されていないと discriminator が
+ * 自動付与されないため。zod-to-openapi v8 のソース参照）。
+ *
+ * 各 branch は `SubmitGameRequest` の oneOf 要素として独立コンポーネント化されるが、
+ * FE/BE どちらも基本は親の `SubmitGameRequest` 型を介して扱うため、ここで生成される
+ * 個別型は OpenAPI ドキュメント表示と discriminator マッピング用の副産物と捉える。
+ */
+const submitGameRequestGame1Schema = registry.register(
+    'SubmitGameRequestGame1',
+    z
+        .object({
+            user_id: userIdSchema,
+            game_type: z.literal(GAME_TYPES.TERMS_GAME),
+            data: game1DataSchema,
+        })
+        .openapi({
+            description: 'Game1（利用規約ゲーム）の終了時に送るリクエスト',
+            example: submitGameRequestExampleGame1,
+        }),
+);
+
+const submitGameRequestGame2Schema = registry.register(
+    'SubmitGameRequestGame2',
+    z
+        .object({
+            user_id: userIdSchema,
+            game_type: z.literal(GAME_TYPES.AI_CHAT),
+            data: game2DataSchema,
+        })
+        .openapi({
+            description: 'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
+            example: submitGameRequestExampleGame2,
+        }),
+);
+
+const submitGameRequestGame3Schema = registry.register(
+    'SubmitGameRequestGame3',
+    z
+        .object({
+            user_id: userIdSchema,
+            game_type: z.literal(GAME_TYPES.GROUP_CHAT),
+            data: game3DataSchema,
+        })
+        .openapi({
+            description: 'Game3（グループチャット）の終了時に送るリクエスト',
+            example: submitGameRequestExampleGame3,
+        }),
+);
+
+/**
  * POST /api/games/submit のリクエストボディ。
  *
  * `z.discriminatedUnion('game_type', [...])` で `game_type` × `data` の対応を
@@ -77,8 +131,8 @@ export const gameTypeSchema = registry.register(
  * - game_type === 2 のとき data は Game2Data
  * - game_type === 3 のとき data は Game3Data
  *
- * これにより OpenAPI 上は `oneOf` + discriminator として表現され、Swagger UI / 生成型
- * からも game_type 別の構造が見える。
+ * これにより OpenAPI 上は `oneOf` + `discriminator: { propertyName: 'game_type' }`
+ * として表現され、Swagger UI / 生成型からも game_type 別の構造が見える。
  *
  * 入口バリデーション（discriminatedUnion）で既に data 構造は検証済みだが、
  * 既存挙動の維持を優先して `gameService.parseGameData` 側でも safeParse を残す
@@ -88,39 +142,9 @@ export const submitGameRequestSchema = registry.register(
     'SubmitGameRequest',
     z
         .discriminatedUnion('game_type', [
-            z
-                .object({
-                    user_id: userIdSchema,
-                    game_type: z.literal(GAME_TYPES.TERMS_GAME),
-                    data: game1DataSchema,
-                })
-                .openapi({
-                    description:
-                        'Game1（利用規約ゲーム）の終了時に送るリクエスト',
-                    example: submitGameRequestExampleGame1,
-                }),
-            z
-                .object({
-                    user_id: userIdSchema,
-                    game_type: z.literal(GAME_TYPES.AI_CHAT),
-                    data: game2DataSchema,
-                })
-                .openapi({
-                    description:
-                        'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
-                    example: submitGameRequestExampleGame2,
-                }),
-            z
-                .object({
-                    user_id: userIdSchema,
-                    game_type: z.literal(GAME_TYPES.GROUP_CHAT),
-                    data: game3DataSchema,
-                })
-                .openapi({
-                    description:
-                        'Game3（グループチャット）の終了時に送るリクエスト',
-                    example: submitGameRequestExampleGame3,
-                }),
+            submitGameRequestGame1Schema,
+            submitGameRequestGame2Schema,
+            submitGameRequestGame3Schema,
         ])
         .openapi({
             description:

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -11,11 +11,13 @@ import {
 /**
  * game_type に応じて、受け取った data を対応する zod スキーマで parse する。
  *
- * route 層の `gameDataSchema`（= `record(string, unknown)` + 「空でない」refine）では
- * data の中身までは検証されないため、ここで game_type に応じた構造検証を行ったうえで
- * `gameType` と `rawData` を組（判別可能 union `GameRawDataPayload`）として返す。
- * これにより `gameRepository.saveLog` の引数で gameType と rawData のミスマッチを
- * 型レベルで弾ける。
+ * route 層の `submitGameRequestSchema`（discriminatedUnion 化済み）で data の
+ * 構造は既に検証されているため、本関数の safeParse は実質的にはパススルーになる。
+ * ただし以下の理由で safeParse + switch の構造を残している:
+ * - service が将来 route 以外（CLI / batch ジョブ等）から呼ばれた場合の防御
+ * - `gameType` と `rawData` を組（判別可能 union `GameRawDataPayload`）として
+ *   返すことで、`gameRepository.saveLog` の引数で gameType と rawData の
+ *   ミスマッチを型レベルで弾く
  *
  * 構造違反（必須フィールド欠落・型違い等）はクライアント起因の不正リクエストとして
  * 400 `invalid_request` を throw する。詳細な issue は warn ログに残し、

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -460,54 +460,136 @@ export interface components {
             status: "success";
         };
         /**
+         * @description Game1 のスクロールイベント（200ms 間隔のサンプリングログ）
+         * @example {
+         *       "position": 1200,
+         *       "timestamp": 2500
+         *     }
+         */
+        ScrollEvent: {
+            /** @description スクロール位置（px） */
+            position: number;
+            /** @description ゲーム開始からの経過時間（ms） */
+            timestamp: number;
+        };
+        /**
+         * @description Game1 のチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）
+         * @example {
+         *       "checked": true,
+         *       "changed": true
+         *     }
+         */
+        CheckboxState: {
+            /** @description 最終的なチェック状態 */
+            checked: boolean;
+            /** @description ユーザーが初期状態から変更したか */
+            changed: boolean;
+        };
+        /**
+         * @description Game1 のポップアップ統計。高速スクロール時はポップアップ自体が出ないため Game1Data 側で optional
+         * @example {
+         *       "timeToClose": 850,
+         *       "clickCount": 1,
+         *       "mouseJitter": 42.3
+         *     }
+         */
+        PopupStats: {
+            /** @description ポップアップ表示から閉じるまでの時間（ms） */
+            timeToClose: number;
+            /** @description ポップアップ閉じるまでのクリック回数 */
+            clickCount: number;
+            /** @description マウス余剰移動距離（px） */
+            mouseJitter: number;
+        };
+        /** @description Game1（利用規約ゲーム）の行動データ。仕様書「データ構造 → Game1Data」準拠 */
+        Game1Data: {
+            /** @description 滞在時間（秒） */
+            totalTime: number;
+            /**
+             * @description 最終アクション（同意 / 拒否）
+             * @enum {unknown}
+             */
+            finalAction: "agree" | "disagree";
+            /** @description 規約の最下部までスクロールしたか */
+            reachedBottom: boolean;
+            /** @description スクロールイベントの時系列ログ */
+            scrollEvents: components["schemas"]["ScrollEvent"][];
+            /** @description 隠しテキスト入力欄の値（未入力なら null） */
+            hiddenInput: string | null;
+            /** @description 3 つのチェックボックスの最終状態と変更有無 */
+            checkboxStates: {
+                readConfirm: components["schemas"]["CheckboxState"];
+                mailMagazine: components["schemas"]["CheckboxState"];
+                thirdPartyShare: components["schemas"]["CheckboxState"];
+            };
+            popupStats?: components["schemas"]["PopupStats"] & unknown;
+            /** @description 同意ボタンホバー → クリックの迷い時間（ms） */
+            agreeButtonHoverTimeMs: number;
+        };
+        /**
+         * @description Game2 の入力方式（voice: 音声 / text: テキスト）
+         * @enum {unknown}
+         */
+        Game2InputMethod: "voice" | "text";
+        /** @description Game2 の 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null */
+        Game2Turn: {
+            /** @description ターン番号（1 始まり） */
+            turnIndex: number;
+            inputMethod: components["schemas"]["Game2InputMethod"];
+            /** @description 喋り出しまでの反応速度（ms）。テキスト入力時は null */
+            reactionTimeMs: number | null;
+            /** @description 発話時間（ms）。テキスト入力時は null */
+            speechDurationMs: number | null;
+            /** @description 発話中の沈黙合計（ms）。テキスト入力時は null */
+            silenceDurationMs: number | null;
+            /** @description 平均音量（dB）。テキスト入力時は null */
+            volumeDb: number | null;
+            /** @description 文字起こし結果 or テキスト入力内容 */
+            transcribedText: string;
+        };
+        /** @description Game2 のテキスト入力メトリクス。全ターン音声入力の場合は Game2Data 側で null */
+        Game2TextInputMetrics: {
+            /** @description タイピング間隔の分散 */
+            typingIntervalVariance: number;
+        };
+        /** @description Game2（AI カスタマーサポート）の行動データ。仕様書「データ構造 → Game2Data」準拠 */
+        Game2Data: {
+            inputMethod: components["schemas"]["Game2InputMethod"];
+            /** @description 実施ターン数 */
+            turnCount: number;
+            /** @description 各ターンのメトリクス（turnCount 件） */
+            turns: components["schemas"]["Game2Turn"][];
+            textInputMetrics: components["schemas"]["Game2TextInputMetrics"] & (Record<string, never> | null);
+        };
+        /** @description Game3 の 1 ステージ分のメトリクス */
+        Game3Stage: {
+            /** @description ステージ ID（1-5） */
+            stageId: number;
+            /** @description 選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0） */
+            selectedOptionId: number;
+            /** @description ステージ表示から選択までの反応時間（ms） */
+            reactionTimeMs: number;
+            /** @description タイムアウトしたか */
+            isTimeout: boolean;
+        };
+        /** @description Game3（空気読みグループチャット）の行動データ。仕様書「データ構造 → Game3Data」準拠 */
+        Game3Data: {
+            /** @description チュートリアル閲覧時間（ms） */
+            tutorialViewTime: number;
+            /** @description 全ステージ通じた選択肢ホバー回数の合計 */
+            hoveredOptions: number;
+            /** @description ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null */
+            typingIndicatorReactTimeMs: number | null;
+            /** @description 各ステージのメトリクス */
+            stages: components["schemas"]["Game3Stage"][];
+        };
+        /**
          * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット
          * @example 1
          * @enum {unknown}
          */
         GameType: 1 | 2 | 3;
-        /**
-         * @description 各ゲーム終了時に行動データを送信するリクエスト。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す
-         * @example {
-         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
-         *       "game_type": 1,
-         *       "data": {
-         *         "totalTime": 42.5,
-         *         "finalAction": "agree",
-         *         "reachedBottom": true,
-         *         "scrollEvents": [
-         *           {
-         *             "position": 0,
-         *             "timestamp": 0
-         *           },
-         *           {
-         *             "position": 1200,
-         *             "timestamp": 2500
-         *           }
-         *         ],
-         *         "hiddenInput": null,
-         *         "checkboxStates": {
-         *           "readConfirm": {
-         *             "checked": true,
-         *             "changed": true
-         *           },
-         *           "mailMagazine": {
-         *             "checked": true,
-         *             "changed": false
-         *           },
-         *           "thirdPartyShare": {
-         *             "checked": false,
-         *             "changed": true
-         *           }
-         *         },
-         *         "popupStats": {
-         *           "timeToClose": 850,
-         *           "clickCount": 1,
-         *           "mouseJitter": 42.3
-         *         },
-         *         "agreeButtonHoverTimeMs": 1200
-         *       }
-         *     }
-         */
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
         SubmitGameRequest: {
             /**
              * Format: uuid
@@ -515,49 +597,29 @@ export interface components {
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            game_type: components["schemas"]["GameType"];
+            /** @enum {number} */
+            game_type: 1;
+            data: components["schemas"]["Game1Data"];
+        } | {
             /**
-             * @description ゲーム固有の行動データ。game_type ごとに構造が異なる（仕様書「データ構造」参照）。空オブジェクト不可
-             * @example {
-             *       "totalTime": 42.5,
-             *       "finalAction": "agree",
-             *       "reachedBottom": true,
-             *       "scrollEvents": [
-             *         {
-             *           "position": 0,
-             *           "timestamp": 0
-             *         },
-             *         {
-             *           "position": 1200,
-             *           "timestamp": 2500
-             *         }
-             *       ],
-             *       "hiddenInput": null,
-             *       "checkboxStates": {
-             *         "readConfirm": {
-             *           "checked": true,
-             *           "changed": true
-             *         },
-             *         "mailMagazine": {
-             *           "checked": true,
-             *           "changed": false
-             *         },
-             *         "thirdPartyShare": {
-             *           "checked": false,
-             *           "changed": true
-             *         }
-             *       },
-             *       "popupStats": {
-             *         "timeToClose": 850,
-             *         "clickCount": 1,
-             *         "mouseJitter": 42.3
-             *       },
-             *       "agreeButtonHoverTimeMs": 1200
-             *     }
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
              */
-            data: {
-                [key: string]: unknown;
-            };
+            user_id: string;
+            /** @enum {number} */
+            game_type: 2;
+            data: components["schemas"]["Game2Data"];
+        } | {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /** @enum {number} */
+            game_type: 3;
+            data: components["schemas"]["Game3Data"];
         };
         /**
          * @description ゲームデータ保存成功レスポンス（200 OK）

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -589,7 +589,7 @@ export interface components {
          * @enum {unknown}
          */
         GameType: 1 | 2 | 3;
-        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
         SubmitGameRequest: {
             /**
              * Format: uuid

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -589,153 +589,38 @@ export interface components {
          * @enum {unknown}
          */
         GameType: 1 | 2 | 3;
-        /**
-         * @description Game1（利用規約ゲーム）の終了時に送るリクエスト
-         * @example {
-         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
-         *       "game_type": 1,
-         *       "data": {
-         *         "totalTime": 42.5,
-         *         "finalAction": "agree",
-         *         "reachedBottom": true,
-         *         "scrollEvents": [
-         *           {
-         *             "position": 0,
-         *             "timestamp": 0
-         *           },
-         *           {
-         *             "position": 1200,
-         *             "timestamp": 2500
-         *           }
-         *         ],
-         *         "hiddenInput": null,
-         *         "checkboxStates": {
-         *           "readConfirm": {
-         *             "checked": true,
-         *             "changed": true
-         *           },
-         *           "mailMagazine": {
-         *             "checked": true,
-         *             "changed": false
-         *           },
-         *           "thirdPartyShare": {
-         *             "checked": false,
-         *             "changed": true
-         *           }
-         *         },
-         *         "popupStats": {
-         *           "timeToClose": 850,
-         *           "clickCount": 1,
-         *           "mouseJitter": 42.3
-         *         },
-         *         "agreeButtonHoverTimeMs": 1200
-         *       }
-         *     }
-         */
-        SubmitGameRequestGame1: {
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
+        SubmitGameRequest: {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            game_type: "1";
+            /** @enum {number} */
+            game_type: 1;
             data: components["schemas"]["Game1Data"];
-        };
-        /**
-         * @description Game2（AI カスタマーサポート）の終了時に送るリクエスト
-         * @example {
-         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
-         *       "game_type": 2,
-         *       "data": {
-         *         "inputMethod": "voice",
-         *         "turnCount": 2,
-         *         "turns": [
-         *           {
-         *             "turnIndex": 1,
-         *             "inputMethod": "voice",
-         *             "reactionTimeMs": 850,
-         *             "speechDurationMs": 3200,
-         *             "silenceDurationMs": 400,
-         *             "volumeDb": -18.5,
-         *             "transcribedText": "パスワードを忘れました"
-         *           },
-         *           {
-         *             "turnIndex": 2,
-         *             "inputMethod": "text",
-         *             "reactionTimeMs": null,
-         *             "speechDurationMs": null,
-         *             "silenceDurationMs": null,
-         *             "volumeDb": null,
-         *             "transcribedText": "メールアドレスは abc@example.com です"
-         *           }
-         *         ],
-         *         "textInputMetrics": {
-         *           "typingIntervalVariance": 120.5
-         *         }
-         *       }
-         *     }
-         */
-        SubmitGameRequestGame2: {
+        } | {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            game_type: "2";
+            /** @enum {number} */
+            game_type: 2;
             data: components["schemas"]["Game2Data"];
-        };
-        /**
-         * @description Game3（グループチャット）の終了時に送るリクエスト
-         * @example {
-         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
-         *       "game_type": 3,
-         *       "data": {
-         *         "tutorialViewTime": 8500,
-         *         "hoveredOptions": 7,
-         *         "typingIndicatorReactTimeMs": 1450,
-         *         "stages": [
-         *           {
-         *             "stageId": 1,
-         *             "selectedOptionId": 2,
-         *             "reactionTimeMs": 3200,
-         *             "isTimeout": false
-         *           },
-         *           {
-         *             "stageId": 2,
-         *             "selectedOptionId": 0,
-         *             "reactionTimeMs": 10000,
-         *             "isTimeout": true
-         *           }
-         *         ]
-         *       }
-         *     }
-         */
-        SubmitGameRequestGame3: {
+        } | {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            game_type: "3";
+            /** @enum {number} */
+            game_type: 3;
             data: components["schemas"]["Game3Data"];
         };
-        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
-        SubmitGameRequest: components["schemas"]["SubmitGameRequestGame1"] | components["schemas"]["SubmitGameRequestGame2"] | components["schemas"]["SubmitGameRequestGame3"];
         /**
          * @description ゲームデータ保存成功レスポンス（200 OK）
          * @example {

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -507,7 +507,7 @@ export interface components {
             totalTime: number;
             /**
              * @description 最終アクション（同意 / 拒否）
-             * @enum {unknown}
+             * @enum {string}
              */
             finalAction: "agree" | "disagree";
             /** @description 規約の最下部までスクロールしたか */
@@ -528,7 +528,7 @@ export interface components {
         };
         /**
          * @description Game2 の入力方式（voice: 音声 / text: テキスト）
-         * @enum {unknown}
+         * @enum {string}
          */
         Game2InputMethod: "voice" | "text";
         /** @description Game2 の 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null */

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -522,7 +522,7 @@ export interface components {
                 mailMagazine: components["schemas"]["CheckboxState"];
                 thirdPartyShare: components["schemas"]["CheckboxState"];
             };
-            popupStats?: components["schemas"]["PopupStats"] & unknown;
+            popupStats?: components["schemas"]["PopupStats"];
             /** @description 同意ボタンホバー → クリックの迷い時間（ms） */
             agreeButtonHoverTimeMs: number;
         };
@@ -559,7 +559,7 @@ export interface components {
             turnCount: number;
             /** @description 各ターンのメトリクス（turnCount 件） */
             turns: components["schemas"]["Game2Turn"][];
-            textInputMetrics: components["schemas"]["Game2TextInputMetrics"] & (Record<string, never> | null);
+            textInputMetrics: components["schemas"]["Game2TextInputMetrics"] | null;
         };
         /** @description Game3 の 1 ステージ分のメトリクス */
         Game3Stage: {
@@ -589,38 +589,153 @@ export interface components {
          * @enum {unknown}
          */
         GameType: 1 | 2 | 3;
-        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
-        SubmitGameRequest: {
+        /**
+         * @description Game1（利用規約ゲーム）の終了時に送るリクエスト
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "game_type": 1,
+         *       "data": {
+         *         "totalTime": 42.5,
+         *         "finalAction": "agree",
+         *         "reachedBottom": true,
+         *         "scrollEvents": [
+         *           {
+         *             "position": 0,
+         *             "timestamp": 0
+         *           },
+         *           {
+         *             "position": 1200,
+         *             "timestamp": 2500
+         *           }
+         *         ],
+         *         "hiddenInput": null,
+         *         "checkboxStates": {
+         *           "readConfirm": {
+         *             "checked": true,
+         *             "changed": true
+         *           },
+         *           "mailMagazine": {
+         *             "checked": true,
+         *             "changed": false
+         *           },
+         *           "thirdPartyShare": {
+         *             "checked": false,
+         *             "changed": true
+         *           }
+         *         },
+         *         "popupStats": {
+         *           "timeToClose": 850,
+         *           "clickCount": 1,
+         *           "mouseJitter": 42.3
+         *         },
+         *         "agreeButtonHoverTimeMs": 1200
+         *       }
+         *     }
+         */
+        SubmitGameRequestGame1: {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /** @enum {number} */
-            game_type: 1;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            game_type: "1";
             data: components["schemas"]["Game1Data"];
-        } | {
+        };
+        /**
+         * @description Game2（AI カスタマーサポート）の終了時に送るリクエスト
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "game_type": 2,
+         *       "data": {
+         *         "inputMethod": "voice",
+         *         "turnCount": 2,
+         *         "turns": [
+         *           {
+         *             "turnIndex": 1,
+         *             "inputMethod": "voice",
+         *             "reactionTimeMs": 850,
+         *             "speechDurationMs": 3200,
+         *             "silenceDurationMs": 400,
+         *             "volumeDb": -18.5,
+         *             "transcribedText": "パスワードを忘れました"
+         *           },
+         *           {
+         *             "turnIndex": 2,
+         *             "inputMethod": "text",
+         *             "reactionTimeMs": null,
+         *             "speechDurationMs": null,
+         *             "silenceDurationMs": null,
+         *             "volumeDb": null,
+         *             "transcribedText": "メールアドレスは abc@example.com です"
+         *           }
+         *         ],
+         *         "textInputMetrics": {
+         *           "typingIntervalVariance": 120.5
+         *         }
+         *       }
+         *     }
+         */
+        SubmitGameRequestGame2: {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /** @enum {number} */
-            game_type: 2;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            game_type: "2";
             data: components["schemas"]["Game2Data"];
-        } | {
+        };
+        /**
+         * @description Game3（グループチャット）の終了時に送るリクエスト
+         * @example {
+         *       "user_id": "550e8400-e29b-41d4-a716-446655440000",
+         *       "game_type": 3,
+         *       "data": {
+         *         "tutorialViewTime": 8500,
+         *         "hoveredOptions": 7,
+         *         "typingIndicatorReactTimeMs": 1450,
+         *         "stages": [
+         *           {
+         *             "stageId": 1,
+         *             "selectedOptionId": 2,
+         *             "reactionTimeMs": 3200,
+         *             "isTimeout": false
+         *           },
+         *           {
+         *             "stageId": 2,
+         *             "selectedOptionId": 0,
+         *             "reactionTimeMs": 10000,
+         *             "isTimeout": true
+         *           }
+         *         ]
+         *       }
+         *     }
+         */
+        SubmitGameRequestGame3: {
             /**
              * Format: uuid
              * @description ユーザー識別子（UUID v4）
              * @example 550e8400-e29b-41d4-a716-446655440000
              */
             user_id: string;
-            /** @enum {number} */
-            game_type: 3;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            game_type: "3";
             data: components["schemas"]["Game3Data"];
         };
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type を discriminator として data 構造が決まる。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
+        SubmitGameRequest: components["schemas"]["SubmitGameRequestGame1"] | components["schemas"]["SubmitGameRequestGame2"] | components["schemas"]["SubmitGameRequestGame3"];
         /**
          * @description ゲームデータ保存成功レスポンス（200 OK）
          * @example {


### PR DESCRIPTION
## 概要

`backend/src/schemas/gameData.ts` の Game1/2/3 zod スキーマを OpenAPI 公開コンポーネントに昇格させ、`submitGameRequestSchema` を `z.discriminatedUnion('game_type', [...])` に再構成した。これにより Swagger UI / FE 生成型に `Game1Data` / `Game2Data` / `Game3Data` / `SubmitGameRequest`（oneOf + 各 branch の game_type literal）が出るようになり、`#52` の FE 手書き型置き換えへの道筋が整う。

closes #58

## 変更内容

### BE: スキーマの OpenAPI 公開化
- `game1DataSchema` / `game2DataSchema` / `game3DataSchema` を `registry.register()` で名前付きコンポーネント化
- 内部サブスキーマも独立コンポーネント化（`ScrollEvent` / `CheckboxState` / `PopupStats` / `Game2InputMethod` / `Game2Turn` / `Game2TextInputMetrics` / `Game3Stage`）
- description は仕様書「データ構造」の文言に揃えた

### BE: discriminatedUnion 化
- `submitGameRequestSchema` を `z.discriminatedUnion('game_type', [...])` で再構成
- 不要になった `gameDataSchema`（汎用 record）を削除
- `examples.ts` に `submitGameRequestExampleGame2` / `Game3` を追加

### BE: gameService の挙動確認
- `parseGameData` の switch + safeParse は維持（Issue 指示「既存挙動の維持を優先」）
- 冒頭コメントを discriminatedUnion 化を踏まえて更新

### FE: 自動生成型の更新
- `npm run gen:api-types` で `frontend/src/lib/api/generated.ts` を再生成
- FE の手書き Game[1-3]Data 型置き換えは `#52` で対応

### レビュー反映で実施した追加修正
- `popupStats: PopupStatsSchema.optional().openapi({...})` の組み合わせで生成型に `& unknown` が出ていたため wrapper 側の `.openapi({ description })` を削除
- `textInputMetrics: game2TextInputMetricsSchema.nullable()` が OpenAPI 3.1 で `allOf: [$ref, type:['object','null']]` 形式になり生成型が `Game2TextInputMetrics & (Record<string, never> | null)` という壊れた交差型になっていたため、`z.union([game2TextInputMetricsSchema, z.null()])` に置き換えて生成型を `Game2TextInputMetrics | null` に修正

## Issue 完了条件「discriminator 付きで OpenAPI に出る」の解釈について

当初は各 branch を `SubmitGameRequestGame[1-3]` として `registry.register()` 化し、OpenAPI に明示的な `discriminator: { propertyName: 'game_type', mapping: ... }` キーを出力する実装にしていた（コミット `653fbdc`）。

しかし Copilot のレビュー指摘により、この実装は FE 生成型を破壊することが判明したため revert している。

### 何が起きていたか
- zod-to-openapi v8 は branch が named component の場合のみ `discriminator.mapping` を出力する。OpenAPI 仕様上 `mapping` のキーは `Map<string, string>` のため、数値リテラルでも JSON のオブジェクトキーとして文字列化される。
- openapi-typescript v7 の `createDiscriminatorProperty` は `mapping` のキーをそのまま `tsLiteral` に渡すため、各 branch の `game_type` フィールドが**文字列リテラル `"1"` / `"2"` / `"3"`** として生成される（`game_type: 1` の数値リテラルではなく）。
- BE は `z.literal(1|2|3)` で数値しか受け付けないため、生成型と BE バリデーションが矛盾し、`#52` で FE が生成型に切り替わった瞬間に通信が壊れる。
- openapi-typescript v7 にはこの挙動を切り替えるオプションがない。

### 採用した方針（loose 解釈）
- branch の named component 登録を解除し、discriminatedUnion を inline branches で表現
- OpenAPI 出力は `oneOf` + 各 branch の `game_type: { type: 'number', enum: [N] }` 形式（discriminator キーなし）
- 各 branch の game_type literal で discriminator 等価の振る舞いは維持される（Swagger UI 表示も人間に十分明示的）
- FE 生成型は `game_type: 1 | 2 | 3` の数値リテラルで BE と整合
- Issue 全体の意図（FE/BE/仕様書の SoT を OpenAPI に寄せる）はこの形でも達成される

## 動作確認

- BE: `npx tsc --noEmit` / `npm run build` 通過
- FE: `npm run lint` / `npx tsc --noEmit` / `npm run build` 通過
- `npm run dump:openapi` 出力で `Game1Data` / `Game2Data` / `Game3Data` が独立コンポーネントとして登場
- `SubmitGameRequest` が `oneOf` + 各 branch の `game_type` literal で表現されることを確認
- FE 生成型 `generated.ts` の `game_type` が **数値リテラル `1` / `2` / `3`**、`textInputMetrics` が `Game2TextInputMetrics | null`、`popupStats?` が `PopupStats?` で正しく表現されることを確認

## スコープ外（次 Issue に切り出し検討）

レビューで指摘されたが、本 Issue のスコープ外として保留:

- `gameService.submitGame` の引数型が `Record<string, unknown>` のままで、route 層で discriminatedUnion により narrow された型情報が service 境界で失われている（Issue 指示「既存挙動の維持を優先」のため据え置き）
- `gameTypeSchema`（`GameType` コンポーネント）が現時点で `$ref` 参照されない孤立コンポーネント（`#50` で登録済み、将来の他エンドポイント再利用を想定して残置）

## 関連

- 親 Issue: #45
- 依存: #51（完了済み）
- 後続: #52（FE 手書き型置き換え）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲーム種別ごとの個別スキーマを導入し、送信リクエストの構造を明確化。
  * 各ゲーム種別向けのAPIリクエスト例を追加（ゲーム2・ゲーム3を含む）。

* **改善**
  * リクエスト検証を強化し、ゲーム種別に応じたデータ検証を適用。
  * フロントエンドの型定義を更新し、ゲーム別ペイロードの型安全性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->