### PR TITLE
refactor: FE games feature の手書き API 型を OpenAPI 生成型に置き換え

### DIFF
--- a/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
+++ b/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
@@ -76,7 +76,7 @@ export default function BaselineSurvey() {
           await submitGame({
             user_id: result.user_id,
             game_type: 1,
-            data: game1Data as unknown as Record<string, unknown>,
+            data: game1Data,
           });
         }
 

--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -61,7 +61,7 @@ export default function GroupChatGameFlow() {
     await submitGame({
       user_id: userId,
       game_type: 3,
-      data: data as unknown as Record<string, unknown>,
+      data,
     });
   }, []);
 

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Game3Data, Game3StageLog } from '@/features/games/types';
+import type { Game3Data, Game3Stage } from '@/features/games/types';
 import {
   BOTS,
   STAGES,
@@ -100,7 +100,7 @@ export function useGroupChatGame(options: {
   /** ステージ3の「○○が返信中」表示〜ユーザー操作までの時間(ms) */
   const stage3TypingReactRef = useRef<number | null>(null);
   /** 各ステージの操作ログを蓄積 */
-  const stageResultsRef = useRef<Game3StageLog[]>([]);
+  const stageResultsRef = useRef<Game3Stage[]>([]);
   const tutorialViewTimeRef = useRef(0);
   const timerIdRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -130,15 +130,15 @@ export function useGroupChatGame(options: {
   // =========================================================
   const recordStageAndAdvance = useCallback(
     (
-      selectedOptionId: number | null,
+      selectedOptionId: number,
       reactionTimeMs: number,
       isTimeout: boolean,
       typingIndicatorReactTimeMs?: number | null
     ) => {
       const stage = STAGES[currentStageIndex];
-      const log: Game3StageLog = {
+      const log: Game3Stage = {
         stageId: stage.stageId,
-        selectedOptionId: isTimeout ? 0 : selectedOptionId,
+        selectedOptionId,
         reactionTimeMs,
         isTimeout,
       };
@@ -312,7 +312,7 @@ export function useGroupChatGame(options: {
             : undefined;
 
         // タイムアウト: selectedOptionId=0, isTimeout=true
-        recordStageAndAdvance(null, reactionTimeMs, true, typingReact);
+        recordStageAndAdvance(0, reactionTimeMs, true, typingReact);
       }
     }, 100);
 

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -52,7 +52,7 @@ export default function HelpdeskGameFlow() {
     await submitGame({
       user_id: userId,
       game_type: 2,
-      data: data as unknown as Record<string, unknown>,
+      data,
     });
   }, []);
 

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   Game2Data,
   Game2Turn,
-  TextInputMetrics,
+  Game2TextInputMetrics,
 } from '@/features/games/types';
 import { postVoiceRespond } from '@/lib/api';
 import {
@@ -225,7 +225,7 @@ export function useHelpdeskGame(options: {
   const buildAndSubmit = useCallback(() => {
     const currentTurns = turnsRef.current;
     const hasTextTurn = currentTurns.some((t) => t.inputMethod === 'text');
-    const textInputMetrics: TextInputMetrics | null = hasTextTurn
+    const textInputMetrics: Game2TextInputMetrics | null = hasTextTurn
       ? {
           typingIntervalVariance:
             typingVariancesRef.current.length > 0

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -1,6 +1,6 @@
 // OpenAPI から自動生成された型を再エクスポートする。
 // 手書き定義は廃止済み。スキーマ変更は backend/src/openapi/ を更新したうえで
-// `npm run gen:openapi:fe` で frontend/src/lib/api/generated.ts を再生成する。
+// `npm run gen:api-types` で frontend/src/lib/api/generated.ts を再生成する。
 
 import type { components } from '@/lib/api/generated';
 

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -1,111 +1,36 @@
+// OpenAPI から自動生成された型を再エクスポートする。
+// 手書き定義は廃止済み。スキーマ変更は backend/src/openapi/ を更新したうえで
+// `npm run gen:openapi:fe` で frontend/src/lib/api/generated.ts を再生成する。
+
+import type { components } from '@/lib/api/generated';
+
 // ========================================
 // Game 共通型
 // ========================================
-
-export interface SubmitGameRequest {
-  user_id: string;
-  game_type: 1 | 2 | 3;
-  data: Record<string, unknown>;
-}
-
-export interface SubmitGameResponse {
-  status: 'success' | 'error';
-  message: string;
-}
+export type SubmitGameRequest = components['schemas']['SubmitGameRequest'];
+export type SubmitGameResponse = components['schemas']['SubmitGameResponse'];
 
 // ========================================
 // Game 1: 利用規約ゲーム
 // ========================================
-
-export interface ScrollEvent {
-  position: number;
-  timestamp: number;
-}
-
-export interface CheckboxState {
-  checked: boolean;
-  changed: boolean;
-}
-
-export interface PopupStats {
-  timeToClose: number;
-  clickCount: number;
-  // ポップアップ表示中のマウス余剰移動距離（px）。総移動距離 − 最短直線距離
-  mouseJitter: number;
-}
-
-export interface Game1Data {
-  totalTime: number;
-  finalAction: 'agree' | 'disagree';
-  reachedBottom: boolean;
-  scrollEvents: ScrollEvent[];
-  hiddenInput: string | null;
-  checkboxStates: {
-    readConfirm: CheckboxState;
-    mailMagazine: CheckboxState;
-    thirdPartyShare: CheckboxState;
-  };
-  // ポップアップ広告が表示されかつ閉じられた場合にのみ送信する。
-  // 未表示・操作中断時は未送信（undefined）とし、BE 側で worst 値フォールバックさせる。
-  popupStats?: PopupStats;
-  // 「同意する」ボタンにホバーしてからクリックするまでの時間（ms）
-  agreeButtonHoverTimeMs: number;
-}
+export type ScrollEvent = components['schemas']['ScrollEvent'];
+export type CheckboxState = components['schemas']['CheckboxState'];
+export type PopupStats = components['schemas']['PopupStats'];
+export type Game1Data = components['schemas']['Game1Data'];
 
 // ========================================
 // Game 2: カスタマーサポートチャット
 // ========================================
-
-export interface Game2Turn {
-  turnIndex: number;
-  inputMethod: 'voice' | 'text';
-  reactionTimeMs: number | null;
-  speechDurationMs: number | null;
-  silenceDurationMs: number | null;
-  volumeDb: number | null;
-  transcribedText: string;
-}
-
-export interface TextInputMetrics {
-  typingIntervalVariance: number;
-}
-
-export interface Game2Data {
-  inputMethod: 'voice' | 'text';
-  turnCount: number;
-  turns: Game2Turn[];
-  textInputMetrics: TextInputMetrics | null;
-}
-
-// Game 2: AI返答生成API (POST /api/voice/respond)
-export interface VoiceRespondRequest {
-  user_id: string;
-  message: string;
-  conversation_history?: { role: 'user' | 'assistant'; content: string }[];
-}
-
-export interface VoiceRespondResponse {
-  response: string;
-  emotion: string;
-  confidence: number;
-}
+export type Game2Turn = components['schemas']['Game2Turn'];
+export type Game2TextInputMetrics =
+  components['schemas']['Game2TextInputMetrics'];
+export type Game2Data = components['schemas']['Game2Data'];
+export type VoiceRespondRequest = components['schemas']['VoiceRespondRequest'];
+export type VoiceRespondResponse =
+  components['schemas']['VoiceRespondResponse'];
 
 // ========================================
 // Game 3: グループチャット（空気読み）
 // ========================================
-
-export interface Game3StageLog {
-  stageId: number;
-  selectedOptionId: number | null;
-  reactionTimeMs: number;
-  isTimeout: boolean;
-}
-
-export interface Game3Data {
-  tutorialViewTime: number;
-  stages: Game3StageLog[];
-  /** 全ステージ通じた選択肢ホバー回数の合計 */
-  hoveredOptions: number;
-  /** ステージ3の「○○が返信中」表示〜ユーザー操作までの時間(ms) */
-  typingIndicatorReactTimeMs: number | null;
-}
+export type Game3Stage = components['schemas']['Game3Stage'];
+export type Game3Data = components['schemas']['Game3Data'];


### PR DESCRIPTION
## 概要

`frontend/src/features/games/types/index.ts` の手書き API 型を、`frontend/src/lib/api/generated.ts` の生成型再エクスポートに置き換える。`SubmitGameRequest` が discriminatedUnion 化されたことで、`game_type` × `data` の対応が型レベルで保証されるようになる。

closes #66
refs #52

## 変更内容

### 型定義の置き換え

- `frontend/src/features/games/types/index.ts` から手書き interface を削除し、`components['schemas'][...]` の再エクスポートに変更

### FE 側の rename（生成型に合わせる）

- `TextInputMetrics` → `Game2TextInputMetrics`（`useHelpdeskGame.ts`）
- `Game3StageLog` → `Game3Stage`（`useGroupChatGame.ts`）

### selectedOptionId の null 許容を解消

- `useGroupChatGame.ts` の `recordStageAndAdvance` 引数を `number | null` → `number` に絞り、タイムアウト時は呼び出し側で `0` を渡す形に変更

### submitGame 呼び出しの型キャスト除去

discriminatedUnion 化により `data: ... as unknown as Record<string, unknown>` キャストが逆に型エラーになるため、3 箇所のキャストを除去:

- `HelpdeskGameFlow.tsx`（Game2 送信）
- `GroupChatGameFlow.tsx`（Game3 送信）
- `BaselineSurvey.tsx`（Game1 送信）— diagnosis feature 配下だが Game1 を送っているため Issue #66 の連鎖影響として併せて対応（Issue 本文にも追記済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * TypeScriptの型安全性を向上させました。APIスキーマ生成型の採用により、ゲーム機能の型定義を統一・簡潔化しました。エンドユーザー向けの動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->