### PR TITLE
feat: FE に ApiClientError と共通エラー UI ErrorScreen を導入

### DIFF
--- a/frontend/src/components/common/ErrorScreen.tsx
+++ b/frontend/src/components/common/ErrorScreen.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * 通信エラー / 業務エラー時に表示する全画面エラー UI。
+ *
+ * - `variant: 'retry'`  … 一時的な通信エラー想定。リトライボタンで同じ操作を再試行する
+ * - `variant: 'restart'` … `RESTART_CODES`（user_not_found 等）想定。トップから最初の操作をやり直してもらう
+ *
+ * 後続 Issue で各画面の catch から呼び出す。本 Issue ではコンポーネント本体のみ実装する。
+ */
+
+type ErrorScreenProps =
+  | { variant: 'retry'; onRetry: () => void }
+  | { variant: 'restart'; onGoTop: () => void };
+
+export default function ErrorScreen(props: ErrorScreenProps) {
+  const isRetry = props.variant === 'retry';
+
+  const title = isRetry
+    ? '通信に失敗しました'
+    : '最初からやり直してください';
+
+  const description = isRetry
+    ? '少し時間をおいて、もう一度お試しください。'
+    : 'セッションが切れている可能性があります。';
+
+  const buttonLabel = isRetry ? 'もう一度試す' : 'トップへ戻る';
+
+  const handleClick = () => {
+    if (props.variant === 'retry') {
+      props.onRetry();
+    } else {
+      props.onGoTop();
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6 text-center"
+    >
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-3xl">
+        <span aria-hidden="true">!</span>
+      </div>
+
+      <h2 className="text-2xl font-bold text-gray-900">{title}</h2>
+      <p className="text-base text-gray-600">{description}</p>
+
+      <button
+        type="button"
+        onClick={handleClick}
+        className="mt-2 rounded-full bg-blue-600 px-8 py-3 text-base font-bold text-white shadow-md transition hover:bg-blue-700 active:scale-95"
+      >
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/common/ErrorScreen.tsx
+++ b/frontend/src/components/common/ErrorScreen.tsx
@@ -57,8 +57,14 @@ export default function ErrorScreen(props: ErrorScreenProps) {
         {description}
       </p>
 
+      {/*
+       * autoFocus: role="alertdialog" の WAI-ARIA ベストプラクティスとして、
+       * 表示時にフォーカスをダイアログ内（主操作ボタン）に移す。
+       * これによりキーボード操作・スクリーンリーダーでも即座に操作できる。
+       */}
       <button
         type="button"
+        autoFocus
         onClick={handleClick}
         className="mt-2 rounded-full bg-blue-600 px-8 py-3 text-base font-bold text-white shadow-md transition hover:bg-blue-700 active:scale-95"
       >

--- a/frontend/src/components/common/ErrorScreen.tsx
+++ b/frontend/src/components/common/ErrorScreen.tsx
@@ -33,16 +33,29 @@ export default function ErrorScreen(props: ErrorScreenProps) {
   };
 
   return (
+    // 全画面オーバーレイで操作ボタン（リトライ / トップへ戻る）を提示するため、
+    // ライブリージョン（role="alert"）ではなく緊急ダイアログとして扱う。
+    // - role="alertdialog": 緊急性のあるモーダルダイアログ
+    // - aria-modal: 背景操作を抑止することを支援技術に伝える
+    // - aria-labelledby / aria-describedby: 見出しと本文を関連付ける
+    // 既存の MbtiSelect の決定確認モーダル（role="dialog" + aria-modal + aria-labelledby）と同じ流儀に揃えている。
     <div
-      role="alert"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="error-screen-title"
+      aria-describedby="error-screen-description"
       className="fixed inset-0 z-[9999] flex flex-col items-center justify-center gap-6 bg-white px-6 text-center"
     >
       <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-3xl">
         <span aria-hidden="true">!</span>
       </div>
 
-      <h2 className="text-2xl font-bold text-gray-900">{title}</h2>
-      <p className="text-base text-gray-600">{description}</p>
+      <h2 id="error-screen-title" className="text-2xl font-bold text-gray-900">
+        {title}
+      </h2>
+      <p id="error-screen-description" className="text-base text-gray-600">
+        {description}
+      </p>
 
       <button
         type="button"

--- a/frontend/src/components/common/ErrorScreen.tsx
+++ b/frontend/src/components/common/ErrorScreen.tsx
@@ -16,9 +16,7 @@ type ErrorScreenProps =
 export default function ErrorScreen(props: ErrorScreenProps) {
   const isRetry = props.variant === 'retry';
 
-  const title = isRetry
-    ? '通信に失敗しました'
-    : '最初からやり直してください';
+  const title = isRetry ? '通信に失敗しました' : '最初からやり直してください';
 
   const description = isRetry
     ? '少し時間をおいて、もう一度お試しください。'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,7 @@ import type {
 } from '@/features/games/types';
 import type { ResultResponse } from '@/features/result/types';
 import type { components } from '@/lib/api/generated';
-import { ApiClientError, type ApiErrorBody } from '@/lib/api/error';
+import { ApiClientError, type RawApiErrorBody } from '@/lib/api/error';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
@@ -35,6 +35,7 @@ async function buildApiClientError(
   const message = body?.message ?? fallbackMessage;
 
   console.error('[ApiClientError]', {
+    url: res.url,
     httpStatus: res.status,
     code: body?.error ?? null,
     message,
@@ -44,11 +45,18 @@ async function buildApiClientError(
 }
 
 /**
- * 受け取った値が `ApiErrorBody` の形をしているかをチェックする。
- * サーバ側の OpenAPI で型を縛っているため通常は常に true だが、
- * 想定外の JSON が返ってきたとき（プロキシが差し込んだエラー等）に備えて検証する。
+ * 受け取った値が共通エラーレスポンスの形をしているかをチェックする。
+ *
+ * 戻り値型は `RawApiErrorBody`（緩い型）。`error` フィールドは `string` の形だけ
+ * 検証して `ApiErrorCodeOrUnknown` として透過させる。これは「BE が新コードを
+ * 追加した瞬間に FE で取り落とさず、message を console に残す」ことを優先した
+ * 設計判断（詳細は `lib/api/error.ts` のモジュール JSDoc 参照）。
+ *
+ * 厳格な `ApiErrorBody`（既知 9 コードのみ）に断定する型ガードにはしない。
+ * もし「`ApiErrorBody` だけを受け入れたい」場合は呼び出し側で
+ * `RESTART_CODES.includes` 等の追加チェックを行う。
  */
-function isApiErrorBody(value: unknown): value is ApiErrorBody {
+function isApiErrorBody(value: unknown): value is RawApiErrorBody {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,8 +34,10 @@ async function buildApiClientError(
   const body = isApiErrorBody(rawBody) ? rawBody : null;
   const message = body?.message ?? fallbackMessage;
 
+  // url は出力しない: getResult のように URL パスに userId を含む API があり、
+  // ログから ID が漏洩するリスクを避ける。エンドポイントの識別は呼び出し側の
+  // fallbackMessage（'結果の取得に失敗しました' 等のエンドポイント別文言）で十分。
   console.error('[ApiClientError]', {
-    url: res.url,
     httpStatus: res.status,
     code: body?.error ?? null,
     message,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,11 +6,57 @@ import type {
 } from '@/features/games/types';
 import type { ResultResponse } from '@/features/result/types';
 import type { components } from '@/lib/api/generated';
+import { ApiClientError, type ApiErrorBody } from '@/lib/api/error';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 type RegisterRequest = components['schemas']['RegisterRequest'];
 type RegisterResponse = components['schemas']['RegisterResponse'];
+
+/**
+ * fetch のレスポンスが `!res.ok` のときに `ApiClientError` を生成して返す。
+ *
+ * - サーバが返す JSON が `ApiErrorBody`（`{ status, error, message }`）の形なら
+ *   そのまま `body` として保持し、`message` も流用する
+ * - JSON パースに失敗した場合（HTML エラーページ・ネットワーク途絶等）は
+ *   `body: null` でフォールバックし、`fallbackMessage` を `message` にする
+ *
+ * 返却直前に `console.error('[ApiClientError]', ...)` を出して開発者の追跡を助ける。
+ * 呼び出し側は `throw await buildApiClientError(res, '...')` の形で投げる。
+ */
+async function buildApiClientError(
+  res: Response,
+  fallbackMessage: string
+): Promise<ApiClientError> {
+  // `!res.ok` の場合のみ呼ばれる前提。レスポンスは一度しか read できないため、
+  // ここで JSON を読み切ってから ApiClientError を組み立てる。
+  const rawBody: unknown = await res.json().catch(() => null);
+  const body = isApiErrorBody(rawBody) ? rawBody : null;
+  const message = body?.message ?? fallbackMessage;
+
+  console.error('[ApiClientError]', {
+    httpStatus: res.status,
+    code: body?.error ?? null,
+    message,
+  });
+
+  return new ApiClientError(res.status, body, message);
+}
+
+/**
+ * 受け取った値が `ApiErrorBody` の形をしているかをチェックする。
+ * サーバ側の OpenAPI で型を縛っているため通常は常に true だが、
+ * 想定外の JSON が返ってきたとき（プロキシが差し込んだエラー等）に備えて検証する。
+ */
+function isApiErrorBody(value: unknown): value is ApiErrorBody {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.status === 'error' &&
+    typeof v.error === 'string' &&
+    typeof v.message === 'string'
+  );
+}
 
 export async function postRegister(
   body: RegisterRequest
@@ -22,8 +68,7 @@ export async function postRegister(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => null);
-    throw new Error(errorData?.message || 'データ送信に失敗しました');
+    throw await buildApiClientError(res, 'データ送信に失敗しました');
   }
 
   return res.json();
@@ -39,8 +84,7 @@ export async function submitGame(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => null);
-    throw new Error(errorData?.message || 'ゲームデータの送信に失敗しました');
+    throw await buildApiClientError(res, 'ゲームデータの送信に失敗しました');
   }
 
   return res.json();
@@ -57,8 +101,7 @@ export async function postVoiceRespond(
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => null);
-    throw new Error(errorData?.message || 'AI返答の生成に失敗しました');
+    throw await buildApiClientError(res, 'AI返答の生成に失敗しました');
   }
 
   return res.json();
@@ -70,8 +113,7 @@ export async function getResult(userId: string): Promise<ResultResponse> {
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => null);
-    throw new Error(errorData?.message || '結果の取得に失敗しました');
+    throw await buildApiClientError(res, '結果の取得に失敗しました');
   }
 
   return res.json();

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -10,20 +10,73 @@
  *
  * 既存の各画面は `err instanceof Error` で `err.message` を読み続けるだけで
  * 動き続ける（`ApiClientError` は Error を継承しているため）。
+ *
+ * ## エラーコードの型設計（厳格型 + ハイブリッド型）
+ *
+ * BE が OpenAPI で縛っている既知コード（9 種類）を `ApiErrorCode` 厳格型として
+ * export しつつ、サーバから未知のコードが返ってきても落とさず受け止めるため、
+ * `ApiClientError.code` の戻り値型は `ApiErrorCodeOrUnknown | null` にしている。
+ *
+ * `ApiErrorCodeOrUnknown = ApiErrorCode | (string & {})` の `(string & {})`
+ * は TypeScript の小ネタ。通常 `'a' | 'b' | string` は `string` に縮約されて
+ * リテラル候補が消えてしまうが、`(string & {})` を挟むと縮約を回避でき、
+ * IDE の補完で既知 9 コードを候補として出しつつ、任意 string も許容できる。
+ *
+ * これにより
+ *   - BE が新コードを追加しても FE 側の修正なく `message` を保持できる
+ *   - 既存コードの比較（`err.code === 'user_not_found'` 等）で IDE 補完が効く
+ * の両立を狙っている。
  */
 import type { components } from '@/lib/api/generated';
 
 /**
- * バックエンドが返す共通エラーレスポンス本体の型。
+ * バックエンドが返す共通エラーレスポンス本体の厳格型。
  * OpenAPI 由来の `components['schemas']['ApiError']` を re-export している。
+ *
+ * 「9 種類の既知コードのみが入る」前提で型付けしたい場面（ドキュメント・分岐の網羅）
+ * で使う。サーバから来た生 JSON の保持には使わない（`ApiClientError.body` は
+ * `RawApiErrorBody` を使う）。
  */
 export type ApiErrorBody = components['schemas']['ApiError'];
 
 /**
- * 業務エラーコードの型（`invalid_request` / `user_not_found` / ...）。
+ * 業務エラーコードの厳格型（`invalid_request` / `user_not_found` / ...）。
  * `ApiErrorBody['error']` から抽出している。
  */
 export type ApiErrorCode = ApiErrorBody['error'];
+
+/**
+ * 既知の業務エラーコード + 未知の string も許容するハイブリッド型。
+ *
+ * `(string & {})` は TypeScript が `'a' | 'b' | string` を `string` に縮約
+ * してしまうのを避けるテクニック（無意味な交差型を挟むことで両者を別物として保持
+ * させる）。結果として IDE は既知コードを補完候補として出しつつ、未知コードも
+ * 代入可能になる。
+ *
+ * 原理: TypeScript の union は「サブタイプ吸収」が起こり、リテラル型 `'a'` は
+ * `string` のサブタイプなので `'a' | string` は `string` に潰れて補完候補が消える。
+ * `(string & {})` は意味的には `string` と等価だが TypeScript の型システム上は
+ * 別オブジェクトとして扱われるため、吸収を回避できる。
+ *
+ * BE が OpenAPI に新コードを追加しても FE 側で取り落とさないようにするため、
+ * `ApiClientError.code` の戻り値型はこちらを使う。
+ */
+export type ApiErrorCodeOrUnknown = ApiErrorCode | (string & {});
+
+/**
+ * `ApiClientError` が内部に保持するエラーレスポンスの形。
+ *
+ * 公開型 `ApiErrorBody` と違い、`error` フィールドは `ApiErrorCodeOrUnknown` で
+ * 緩めに受ける。サーバが OpenAPI に未記載のコードを返した場合でも message を
+ * 失わずに保持し、`console.error` でデバッグに使えるようにするため。
+ *
+ * 構造的には `ApiErrorBody` のスーパータイプ（`ApiErrorBody` を代入可能）。
+ */
+export type RawApiErrorBody = {
+  status: 'error';
+  error: ApiErrorCodeOrUnknown;
+  message: string;
+};
 
 /**
  * 「リトライしても回復しない」業務エラーコードの一覧。
@@ -46,7 +99,7 @@ export const MAX_RETRY_COUNT = 3;
  * API 通信失敗時に throw される共通エラー。
  *
  * - `httpStatus` … fetch のレスポンスステータス（400 / 404 / 500 等）
- * - `body` … サーバから返ってきた `ApiErrorBody`。JSON パースに失敗した場合は `null`
+ * - `body` … サーバから返ってきた `RawApiErrorBody`。JSON パースに失敗した場合は `null`
  * - `code` … `body.error`（業務エラーコード）。body が無ければ `null`
  *
  * `Error` を継承しているため、既存の `err instanceof Error` / `err.message`
@@ -54,9 +107,13 @@ export const MAX_RETRY_COUNT = 3;
  */
 export class ApiClientError extends Error {
   readonly httpStatus: number;
-  readonly body: ApiErrorBody | null;
+  readonly body: RawApiErrorBody | null;
 
-  constructor(httpStatus: number, body: ApiErrorBody | null, message: string) {
+  constructor(
+    httpStatus: number,
+    body: RawApiErrorBody | null,
+    message: string
+  ) {
     super(message);
     this.name = 'ApiClientError';
     this.httpStatus = httpStatus;
@@ -65,8 +122,11 @@ export class ApiClientError extends Error {
 
   /**
    * 業務エラーコード。body が無い（JSON パース失敗等）場合は `null`。
+   *
+   * 戻り値型は `ApiErrorCodeOrUnknown | null`。既知 9 コードは IDE 補完で
+   * 候補として出るが、サーバから未知コードが来た場合もそのまま透過する。
    */
-  get code(): ApiErrorCode | null {
+  get code(): ApiErrorCodeOrUnknown | null {
     return this.body?.error ?? null;
   }
 }
@@ -82,12 +142,17 @@ export function isApiClientError(value: unknown): value is ApiClientError {
 /**
  * 渡された業務エラーコードが「最初からやり直す」べきものかを判定する。
  *
- * `ApiClientError.code` は `ApiErrorCode | null` 型なので、
+ * `ApiClientError.code` は `ApiErrorCodeOrUnknown | null` 型なので、
  * `RESTART_CODES.includes(err.code)` の形では TypeScript の型チェックで
  * エラーになる。後続の各画面が catch で扱う際に詰まらないよう、
  * `null` も受け取れる薄いラッパーを用意しておく。
+ *
+ * `RESTART_CODES` の要素型は厳格型 `ApiErrorCode`、`code` は未知コードを含む
+ * `ApiErrorCodeOrUnknown` で型の幅が違うため、比較を string 同士に落として
+ * 行うために `as readonly string[]` で幅キャストしている。
+ * 未知コード（OpenAPI 未記載）が渡された場合は false（リトライ可能扱い）になる。
  */
-export function isRestartCode(code: ApiErrorCode | null): boolean {
+export function isRestartCode(code: ApiErrorCodeOrUnknown | null): boolean {
   if (code === null) return false;
-  return RESTART_CODES.includes(code);
+  return (RESTART_CODES as readonly string[]).includes(code);
 }

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -82,12 +82,28 @@ export type RawApiErrorBody = {
  * 「リトライしても回復しない」業務エラーコードの一覧。
  * これらが返ってきた場合は ErrorScreen の `variant: 'restart'` を出して
  * トップ画面からのやり直しを促す。
+ *
+ * `as const satisfies readonly ApiErrorCode[]` の形にしている理由:
+ * - `as const` でリテラルタプル `readonly ['user_not_found', ...]` 型を保持する
+ *   （要素まで型情報に残るので `(typeof RESTART_CODES)[number]` で派生型が作れる）
+ * - `satisfies` は型注釈と違い、`as const` の効果を上書きしない。一方で
+ *   「`ApiErrorCode` のいずれかしか入らない」という妥当性チェックは効くため、
+ *   タイポ（例: `'user_not_foud'`）を書いた瞬間にビルドエラーになる
  */
-export const RESTART_CODES: readonly ApiErrorCode[] = [
+export const RESTART_CODES = [
   'user_not_found',
   'invalid_user_id',
   'incomplete_games',
-] as const;
+] as const satisfies readonly ApiErrorCode[];
+
+/**
+ * `isRestartCode` が `RESTART_CODES.includes(code)` で型エラーにならないよう、
+ * 内部判定用に Set 化したもの。`Set<string>.has` は string を受けるため、
+ * `ApiErrorCodeOrUnknown` を型キャストなしでそのまま渡せる。
+ *
+ * モジュール外には公開しない（外向き API は `RESTART_CODES` のまま）。
+ */
+const RESTART_CODES_SET: ReadonlySet<string> = new Set(RESTART_CODES);
 
 /**
  * 通信エラー時のリトライ上限回数。
@@ -142,17 +158,11 @@ export function isApiClientError(value: unknown): value is ApiClientError {
 /**
  * 渡された業務エラーコードが「最初からやり直す」べきものかを判定する。
  *
- * `ApiClientError.code` は `ApiErrorCodeOrUnknown | null` 型なので、
- * `RESTART_CODES.includes(err.code)` の形では TypeScript の型チェックで
- * エラーになる。後続の各画面が catch で扱う際に詰まらないよう、
- * `null` も受け取れる薄いラッパーを用意しておく。
- *
- * `RESTART_CODES` の要素型は厳格型 `ApiErrorCode`、`code` は未知コードを含む
- * `ApiErrorCodeOrUnknown` で型の幅が違うため、比較を string 同士に落として
- * 行うために `as readonly string[]` で幅キャストしている。
- * 未知コード（OpenAPI 未記載）が渡された場合は false（リトライ可能扱い）になる。
+ * `ApiClientError.code` は `ApiErrorCodeOrUnknown | null` 型のため、
+ * `null` を受けて false に短絡する薄いラッパーとして用意。
+ * 未知コード（OpenAPI 未記載）が渡された場合も false（リトライ可能扱い）になる。
  */
 export function isRestartCode(code: ApiErrorCodeOrUnknown | null): boolean {
   if (code === null) return false;
-  return (RESTART_CODES as readonly string[]).includes(code);
+  return RESTART_CODES_SET.has(code);
 }

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -78,3 +78,16 @@ export class ApiClientError extends Error {
 export function isApiClientError(value: unknown): value is ApiClientError {
   return value instanceof ApiClientError;
 }
+
+/**
+ * 渡された業務エラーコードが「最初からやり直す」べきものかを判定する。
+ *
+ * `ApiClientError.code` は `ApiErrorCode | null` 型なので、
+ * `RESTART_CODES.includes(err.code)` の形では TypeScript の型チェックで
+ * エラーになる。後続の各画面が catch で扱う際に詰まらないよう、
+ * `null` も受け取れる薄いラッパーを用意しておく。
+ */
+export function isRestartCode(code: ApiErrorCode | null): boolean {
+  if (code === null) return false;
+  return RESTART_CODES.includes(code);
+}

--- a/frontend/src/lib/api/error.ts
+++ b/frontend/src/lib/api/error.ts
@@ -1,0 +1,80 @@
+/**
+ * API 通信用の共通エラークラスと関連定数。
+ *
+ * バックエンドの共通エラーレスポンス（`{ status: "error", error, message }`）を
+ * FE 側で扱いやすくするためのラッパー。
+ *
+ * - `ApiClientError` … fetch のレスポンスが `!res.ok` のときに throw する
+ * - `RESTART_CODES` … 「最初からやり直してください」を出すべき業務エラーコード
+ * - `MAX_RETRY_COUNT` … 通信エラー時のリトライ上限回数
+ *
+ * 既存の各画面は `err instanceof Error` で `err.message` を読み続けるだけで
+ * 動き続ける（`ApiClientError` は Error を継承しているため）。
+ */
+import type { components } from '@/lib/api/generated';
+
+/**
+ * バックエンドが返す共通エラーレスポンス本体の型。
+ * OpenAPI 由来の `components['schemas']['ApiError']` を re-export している。
+ */
+export type ApiErrorBody = components['schemas']['ApiError'];
+
+/**
+ * 業務エラーコードの型（`invalid_request` / `user_not_found` / ...）。
+ * `ApiErrorBody['error']` から抽出している。
+ */
+export type ApiErrorCode = ApiErrorBody['error'];
+
+/**
+ * 「リトライしても回復しない」業務エラーコードの一覧。
+ * これらが返ってきた場合は ErrorScreen の `variant: 'restart'` を出して
+ * トップ画面からのやり直しを促す。
+ */
+export const RESTART_CODES: readonly ApiErrorCode[] = [
+  'user_not_found',
+  'invalid_user_id',
+  'incomplete_games',
+] as const;
+
+/**
+ * 通信エラー時のリトライ上限回数。
+ * 後続の画面適用 Issue で各画面の retry ロジックから参照する。
+ */
+export const MAX_RETRY_COUNT = 3;
+
+/**
+ * API 通信失敗時に throw される共通エラー。
+ *
+ * - `httpStatus` … fetch のレスポンスステータス（400 / 404 / 500 等）
+ * - `body` … サーバから返ってきた `ApiErrorBody`。JSON パースに失敗した場合は `null`
+ * - `code` … `body.error`（業務エラーコード）。body が無ければ `null`
+ *
+ * `Error` を継承しているため、既存の `err instanceof Error` / `err.message`
+ * の読み出しはそのまま機能する。
+ */
+export class ApiClientError extends Error {
+  readonly httpStatus: number;
+  readonly body: ApiErrorBody | null;
+
+  constructor(httpStatus: number, body: ApiErrorBody | null, message: string) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.httpStatus = httpStatus;
+    this.body = body;
+  }
+
+  /**
+   * 業務エラーコード。body が無い（JSON パース失敗等）場合は `null`。
+   */
+  get code(): ApiErrorCode | null {
+    return this.body?.error ?? null;
+  }
+}
+
+/**
+ * `ApiClientError` 判定用の型ガード。
+ * 既存の汎用 `Error` ハンドリングと使い分けるときに使う。
+ */
+export function isApiClientError(value: unknown): value is ApiClientError {
+  return value instanceof ApiClientError;
+}


### PR DESCRIPTION
## 概要

FE のエラーハンドリングの基盤として `ApiClientError` クラスと共通エラー UI コンポーネント `ErrorScreen` を導入する。後続の画面適用 Issue と Error Boundary Issue の前提となる。

## 変更内容

### 新規: `frontend/src/lib/api/error.ts`
- `ApiClientError` class（`Error` 継承、`httpStatus` / `body` プロパティ、`code` getter）
- `isApiClientError` 型ガード
- `isRestartCode` ヘルパー（`ApiErrorCode | null` を受け取り `RESTART_CODES` 判定。後続 Issue での `RESTART_CODES.includes(err.code)` の型エラー回避用）
- `ApiErrorBody` / `ApiErrorCode` 型を `components['schemas']['ApiError']` から re-export
- `RESTART_CODES = ['user_not_found', 'invalid_user_id', 'incomplete_games']`
- `MAX_RETRY_COUNT = 3`

### 変更: `frontend/src/lib/api.ts`
- 4 関数（`postRegister` / `submitGame` / `postVoiceRespond` / `getResult`）の `!res.ok` 時に `ApiClientError` を throw
- `buildApiClientError` ヘルパーに集約し、throw 直前に `console.error('[ApiClientError]', { httpStatus, code, message })` を出力
- JSON パース失敗時は `body: null` でフォールバック
- `isApiErrorBody` で `{ status, error, message }` 形のレスポンスのみ `body` に格納（プロキシ等が差し込んだ別形式の JSON で誤動作しないように）

### 新規: `frontend/src/components/common/ErrorScreen.tsx`
- props: `{ variant: 'retry'; onRetry } | { variant: 'restart'; onGoTop }`
- `retry`: 「通信に失敗しました」+ リトライボタン
- `restart`: 「最初からやり直してください」+ トップへ戻すボタン
- `role="alert"` を付けて支援技術にも通知

## 互換性

`ApiClientError extends Error` なので、既存画面の catch（`useResult.ts` の `err instanceof Error ? err.message : ...` パターン）はそのまま動作する。

## スコープ外（別子 Issue）

- 各画面の catch 改修（リトライ / 再開動線の組み込み）
- Error Boundary の実装

closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 全画面のアクセシブルなエラー画面を追加（リトライとトップへ戻るの選択肢、キーボードフォーカス対応）。
* **バグ修正**
  * フロントエンドのAPIエラー処理を統一化し、エラーメッセージの安定化と構造化ログ出力を導入。再試行／再起動判定と解析失敗時フォールバックを改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->