### PR TITLE
docs: API 型生成フロー（zod → OpenAPI → generated.ts）を整備

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,7 @@ Swagger UI 上の「Try it out」ボタンからその場で API を叩いて挙
 
 ## 仕組み
 
-zod スキーマを SoT として、Swagger UI（人間が読む用）と FE の TypeScript 型（コードが使う用）の両方を自動生成しています。
+以下のパイプラインで Swagger UI（人間が読む用）と FE の TypeScript 型（コードが使う用）を生成しています。
 
 ```
 zod スキーマ（backend/src/schemas/*.ts）  ← Single Source of Truth

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
-# API 仕様
+# API 仕様 / 型生成
 
 Real You のバックエンド API は OpenAPI 3.1 に対応しており、Swagger UI から閲覧できます。
+**zod スキーマを Single Source of Truth（単一の真実）** として、Swagger UI の表示・FE で使う TypeScript 型の両方を自動生成しています。
 
 ## Swagger UI を開く
 
@@ -26,32 +27,45 @@ Swagger UI 上の「Try it out」ボタンからその場で API を叩いて挙
 
 ## 仕組み
 
-Real You では **zod スキーマを仕様の Single Source of Truth（単一の真実）** として扱い、そこから OpenAPI ドキュメントを自動生成しています。
+zod スキーマを SoT として、Swagger UI（人間が読む用）と FE の TypeScript 型（コードが使う用）の両方を自動生成しています。
 
 ```
