### PR TITLE
refactor: FE diagnosis feature と register API の手書き型を OpenAPI 生成型に置き換え

### DIFF
--- a/frontend/src/features/diagnosis/types/index.ts
+++ b/frontend/src/features/diagnosis/types/index.ts
@@ -1,6 +1,7 @@
 // OpenAPI から自動生成された型を再エクスポートする。
-// 手書き定義は廃止済み。スキーマ変更は backend/src/openapi/ を更新したうえで
+// 手書き定義は廃止済み。スキーマ変更は backend/src/schemas/ の zod 定義を更新したうえで
 // `npm run gen:api-types` で frontend/src/lib/api/generated.ts を再生成する。
+// （新規エンドポイント追加時は backend/src/openapi/paths/ への登録も必要）
 
 import type { components } from '@/lib/api/generated';
 

--- a/frontend/src/features/diagnosis/types/index.ts
+++ b/frontend/src/features/diagnosis/types/index.ts
@@ -1,14 +1,21 @@
-export type AnswerOption = 'A' | 'B' | 'C' | 'D';
+// OpenAPI から自動生成された型を再エクスポートする。
+// 手書き定義は廃止済み。スキーマ変更は backend/src/openapi/ を更新したうえで
+// `npm run gen:api-types` で frontend/src/lib/api/generated.ts を再生成する。
 
-export type QuestionKey =
-  | 'q1_caution'
-  | 'q2_calmness'
-  | 'q3_logic'
-  | 'q4_cooperativeness'
-  | 'q5_positivity';
+import type { components } from '@/lib/api/generated';
 
-export type BaselineAnswers = Record<QuestionKey, AnswerOption>;
+// ========================================
+// 自己申告アンケートの API 型
+// ========================================
+export type AnswerOption = components['schemas']['AnswerOption'];
+export type BaselineAnswers = components['schemas']['BaselineAnswers'];
 
+// QuestionKey は API I/O ではなく FE 内部のキー定義。BaselineAnswers から導出する。
+export type QuestionKey = keyof BaselineAnswers;
+
+// ========================================
+// FE 内部データ（API I/O ではない）
+// ========================================
 export type QuestionOption = {
   value: AnswerOption;
   label: string;

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -1,6 +1,7 @@
 // OpenAPI から自動生成された型を再エクスポートする。
-// 手書き定義は廃止済み。スキーマ変更は backend/src/openapi/ を更新したうえで
+// 手書き定義は廃止済み。スキーマ変更は backend/src/schemas/ の zod 定義を更新したうえで
 // `npm run gen:api-types` で frontend/src/lib/api/generated.ts を再生成する。
+// （新規エンドポイント追加時は backend/src/openapi/paths/ への登録も必要）
 
 import type { components } from '@/lib/api/generated';
 

--- a/frontend/src/features/result/types/index.ts
+++ b/frontend/src/features/result/types/index.ts
@@ -1,7 +1,9 @@
 // ========================================
 // 結果画面で使う API 型
-// OpenAPI から自動生成された型（src/lib/api/generated.ts）を再エクスポートする。
-// 仕様書と乖離しないよう、手書き interface は置かない。
+// OpenAPI から自動生成された型を再エクスポートする。
+// 手書き定義は廃止済み。スキーマ変更は backend/src/schemas/ の zod 定義を更新したうえで
+// `npm run gen:api-types` で frontend/src/lib/api/generated.ts を再生成する。
+// （新規エンドポイント追加時は backend/src/openapi/paths/ への登録も必要）
 // ========================================
 
 import type { components } from '@/lib/api/generated';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,3 @@
-import type { BaselineAnswers } from '@/features/diagnosis/types';
 import type {
   SubmitGameRequest,
   SubmitGameResponse,
@@ -6,18 +5,12 @@ import type {
   VoiceRespondResponse,
 } from '@/features/games/types';
 import type { ResultResponse } from '@/features/result/types';
+import type { components } from '@/lib/api/generated';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
-type RegisterRequest = {
-  mbti: string | null;
-  baseline_answers: BaselineAnswers;
-};
-
-type RegisterResponse = {
-  user_id: string;
-  status: 'success';
-};
+type RegisterRequest = components['schemas']['RegisterRequest'];
+type RegisterResponse = components['schemas']['RegisterResponse'];
 
 export async function postRegister(
   body: RegisterRequest


### PR DESCRIPTION
## 概要

FE の diagnosis feature と register API の手書き型を `frontend/src/lib/api/generated.ts`（OpenAPI 生成型）に置き換える。result (#65) / games (#66) と同じ再エクスポート方針に統一し、API 入出力の手書き型を全廃する。

親 Issue #52 の最終分。

closes #67
closes #52

## 変更内容

### `frontend/src/features/diagnosis/types/index.ts`
- `AnswerOption` / `BaselineAnswers` を `components['schemas'][...]` からの再エクスポートに置き換え
- `QuestionKey` は `keyof BaselineAnswers` で導出（FE 内部のキー定義として維持）
- `QuestionOption` / `Question` / `QUESTIONS` は API I/O ではないので手書き維持
- 先頭コメントで「手書きを置かない」方針と再生成手順 (`npm run gen:api-types`) を明示

### `frontend/src/lib/api.ts`
- ローカル定義の `type RegisterRequest` / `type RegisterResponse` を削除
- `components['schemas']['RegisterRequest']` / `components['schemas']['RegisterResponse']` を使う形に置き換え
- 不要になった `BaselineAnswers` の import を削除

### 影響範囲（変更不要を確認済み）
- `frontend/src/features/diagnosis/components/BaselineSurvey.tsx` — 再エクスポート名が同じため import 変更なしで動く
- `frontend/src/stores/diagnosis.ts` — 同上

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * フロントエンド内部の型定義を、OpenAPI生成スキーマと統一しました。これによりバックエンド側の仕様変更がより正確に反映されるようになります。型定義の管理プロセスを簡潔化し、コード品質を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->