### PR TITLE
chore: 自動生成型 generated.ts の同期検証 CI を追加

### DIFF
--- a/.github/workflows/api-types-sync.yml
+++ b/.github/workflows/api-types-sync.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/scripts/**"
+      - "frontend/src/lib/api/generated.ts"
       - "frontend/package.json"
       - "frontend/package-lock.json"
       - ".github/workflows/api-types-sync.yml"
@@ -17,6 +18,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/scripts/**"
+      - "frontend/src/lib/api/generated.ts"
       - "frontend/package.json"
       - "frontend/package-lock.json"
       - ".github/workflows/api-types-sync.yml"

--- a/.github/workflows/api-types-sync.yml
+++ b/.github/workflows/api-types-sync.yml
@@ -1,0 +1,55 @@
+name: API Types Sync
+
+# BE の zod スキーマ変更で `frontend/src/lib/api/generated.ts` の再生成を忘れた PR を検知する。
+# 失敗した場合はローカルで `cd frontend && npm run gen:api-types` を実行してコミットする。
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "backend/**"
+      - "frontend/scripts/**"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - ".github/workflows/api-types-sync.yml"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "backend/**"
+      - "frontend/scripts/**"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - ".github/workflows/api-types-sync.yml"
+
+jobs:
+  verify:
+    name: Verify generated.ts is up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            backend/package-lock.json
+            frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Verify generated.ts is up-to-date
+        run: npm run check:api-types
+        working-directory: frontend
+
+      - name: Hint on failure
+        if: failure()
+        run: |
+          echo "::error::generated.ts が BE スキーマと同期していません。ローカルで 'cd frontend && npm run gen:api-types' を実行し、差分をコミットしてください。"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "gen:api-types": "node scripts/gen-api-types.mjs",
-    "check:api-types": "npm run gen:api-types && git diff --exit-code src/lib/api/generated.ts"
+    "check:api-types": "npm run gen:api-types && git diff --exit-code -- src/lib/api/generated.ts"
   },
   "dependencies": {
     "framer-motion": "^12.34.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "gen:api-types": "node scripts/gen-api-types.mjs"
+    "gen:api-types": "node scripts/gen-api-types.mjs",
+    "check:api-types": "npm run gen:api-types && git diff --exit-code src/lib/api/generated.ts"
   },
   "dependencies": {
     "framer-motion": "^12.34.2",


### PR DESCRIPTION
## 概要

BE の zod スキーマを変更したのに `frontend/src/lib/api/generated.ts` の再生成を忘れた PR を CI で検知できるようにする。

closes #62

## 変更内容

- `frontend/package.json` に `check:api-types` スクリプトを追加
  - `npm run gen:api-types && git diff --exit-code src/lib/api/generated.ts`
  - 差分対象を `src/lib/api/generated.ts` に絞り、他の未追跡変更で誤検知させない
- `.github/workflows/api-types-sync.yml` を新規作成
  - トリガー: `pull_request` / `push (develop)`
  - paths: `backend/**`, `frontend/scripts/**`, `frontend/package.json`, `frontend/package-lock.json`, `.github/workflows/api-types-sync.yml`
  - 手順: checkout → Node 22 setup（両 lockfile を cache）→ `cd backend && npm ci` → `cd frontend && npm ci` → `cd frontend && npm run check:api-types`
  - 失敗時に `cd frontend && npm run gen:api-types` をローカルで実行するよう促すヒントを出力

## 動作確認

- ローカルで `cd frontend && npm run check:api-types` を実行し、現状の generated.ts が同期済みであること（exit 0）を確認
- `git diff --exit-code` がファイル改変時に exit 1 を返すことを確認

## スコープ外

- `gen:api-types` の生成ロジック自体の変更
- `generated.ts` の gitignore 化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **保守**
  * 開発パイプラインに自動検証機能を追加し、継続的な品質管理プロセスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->