-zod スキーマ（backend/src/schemas/*.ts）
+zod スキーマ（backend/src/schemas/*.ts）  ← Single Source of Truth
       │
       │  .openapi({ description, example, ... }) でメタデータ付与
       ▼
 OpenAPIRegistry（backend/src/openapi/registry.ts）
       │
-      │  registerPath() でエンドポイントを登録
+      │  registerPath() でエンドポイント登録
       │  （backend/src/openapi/paths/*.ts）
       ▼
 OpenAPI ドキュメント（backend/src/openapi/document.ts）
       │
-      ▼
-Swagger UI（/api-docs）
+      ├──► Swagger UI（/api-docs）
+      │
+      └──► dump:openapi で JSON ダンプ
+              │
+              ▼
+            openapi-typescript（frontend/scripts/gen-api-types.mjs）
+              │
+              ▼
+            frontend/src/lib/api/generated.ts（FE 用 TS 型）
+              │
+              └──► FE feature の types/index.ts で再エクスポート
+                    （components['schemas']['xxx']）
 ```
 
 使用ライブラリ:
 
 - [`@asteasolutions/zod-to-openapi`](https://github.com/asteasolutions/zod-to-openapi) — zod スキーマに `.openapi()` メソッドを生やし、OpenAPI ドキュメントを生成する
 - [`swagger-ui-express`](https://github.com/scottie1984/swagger-ui-express) — 生成したドキュメントを Swagger UI として配信する
+- [`openapi-typescript`](https://github.com/openapi-ts/openapi-typescript) — OpenAPI ドキュメントから TypeScript 型を生成する
 
 ## スキーマを更新するとき
 
 API の入出力を変更する場合は、以下の流れで作業します。
+
+### 1. BE: zod スキーマを更新
 
 1. `backend/src/schemas/` の該当ファイルで zod スキーマを更新する
 2. 必要に応じて `.openapi({ description, example })` のメタデータを追記 / 変更する
@@ -61,3 +75,59 @@ API の入出力を変更する場合は、以下の流れで作業します。
 6. backend を再起動し、`/api-docs` で反映を確認する
 
 zod スキーマの変更はリクエスト検証にも直接反映されます（検証ミドルウェアが同じスキーマを使っているため、仕様と実装が乖離しません）。
+
+### 2. FE: 生成型を再生成
+
+BE 側で zod スキーマを変更したら、FE 側でも生成型を再生成する必要があります。
+
+```bash
+cd frontend
+npm run gen:api-types
+```
+
+これで `frontend/src/lib/api/generated.ts` が再生成されます。差分が出たら一緒にコミットしてください。
+
+> **注意**: `generated.ts` は git 管理されていますが手で編集しません。BE スキーマを更新したらこのコマンドで再生成します。
+
+## FE での型の使い方
+
+`frontend/src/lib/api/generated.ts` の生成型は、各 feature の `types/index.ts` で再エクスポートして使います。生成型を直接 import する場所は最小限に留めます。
+
+```ts
+// frontend/src/features/diagnosis/types/index.ts
+import type { components } from '@/lib/api/generated';
+
+export type AnswerOption = components['schemas']['AnswerOption'];
+export type BaselineAnswers = components['schemas']['BaselineAnswers'];
+```
+
+```ts
+// frontend/src/features/diagnosis/components/BaselineSurvey.tsx
+import type { BaselineAnswers } from '@/features/diagnosis/types';
+```
+
+API I/O ではない FE 内部のデータ（UI 用の `Question[]` 配列など）は、生成型から導出するか手書きのまま `types/index.ts` に置きます。
+
+## ローカルでの検証
+
+`generated.ts` が BE スキーマと同期しているかをローカルで確認できます。
+
+```bash
+cd frontend
+npm run check:api-types
+```
+
+差分があれば exit 1 で終了します。差分が出た場合は `npm run gen:api-types` を実行して再生成し、コミットしてください。
+
+## CI による自動検証
+
+`.github/workflows/api-types-sync.yml` が PR / push で `check:api-types` を自動実行します。BE の zod スキーマを変更したのに `generated.ts` の再生成を忘れた PR は CI が fail するため、更新漏れを検知できます。
+
+CI が落ちた場合の対処:
+
+```bash
+cd frontend
+npm run gen:api-types
+git add src/lib/api/generated.ts
+git commit -m "chore: OpenAPI から FE の API 型を再生成"
+```

--- a/docs/development-rule.md
+++ b/docs/development-rule.md
@@ -75,6 +75,8 @@ cd frontend
 | `npm run lint` | ESLint でコードチェック | PR 前チェック |
 | `npm run format` | Prettier でコード整形 | コード整形したいとき |
 | `npm run format:check` | Prettier で整形チェック（変更なし） | CI 用 |
+| `npm run gen:api-types` | BE の zod スキーマから FE の API 型 (`src/lib/api/generated.ts`) を再生成 | BE スキーマ変更後 |
+| `npm run check:api-types` | `generated.ts` が BE スキーマと同期しているか検証（差分があれば exit 1） | スキーマ変更時の確認用（CI でも自動実行） |
 
 ### Backend
 
@@ -102,6 +104,25 @@ npm run build
 cd ../backend
 npm run build
 ```
+
+### API スキーマを変更したとき
+
+BE の zod スキーマを変更した場合は、FE 側の自動生成型も再生成する。
+
+```bash
+# 1. BE 側で zod スキーマを更新
+#    backend/src/schemas/*.ts を編集
+
+# 2. FE 側で生成型を再生成
+cd frontend
+npm run gen:api-types
+
+# 3. BE と FE の変更を一緒にコミット
+```
+
+仕組みの詳細・FE での型の使い方は [docs/api.md](api.md) を参照。
+
+CI（`.github/workflows/api-types-sync.yml`）でも `generated.ts` の同期を自動検証している。BE スキーマだけ変えて FE の再生成を忘れた PR は CI が落ちる。
 
 ## Pull Request
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,6 +28,10 @@ cp .env.local.example .env.local
 
 必要な環境変数は `.env.local.example` を参照してください。
 
+### API 型ファイルについて
+
+`frontend/src/lib/api/generated.ts` は BE の zod スキーマから自動生成された TypeScript 型ファイルです。git 管理されているため、初回 setup での再生成は不要です。BE スキーマを変更した際の再生成手順は [docs/api.md](api.md) を参照してください。
+
 ## 3. Backend のセットアップ
 
 ```bash


### PR DESCRIPTION
## 概要

Issue #45 / #52 / #62 で OpenAPI を SoT とした型自動生成体制が整ったが、既存ドキュメントは BE 側の OpenAPI / Swagger UI までしかカバーしていなかった。FE 側の `gen:api-types` フロー、CI 検証、運用ルールを追加してドキュメントを整える。

## 変更内容

### `docs/api.md`（拡張）
- BE → FE までの型 SoT 全体ガイドに格上げ
- 仕組みのフロー図に `dump:openapi` → `openapi-typescript` → `generated.ts` までを追加
- 「BE スキーマを更新するとき」の手順に FE 側の `gen:api-types` 実行を追加
- 新規節を追加:
  - **FE での型の使い方**: 各 feature の `types/index.ts` で `components['schemas'][...]` を再エクスポートする運用
  - **ローカルでの検証**: `npm run check:api-types` の使い方
  - **CI による自動検証**: `.github/workflows/api-types-sync.yml` の動作と CI 失敗時の対処

### `docs/development-rule.md`
- 開発コマンド表（Frontend）に `gen:api-types` / `check:api-types` を追加
- 「API スキーマを変更したとき」節を新設し、BE → FE の更新手順を明示

### `docs/setup.md`
- Frontend セットアップに「API 型ファイルについて」を追加
- `generated.ts` は git 管理のため初回 setup での再生成は不要、詳細は `docs/api.md` 参照、を補足

## 関連

- 親: #45（API 型管理の方針整理、クローズ済み）
- 関連: #62（CI 自動検証、PR #71 で導入済み）