### PR TITLE
improve: ゲーム 2 / 3 のエラーハンドリングを業務コード分岐に対応

### DIFF
--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -81,7 +81,7 @@ export default function GroupChatGameFlow() {
    *
    * - `duplicate_submission` … 既にサーバ側で受理済みなので結果画面へ自動進行
    * - `RESTART_CODES`（user_not_found / invalid_user_id 等） … `restart` variant
-   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 超過で `restart` に切替
+   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 回に達した場合は `restart` に切替
    *
    * 成功時は `retryCountRef.current = 0` でリセットして次画面へ遷移する。
    * user_id 欠損は localStorage が空のままで回復不能なので即 `restart`。

--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -46,11 +46,31 @@ export default function GroupChatGameFlow() {
   // useResult.ts / BaselineSurvey.tsx と同じ流儀に揃えている。
   const retryCountRef = useRef(0);
 
+  // 次画面への遷移用 setTimeout の ID を保持する。再スケジュール時のキャンセルと
+  // unmount 時の cleanup で使う。タイマーを放置すると、unmount 後に router.push が
+  // 走って意図しない遷移を引き起こす可能性があるため明示的に管理する。
+  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const playSE = useCallback((path: string) => {
     const audio = new Audio(path);
     audio.volume = 0.5;
     audio.play().catch(() => {});
   }, []);
+
+  // 次画面への遷移を 2 秒後にスケジュールする。前回のタイマーが残っていれば
+  // クリアしてから新しいタイマーを設定する。
+  const scheduleRedirect = useCallback(
+    (path: string) => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+      }
+      redirectTimeoutRef.current = setTimeout(() => {
+        redirectTimeoutRef.current = null;
+        router.push(path);
+      }, 2000);
+    },
+    [router]
+  );
 
   // BGMの初期化と再生管理
   useEffect(() => {
@@ -72,6 +92,16 @@ export default function GroupChatGameFlow() {
     return () => {
       bgm.pause();
       window.removeEventListener('click', playBGM);
+    };
+  }, []);
+
+  // unmount 時に予約済みの遷移タイマーをキャンセルする。
+  useEffect(() => {
+    return () => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+        redirectTimeoutRef.current = null;
+      }
     };
   }, []);
 
@@ -103,10 +133,7 @@ export default function GroupChatGameFlow() {
         });
         retryCountRef.current = 0;
         setSubmitStatus('success');
-        bgmRef.current?.pause();
-        setTimeout(() => {
-          router.push('/result');
-        }, 2000);
+        scheduleRedirect('/result');
       } catch (err: unknown) {
         // duplicate_submission（同一 user_id で同じゲームを再送信）は
         // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
@@ -116,10 +143,7 @@ export default function GroupChatGameFlow() {
         if (isDuplicate) {
           retryCountRef.current = 0;
           setSubmitStatus('success');
-          bgmRef.current?.pause();
-          setTimeout(() => {
-            router.push('/result');
-          }, 2000);
+          scheduleRedirect('/result');
           return;
         }
 
@@ -136,13 +160,17 @@ export default function GroupChatGameFlow() {
         setSubmitStatus('error');
       }
     },
-    [router]
+    [scheduleRedirect]
   );
 
   const handleComplete = useCallback(
     async (data: Game3Data) => {
       pendingDataRef.current = data;
       setSubmitStatus('loading');
+      // 送信開始時点で BGM を停止する。HelpdeskGameFlow の handleComplete と
+      // 揃えており、成功・duplicate_submission・error すべての経路で
+      // BGM が止まる（ErrorScreen 表示中の音漏れを防ぐ）。
+      bgmRef.current?.pause();
       await submitGame3(data);
     },
     [submitGame3]

--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -6,7 +6,13 @@ import type { Game3Data } from '@/features/games/types';
 import { BOTS } from '../data/stages';
 import { useGroupChatGame } from '../hooks/useGroupChatGame';
 import { submitGame } from '@/lib/api';
+import {
+  MAX_RETRY_COUNT,
+  isApiClientError,
+  isRestartCode,
+} from '@/lib/api/error';
 import Spinner from '@/components/ui/Spinner';
+import ErrorScreen from '@/components/common/ErrorScreen';
 
 const TUTORIAL_TEXT = `あなたは職場のグループチャットに
 参加しています。
@@ -14,6 +20,14 @@ const TUTORIAL_TEXT = `あなたは職場のグループチャットに
 自由に返信せよ！！`;
 
 type SubmitStatus = 'loading' | 'success' | 'error';
+
+/**
+ * `ErrorScreen` に渡す variant。
+ * - `'retry'`   … 一時的な通信エラー（サーバ 5xx / ネットワーク失敗）想定
+ * - `'restart'` … `RESTART_CODES`（user_not_found / invalid_user_id 等）、
+ *                 user_id 欠損、またはリトライ上限超過
+ */
+type ErrorVariant = 'retry' | 'restart';
 
 function getBotByBotId(botId: string) {
   return BOTS.find((b) => b.id === botId);
@@ -23,8 +37,14 @@ export default function GroupChatGameFlow() {
   const router = useRouter();
   const chatEndRef = useRef<HTMLDivElement>(null);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('loading');
+  const [errorVariant, setErrorVariant] = useState<ErrorVariant>('retry');
   const pendingDataRef = useRef<Game3Data | null>(null);
   const bgmRef = useRef<HTMLAudioElement | null>(null);
+
+  // リトライ回数は描画ロジックに直接影響しない（catch 内で variant を決める材料
+  // としてのみ使う）ため、useState ではなく useRef で扱う。
+  // useResult.ts / BaselineSurvey.tsx と同じ流儀に揃えている。
+  const retryCountRef = useRef(0);
 
   const playSE = useCallback((path: string) => {
     const audio = new Audio(path);
@@ -55,51 +75,99 @@ export default function GroupChatGameFlow() {
     };
   }, []);
 
-  const submitGame3 = useCallback(async (data: Game3Data) => {
-    const userId = localStorage.getItem('user_id');
-    if (!userId) throw new Error('user_id が見つかりません');
-    await submitGame({
-      user_id: userId,
-      game_type: 3,
-      data,
-    });
-  }, []);
-
-  const handleComplete = useCallback(
+  /**
+   * submitGame(game_type=3) 呼び出しの共通処理。
+   * 業務エラーコードに応じて以下の挙動を行う:
+   *
+   * - `duplicate_submission` … 既にサーバ側で受理済みなので結果画面へ自動進行
+   * - `RESTART_CODES`（user_not_found / invalid_user_id 等） … `restart` variant
+   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 超過で `restart` に切替
+   *
+   * 成功時は `retryCountRef.current = 0` でリセットして次画面へ遷移する。
+   * user_id 欠損は localStorage が空のままで回復不能なので即 `restart`。
+   */
+  const submitGame3 = useCallback(
     async (data: Game3Data) => {
-      pendingDataRef.current = data;
-      setSubmitStatus('loading');
+      const userId = localStorage.getItem('user_id');
+      if (!userId) {
+        setErrorVariant('restart');
+        setSubmitStatus('error');
+        return;
+      }
 
       try {
-        await submitGame3(data);
+        await submitGame({
+          user_id: userId,
+          game_type: 3,
+          data,
+        });
+        retryCountRef.current = 0;
         setSubmitStatus('success');
         bgmRef.current?.pause();
         setTimeout(() => {
           router.push('/result');
         }, 2000);
-      } catch {
+      } catch (err: unknown) {
+        // duplicate_submission（同一 user_id で同じゲームを再送信）は
+        // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
+        // BaselineSurvey.tsx の game1 送信と同じ流儀。
+        const isDuplicate =
+          isApiClientError(err) && err.code === 'duplicate_submission';
+        if (isDuplicate) {
+          retryCountRef.current = 0;
+          setSubmitStatus('success');
+          bgmRef.current?.pause();
+          setTimeout(() => {
+            router.push('/result');
+          }, 2000);
+          return;
+        }
+
+        // 業務エラーコードが「最初からやり直し」系の場合は restart。
+        // それ以外（ネットワーク失敗・5xx・未知コード等）はリトライ可能扱いだが、
+        // 既に MAX_RETRY_COUNT 回リトライ済みなら restart に切り替える。
+        if (isApiClientError(err) && isRestartCode(err.code)) {
+          setErrorVariant('restart');
+        } else if (retryCountRef.current >= MAX_RETRY_COUNT) {
+          setErrorVariant('restart');
+        } else {
+          setErrorVariant('retry');
+        }
         setSubmitStatus('error');
       }
     },
-    [router, submitGame3]
+    [router]
+  );
+
+  const handleComplete = useCallback(
+    async (data: Game3Data) => {
+      pendingDataRef.current = data;
+      setSubmitStatus('loading');
+      await submitGame3(data);
+    },
+    [submitGame3]
   );
 
   const handleRetry = useCallback(async () => {
     playSE('/sounds/general-button-se.mp3'); // リトライ音
     const data = pendingDataRef.current;
     if (!data) return;
+    retryCountRef.current += 1;
     setSubmitStatus('loading');
-    try {
-      await submitGame3(data);
-      setSubmitStatus('success');
-      bgmRef.current?.pause();
-      setTimeout(() => {
-        router.push('/result');
-      }, 2000);
-    } catch {
-      setSubmitStatus('error');
+    await submitGame3(data);
+  }, [submitGame3, playSE]);
+
+  const handleGoTop = useCallback(() => {
+    playSE('/sounds/general-button-se.mp3');
+    // RESTART_CODES（user_not_found / invalid_user_id 等）でトップに戻すケースでは、
+    // 古い user_id を握ったまま再開しても同じエラーで詰むため localStorage を掃除する。
+    // ResultPage.tsx / BaselineSurvey.tsx の handleGoTop と挙動を揃えている。
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('user_id');
     }
-  }, [router, submitGame3, playSE]);
+    bgmRef.current?.pause();
+    router.push('/');
+  }, [playSE, router]);
 
   const {
     gamePhase,
@@ -200,42 +268,35 @@ export default function GroupChatGameFlow() {
         </div>
       )}
 
-      {/* --- 終了（完了）オーバーレイ --- */}
-      {gamePhase === 'completed' && (
+      {/* --- 終了（完了）オーバーレイ: 成功 / 送信中のみ表示 --- */}
+      {gamePhase === 'completed' && submitStatus !== 'error' && (
         <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/60">
           <div className="z-10 animate-[fadeInUp_0.4s_ease-out] px-6 text-center">
-            {submitStatus === 'error' ? (
-              <>
-                <p className="text-4xl font-black tracking-widest text-[#e03131] drop-shadow-md bg-white px-6 py-2 rounded-xl border-[4px] border-black">
-                  通信エラー！
-                </p>
-                <button
-                  onClick={handleRetry}
-                  className="mt-6 flex items-center justify-center rounded-xl border-[4px] border-black bg-white px-8 py-3 text-xl font-black text-black shadow-[4px_4px_0_0_#000] transition-transform hover:-translate-y-1 hover:shadow-[6px_6px_0_0_#000] mx-auto"
-                >
-                  リトライする
-                </button>
-              </>
-            ) : (
-              <>
-                <p className="text-6xl font-black tracking-widest text-white drop-shadow-lg">
-                  終了！
-                </p>
-                {submitStatus === 'loading' && (
-                  <div className="mt-8 flex justify-center text-white">
-                    <Spinner message="送信中..." />
-                  </div>
-                )}
-                {submitStatus === 'success' && (
-                  <p className="mt-6 text-lg font-bold text-white/80">
-                    Loading画面へ移動します...
-                  </p>
-                )}
-              </>
+            <p className="text-6xl font-black tracking-widest text-white drop-shadow-lg">
+              終了！
+            </p>
+            {submitStatus === 'loading' && (
+              <div className="mt-8 flex justify-center text-white">
+                <Spinner message="送信中..." />
+              </div>
+            )}
+            {submitStatus === 'success' && (
+              <p className="mt-6 text-lg font-bold text-white/80">
+                Loading画面へ移動します...
+              </p>
             )}
           </div>
         </div>
       )}
+
+      {/* --- 完了時のエラー: ErrorScreen に variant 別で委譲 --- */}
+      {gamePhase === 'completed' &&
+        submitStatus === 'error' &&
+        (errorVariant === 'restart' ? (
+          <ErrorScreen variant="restart" onGoTop={handleGoTop} />
+        ) : (
+          <ErrorScreen variant="retry" onRetry={handleRetry} />
+        ))}
 
       {/* --- スマホフレーム --- */}
       <div

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -72,7 +72,7 @@ export default function HelpdeskGameFlow() {
    *
    * - `duplicate_submission` … 既にサーバ側で受理済みなので次画面へ自動進行
    * - `RESTART_CODES`（user_not_found / invalid_user_id 等） … `restart` variant
-   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 超過で `restart` に切替
+   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 回に達した場合は `restart` に切替
    *
    * 成功時は `retryCountRef.current = 0` でリセットして次画面へ遷移する。
    * user_id 欠損は localStorage が空のままで回復不能なので即 `restart`。

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -4,17 +4,37 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Game2Data } from '@/features/games/types';
 import { submitGame } from '@/lib/api';
+import {
+  MAX_RETRY_COUNT,
+  isApiClientError,
+  isRestartCode,
+} from '@/lib/api/error';
 import { useHelpdeskGame } from '../hooks/useHelpdeskGame';
 import Spinner from '@/components/ui/Spinner';
+import ErrorScreen from '@/components/common/ErrorScreen';
 import { GAME_TOPIC } from '../data/supportResponses';
 
 type SubmitStatus = 'loading' | 'success' | 'error';
+
+/**
+ * `ErrorScreen` に渡す variant。
+ * - `'retry'`   … 一時的な通信エラー（サーバ 5xx / ネットワーク失敗）想定
+ * - `'restart'` … `RESTART_CODES`（user_not_found / invalid_user_id 等）、
+ *                 user_id 欠損、またはリトライ上限超過
+ */
+type ErrorVariant = 'retry' | 'restart';
 
 export default function HelpdeskGameFlow() {
   const router = useRouter();
   const [textInput, setTextInput] = useState('');
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('loading');
+  const [errorVariant, setErrorVariant] = useState<ErrorVariant>('retry');
   const pendingDataRef = useRef<Game2Data | null>(null);
+
+  // リトライ回数は描画ロジックに直接影響しない（catch 内で variant を決める材料
+  // としてのみ使う）ため、useState ではなく useRef で扱う。
+  // useResult.ts / BaselineSurvey.tsx と同じ流儀に揃えている。
+  const retryCountRef = useRef(0);
 
   // --- サウンド管理用のRefとヘルパー ---
   const bgmRef = useRef<HTMLAudioElement | null>(null);
@@ -46,15 +66,67 @@ export default function HelpdeskGameFlow() {
     };
   }, []);
 
-  const submitGame2 = useCallback(async (data: Game2Data) => {
-    const userId = localStorage.getItem('user_id');
-    if (!userId) throw new Error('user_id が見つかりません');
-    await submitGame({
-      user_id: userId,
-      game_type: 2,
-      data,
-    });
-  }, []);
+  /**
+   * submitGame(game_type=2) 呼び出しの共通処理。
+   * 業務エラーコードに応じて以下の挙動を行う:
+   *
+   * - `duplicate_submission` … 既にサーバ側で受理済みなので次画面へ自動進行
+   * - `RESTART_CODES`（user_not_found / invalid_user_id 等） … `restart` variant
+   * - その他 … リトライ可能扱い。`MAX_RETRY_COUNT` 超過で `restart` に切替
+   *
+   * 成功時は `retryCountRef.current = 0` でリセットして次画面へ遷移する。
+   * user_id 欠損は localStorage が空のままで回復不能なので即 `restart`。
+   */
+  const submitGame2 = useCallback(
+    async (data: Game2Data) => {
+      const userId = localStorage.getItem('user_id');
+      if (!userId) {
+        setErrorVariant('restart');
+        setSubmitStatus('error');
+        return;
+      }
+
+      try {
+        await submitGame({
+          user_id: userId,
+          game_type: 2,
+          data,
+        });
+        retryCountRef.current = 0;
+        setSubmitStatus('success');
+        setTimeout(() => {
+          router.push('/games/group-chat');
+        }, 2000);
+      } catch (err: unknown) {
+        // duplicate_submission（同一 user_id で同じゲームを再送信）は
+        // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
+        // BaselineSurvey.tsx の game1 送信と同じ流儀。
+        const isDuplicate =
+          isApiClientError(err) && err.code === 'duplicate_submission';
+        if (isDuplicate) {
+          retryCountRef.current = 0;
+          setSubmitStatus('success');
+          setTimeout(() => {
+            router.push('/games/group-chat');
+          }, 2000);
+          return;
+        }
+
+        // 業務エラーコードが「最初からやり直し」系の場合は restart。
+        // それ以外（ネットワーク失敗・5xx・未知コード等）はリトライ可能扱いだが、
+        // 既に MAX_RETRY_COUNT 回リトライ済みなら restart に切り替える。
+        if (isApiClientError(err) && isRestartCode(err.code)) {
+          setErrorVariant('restart');
+        } else if (retryCountRef.current >= MAX_RETRY_COUNT) {
+          setErrorVariant('restart');
+        } else {
+          setErrorVariant('retry');
+        }
+        setSubmitStatus('error');
+      }
+    },
+    [router]
+  );
 
   const handleComplete = useCallback(
     async (data: Game2Data) => {
@@ -66,17 +138,9 @@ export default function HelpdeskGameFlow() {
         bgmRef.current.pause();
       }
 
-      try {
-        await submitGame2(data);
-        setSubmitStatus('success');
-        setTimeout(() => {
-          router.push('/games/group-chat');
-        }, 2000);
-      } catch {
-        setSubmitStatus('error');
-      }
+      await submitGame2(data);
     },
-    [router, submitGame2]
+    [submitGame2]
   );
 
   const {
@@ -93,11 +157,20 @@ export default function HelpdeskGameFlow() {
     onKeyDown,
     resetTyping,
     voiceApiRetrying,
+    voiceApiErrorVariant,
     retryVoiceApi: originalRetryVoiceApi,
     startInstruction: originalStartInstruction,
     gameTopic,
     hints,
   } = useHelpdeskGame({ onComplete: handleComplete });
+
+  // voice-api-error フェーズで restart variant に切り替わったら ErrorScreen を全画面で
+  // 表示するため、ゲーム中の BGM を裏で鳴らし続けるのは違和感がある。明示的に停止する。
+  useEffect(() => {
+    if (gamePhase === 'voice-api-error' && voiceApiErrorVariant === 'restart') {
+      bgmRef.current?.pause();
+    }
+  }, [gamePhase, voiceApiErrorVariant]);
 
   // --- アクションをラップしてSEを追加 ---
   const startInstruction = useCallback(() => {
@@ -137,17 +210,24 @@ export default function HelpdeskGameFlow() {
     playSE('/sounds/general-button-se.mp3');
     const data = pendingDataRef.current;
     if (!data) return;
+    retryCountRef.current += 1;
     setSubmitStatus('loading');
-    try {
-      await submitGame2(data);
-      setSubmitStatus('success');
-      setTimeout(() => {
-        router.push('/games/group-chat');
-      }, 2000);
-    } catch {
-      setSubmitStatus('error');
+    await submitGame2(data);
+  }, [submitGame2, playSE]);
+
+  const handleGoTop = useCallback(() => {
+    playSE('/sounds/general-button-se.mp3');
+    // RESTART_CODES（user_not_found / invalid_user_id 等）でトップに戻すケースでは、
+    // 古い user_id を握ったまま再開しても同じエラーで詰むため localStorage を掃除する。
+    // ResultPage.tsx / BaselineSurvey.tsx の handleGoTop と挙動を揃えている。
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('user_id');
     }
-  }, [submitGame2, playSE, router]);
+    // ErrorScreen 表示中も BGM が鳴り続けるのを防ぐ。
+    // unmount 時の cleanup でも止まるが、ボタン押下前の状態を考慮して明示的に停止。
+    bgmRef.current?.pause();
+    router.push('/');
+  }, [playSE, router]);
 
   const [hintIndex, setHintIndex] = useState(0);
   const [prevHints, setPrevHints] = useState(hints);
@@ -174,8 +254,12 @@ export default function HelpdeskGameFlow() {
           </button>
         )}
 
-      {/* --- AI応答取得失敗オーバーレイ --- */}
-      {gamePhase === 'voice-api-error' && (
+      {/* --- AI応答取得失敗オーバーレイ ---
+       * variant='retry' は既存のゲーム演出に馴染むカスタムオーバーレイで再試行を促す。
+       * variant='restart'（user_id 欠損 / RESTART_CODES / リトライ上限超過）は
+       * 共通の ErrorScreen に切り替えてトップに戻す。
+       */}
+      {gamePhase === 'voice-api-error' && voiceApiErrorVariant === 'retry' && (
         <div className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/60 px-6 backdrop-blur-sm">
           <div className="rounded-2xl border-[4px] border-black bg-white p-8 text-center shadow-[8px_8px_0_0_#000]">
             <p className="text-xl font-bold text-red-600">通信に失敗しました</p>
@@ -195,6 +279,11 @@ export default function HelpdeskGameFlow() {
           </div>
         </div>
       )}
+
+      {gamePhase === 'voice-api-error' &&
+        voiceApiErrorVariant === 'restart' && (
+          <ErrorScreen variant="restart" onGoTop={handleGoTop} />
+        )}
 
       {/* --- ルールポップアップ (チュートリアルフェーズ) --- */}
       {gamePhase === 'tutorial' && (
@@ -237,23 +326,11 @@ export default function HelpdeskGameFlow() {
       )}
 
       {/* --- 終了画面 (completed オーバーレイ) --- */}
-      {gamePhase === 'completed' && (
+      {gamePhase === 'completed' && submitStatus !== 'error' && (
         <div className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black/80 backdrop-blur-sm">
           {submitStatus === 'loading' ? (
             <div className="flex flex-col items-center gap-4">
               <Spinner message="結果を送信中..." />
-            </div>
-          ) : submitStatus === 'error' ? (
-            <div className="flex flex-col items-center gap-6">
-              <h2 className="text-3xl font-black text-red-500 drop-shadow-md">
-                通信に失敗しました
-              </h2>
-              <button
-                onClick={handleRetry}
-                className="rounded-xl border-[4px] border-black bg-[#3b82f6] px-8 py-3 text-xl font-bold text-white shadow-[4px_4px_0_0_#000] transition-transform hover:translate-y-1 hover:shadow-none"
-              >
-                リトライ
-              </button>
             </div>
           ) : (
             <h2 className="text-6xl font-black tracking-widest text-white drop-shadow-[0_4px_4px_rgba(0,0,0,0.5)] animate-[scaleIn_0.5s_ease-out]">
@@ -262,6 +339,15 @@ export default function HelpdeskGameFlow() {
           )}
         </div>
       )}
+
+      {/* --- 完了時のエラー: ErrorScreen に variant 別で委譲 --- */}
+      {gamePhase === 'completed' &&
+        submitStatus === 'error' &&
+        (errorVariant === 'restart' ? (
+          <ErrorScreen variant="restart" onGoTop={handleGoTop} />
+        ) : (
+          <ErrorScreen variant="retry" onRetry={handleRetry} />
+        ))}
 
       {/* --- 画面下部の会話エリア --- */}
       <div className="absolute bottom-8 left-0 right-0 px-4 z-30">

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -36,6 +36,11 @@ export default function HelpdeskGameFlow() {
   // useResult.ts / BaselineSurvey.tsx と同じ流儀に揃えている。
   const retryCountRef = useRef(0);
 
+  // 次画面への遷移用 setTimeout の ID を保持する。再スケジュール時のキャンセルと
+  // unmount 時の cleanup で使う。タイマーを放置すると、unmount 後に router.push が
+  // 走って意図しない遷移を引き起こす可能性があるため明示的に管理する。
+  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // --- サウンド管理用のRefとヘルパー ---
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
@@ -44,6 +49,21 @@ export default function HelpdeskGameFlow() {
     audio.volume = 0.5;
     audio.play().catch(() => {});
   }, []);
+
+  // 次画面への遷移を 2 秒後にスケジュールする。前回のタイマーが残っていれば
+  // クリアしてから新しいタイマーを設定する。
+  const scheduleRedirect = useCallback(
+    (path: string) => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+      }
+      redirectTimeoutRef.current = setTimeout(() => {
+        redirectTimeoutRef.current = null;
+        router.push(path);
+      }, 2000);
+    },
+    [router]
+  );
 
   // BGMの初期化と再生管理
   useEffect(() => {
@@ -63,6 +83,16 @@ export default function HelpdeskGameFlow() {
     return () => {
       bgm.pause();
       window.removeEventListener('click', playBGM);
+    };
+  }, []);
+
+  // unmount 時に予約済みの遷移タイマーをキャンセルする。
+  useEffect(() => {
+    return () => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+        redirectTimeoutRef.current = null;
+      }
     };
   }, []);
 
@@ -94,9 +124,7 @@ export default function HelpdeskGameFlow() {
         });
         retryCountRef.current = 0;
         setSubmitStatus('success');
-        setTimeout(() => {
-          router.push('/games/group-chat');
-        }, 2000);
+        scheduleRedirect('/games/group-chat');
       } catch (err: unknown) {
         // duplicate_submission（同一 user_id で同じゲームを再送信）は
         // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
@@ -106,9 +134,7 @@ export default function HelpdeskGameFlow() {
         if (isDuplicate) {
           retryCountRef.current = 0;
           setSubmitStatus('success');
-          setTimeout(() => {
-            router.push('/games/group-chat');
-          }, 2000);
+          scheduleRedirect('/games/group-chat');
           return;
         }
 
@@ -125,7 +151,7 @@ export default function HelpdeskGameFlow() {
         setSubmitStatus('error');
       }
     },
-    [router]
+    [scheduleRedirect]
   );
 
   const handleComplete = useCallback(

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -467,7 +467,6 @@ export function useHelpdeskGame(options: {
     const pending = pendingVoiceRequestRef.current;
     if (!pending) return;
 
-    voiceApiRetryCountRef.current += 1;
     setVoiceApiRetrying(true);
 
     const userId =
@@ -475,10 +474,14 @@ export function useHelpdeskGame(options: {
     if (!userId) {
       // user_id 欠損は localStorage が空のままで回復不能なので即 restart。
       // restart variant は再試行されないため pendingVoiceRequestRef は触らない。
+      // API を呼んでいないので voiceApiRetryCountRef も増やさない。
       setVoiceApiErrorVariant('restart');
       setVoiceApiRetrying(false);
       return;
     }
+
+    // API 呼び出しが確定したのでリトライカウンタを進める。
+    voiceApiRetryCountRef.current += 1;
 
     try {
       const result = await postVoiceRespond({

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -486,8 +486,16 @@ export function useHelpdeskGame(options: {
         message: pending.userMessage,
         conversation_history: pending.conversationHistory,
       });
-      // 成功: リトライカウンタをリセットして応答を再生
+      // 成功: リトライカウンタをリセットして応答を再生。
+      // addSupportResponseAndSpeak は TTS の onend で非同期に user-input へ遷移する
+      // （数秒かかる）ため、その間 voice-api-error オーバーレイが残ったままだと
+      // リトライボタンが再表示され、連打で二重送信されてしまう。
+      // 防御として pending をクリアし、フェーズも awaiting-api に切り替えて
+      // 「少々お待ちください。」UI に倒す。awaiting-api は support-speaking effect の
+      // 発動条件に該当しないので、effect 再発動による API 二重呼び出しも起きない。
       voiceApiRetryCountRef.current = 0;
+      pendingVoiceRequestRef.current = null;
+      setGamePhase('awaiting-api');
       addSupportResponseAndSpeak(result.response);
     } catch (err: unknown) {
       pendingVoiceRequestRef.current = pending;

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -57,10 +57,11 @@ export interface ChatMessage {
 }
 
 /**
- * voice-api-error フェーズで `ErrorScreen` に渡す variant。
- * - `'retry'`   … 一時的な通信エラー（既存のカスタムオーバーレイで再試行を促す）
+ * voice-api-error フェーズの UI 分岐 variant。
+ * 呼び出し側は variant に応じて以下を描画する。
+ * - `'retry'`   … 一時的な通信エラー。既存のカスタムオーバーレイで再試行を促す
  * - `'restart'` … `RESTART_CODES`（user_not_found / invalid_user_id 等）、
- *                 user_id 欠損、またはリトライ上限超過。トップへ戻すべき状態
+ *                 user_id 欠損、またはリトライ上限到達。`ErrorScreen` でトップへ戻す
  */
 export type VoiceApiErrorVariant = 'retry' | 'restart';
 
@@ -92,7 +93,8 @@ export function useHelpdeskGame(options: {
   const [currentHints, setCurrentHints] = useState<string[]>(INITIAL_HINTS);
 
   // postVoiceRespond のリトライ回数。voice-api-error フェーズの再試行が
-  // MAX_RETRY_COUNT を超えたら variant='restart' に切り替える。
+  // MAX_RETRY_COUNT 回に達したら variant='restart' に切り替える（判定は `>=` なので
+  // 「上限まで使い切った時点」で restart）。
   // 描画ロジックには直接影響しないため useRef。
   const voiceApiRetryCountRef = useRef(0);
 
@@ -479,7 +481,7 @@ export function useHelpdeskGame(options: {
     } catch (err: unknown) {
       pendingVoiceRequestRef.current = pending;
       // 業務エラーコードが「最初からやり直し」系の場合は restart。
-      // MAX_RETRY_COUNT 超過時も restart に切り替える。
+      // リトライ回数が MAX_RETRY_COUNT 回に達した場合も restart に切り替える。
       if (isApiClientError(err) && isRestartCode(err.code)) {
         setVoiceApiErrorVariant('restart');
       } else if (voiceApiRetryCountRef.current >= MAX_RETRY_COUNT) {

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -396,6 +396,12 @@ export function useHelpdeskGame(options: {
           // user_id 欠損は localStorage が空のままで回復不能なので即 restart。
           // restart variant は再試行されないため pendingVoiceRequestRef は保存しない。
           if (cancelled) return;
+          // 防御的に呼び出し音を停止する。実フローでは currentTurn === 0 で既に停止
+          // 済みのはずだが、要件変更で初回 API 呼び出しになっても安全に倒れるように。
+          if (callingAudioRef.current) {
+            callingAudioRef.current.pause();
+            callingAudioRef.current.currentTime = 0;
+          }
           setVoiceApiErrorVariant('restart');
           setGamePhase('voice-api-error');
           return;
@@ -414,6 +420,11 @@ export function useHelpdeskGame(options: {
             userMessage,
             conversationHistory,
           };
+          // 防御的に呼び出し音を停止する（user_id 欠損経路と同じ理由）。
+          if (callingAudioRef.current) {
+            callingAudioRef.current.pause();
+            callingAudioRef.current.currentTime = 0;
+          }
           // 業務エラーコードが「最初からやり直し」系の場合は restart。
           // それ以外（ネットワーク失敗・5xx・未知コード等）はリトライ可能扱いだが、
           // 既に MAX_RETRY_COUNT 回リトライ済みなら restart に切り替える。

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -8,6 +8,11 @@ import type {
 } from '@/features/games/types';
 import { postVoiceRespond } from '@/lib/api';
 import {
+  MAX_RETRY_COUNT,
+  isApiClientError,
+  isRestartCode,
+} from '@/lib/api/error';
+import {
   GAME_TOPIC,
   INITIAL_SUPPORT_MESSAGE,
   FINAL_SUPPORT_MESSAGE,
@@ -52,6 +57,14 @@ export interface ChatMessage {
 }
 
 /**
+ * voice-api-error フェーズで `ErrorScreen` に渡す variant。
+ * - `'retry'`   … 一時的な通信エラー（既存のカスタムオーバーレイで再試行を促す）
+ * - `'restart'` … `RESTART_CODES`（user_not_found / invalid_user_id 等）、
+ *                 user_id 欠損、またはリトライ上限超過。トップへ戻すべき状態
+ */
+export type VoiceApiErrorVariant = 'retry' | 'restart';
+
+/**
  * Game 2（カスタマーサポートチャット）全体のステート管理フック。
  *
  * useSpeechRecognition / useAudioMetrics / useTypingMetrics を統合し、
@@ -74,7 +87,14 @@ export function useHelpdeskGame(options: {
   const [gamePhase, setGamePhase] = useState<GamePhase>('tutorial');
   const [remainingTimeMs, setRemainingTimeMs] = useState(TURN_TIME_LIMIT_MS);
   const [voiceApiRetrying, setVoiceApiRetrying] = useState(false);
+  const [voiceApiErrorVariant, setVoiceApiErrorVariant] =
+    useState<VoiceApiErrorVariant>('retry');
   const [currentHints, setCurrentHints] = useState<string[]>(INITIAL_HINTS);
+
+  // postVoiceRespond のリトライ回数。voice-api-error フェーズの再試行が
+  // MAX_RETRY_COUNT を超えたら variant='restart' に切り替える。
+  // 描画ロジックには直接影響しないため useRef。
+  const voiceApiRetryCountRef = useRef(0);
 
   // --- 環境チェック & SE 準備 ---
   const isSpeechSupported =
@@ -366,24 +386,42 @@ export function useHelpdeskGame(options: {
           content: m.text,
         }));
 
+        const userId =
+          typeof window !== 'undefined'
+            ? localStorage.getItem('user_id')
+            : null;
+        if (!userId) {
+          // user_id 欠損は localStorage が空のままで回復不能なので即 restart。
+          // restart variant は再試行されないため pendingVoiceRequestRef は保存しない。
+          if (cancelled) return;
+          setVoiceApiErrorVariant('restart');
+          setGamePhase('voice-api-error');
+          return;
+        }
+
         try {
-          const userId =
-            typeof window !== 'undefined'
-              ? localStorage.getItem('user_id')
-              : null;
-          if (!userId) throw new Error('user_id not found');
           const result = await postVoiceRespond({
             user_id: userId,
             message: userMessage,
             conversation_history: conversationHistory,
           });
           supportText = result.response;
-        } catch {
+        } catch (err: unknown) {
           if (cancelled) return;
           pendingVoiceRequestRef.current = {
             userMessage,
             conversationHistory,
           };
+          // 業務エラーコードが「最初からやり直し」系の場合は restart。
+          // それ以外（ネットワーク失敗・5xx・未知コード等）はリトライ可能扱いだが、
+          // 既に MAX_RETRY_COUNT 回リトライ済みなら restart に切り替える。
+          if (isApiClientError(err) && isRestartCode(err.code)) {
+            setVoiceApiErrorVariant('restart');
+          } else if (voiceApiRetryCountRef.current >= MAX_RETRY_COUNT) {
+            setVoiceApiErrorVariant('restart');
+          } else {
+            setVoiceApiErrorVariant('retry');
+          }
           setGamePhase('voice-api-error');
           return;
         }
@@ -416,20 +454,39 @@ export function useHelpdeskGame(options: {
     const pending = pendingVoiceRequestRef.current;
     if (!pending) return;
 
+    voiceApiRetryCountRef.current += 1;
     setVoiceApiRetrying(true);
 
+    const userId =
+      typeof window !== 'undefined' ? localStorage.getItem('user_id') : null;
+    if (!userId) {
+      // user_id 欠損は localStorage が空のままで回復不能なので即 restart。
+      // restart variant は再試行されないため pendingVoiceRequestRef は触らない。
+      setVoiceApiErrorVariant('restart');
+      setVoiceApiRetrying(false);
+      return;
+    }
+
     try {
-      const userId =
-        typeof window !== 'undefined' ? localStorage.getItem('user_id') : null;
-      if (!userId) throw new Error('user_id not found');
       const result = await postVoiceRespond({
         user_id: userId,
         message: pending.userMessage,
         conversation_history: pending.conversationHistory,
       });
+      // 成功: リトライカウンタをリセットして応答を再生
+      voiceApiRetryCountRef.current = 0;
       addSupportResponseAndSpeak(result.response);
-    } catch {
+    } catch (err: unknown) {
       pendingVoiceRequestRef.current = pending;
+      // 業務エラーコードが「最初からやり直し」系の場合は restart。
+      // MAX_RETRY_COUNT 超過時も restart に切り替える。
+      if (isApiClientError(err) && isRestartCode(err.code)) {
+        setVoiceApiErrorVariant('restart');
+      } else if (voiceApiRetryCountRef.current >= MAX_RETRY_COUNT) {
+        setVoiceApiErrorVariant('restart');
+      } else {
+        setVoiceApiErrorVariant('retry');
+      }
     } finally {
       setVoiceApiRetrying(false);
     }
@@ -627,6 +684,7 @@ export function useHelpdeskGame(options: {
     resetTyping,
     isVoiceSupported: speech.isSupported,
     voiceApiRetrying,
+    voiceApiErrorVariant,
     retryVoiceApi,
     hints: currentHints,
   };


### PR DESCRIPTION
## 概要

ゲーム 2（HelpdeskGameFlow）/ ゲーム 3（GroupChatGameFlow）のエラーハンドリングを `ApiClientError` の業務コード分岐に対応させた。HelpdeskGameFlow は submitGame と postVoiceRespond の 2 系統のエラーを扱う。

兄弟 PR #79（結果画面）/ #80（診断画面）と同じパターン（retryCountRef + isRestartCode + duplicate_submission 自動進行 + handleGoTop での localStorage クリア）に揃えた。

closes #76

## 変更内容

### HelpdeskGameFlow.tsx / GroupChatGameFlow.tsx
- `submitGame` の catch を `isApiClientError` + `isRestartCode` で型ガード
- `duplicate_submission` は内側で吸収して次画面へ自動進行（ゲーム 2 → group-chat、ゲーム 3 → result）
- `retryCountRef` を追加し、`MAX_RETRY_COUNT` 超過で variant: 'restart'
- completed フェーズの error UI を `ErrorScreen`（variant: 'retry' / 'restart'）に置き換え
- `handleGoTop` で `localStorage.user_id` をクリア + BGM 停止してトップへ戻す
- user_id 欠損は即 restart（早期リターン）

### useHelpdeskGame.ts
- `voiceApiErrorVariant` state と `voiceApiRetryCountRef` を追加
- `addSupportResponseAndSpeak` / `retryVoiceApi` の catch を `isApiClientError` + `isRestartCode` で型ガード
- 成功時は `voiceApiRetryCountRef.current = 0` でリセット
- user_id 欠損 / `RESTART_CODES` / リトライ上限超過 で variant='restart' に切替

### voice-api-error フェーズの UI 切替（HelpdeskGameFlow.tsx）
- variant='retry' は既存のゲーム演出に馴染むカスタムオーバーレイを維持
- variant='restart' は共通の `ErrorScreen` に切り替えてトップに戻す
- variant='restart' に切り替わった瞬間に BGM を停止する effect を追加

## エラーコード対応マトリクス

| API | コード | アクション |
|---|---|---|
| submitGame(game2/3) | `RESTART_CODES`（user_not_found / invalid_user_id / incomplete_games） | restart |
| submitGame(game2/3) | `duplicate_submission` | 自動進行（次画面へ） |
| submitGame(game2/3) | その他 | retry（3 回で restart） |
| postVoiceRespond | `RESTART_CODES` | restart |
| postVoiceRespond | その他 | retry（3 回で restart） |

## 関連

- 親 Issue: #59
- 依存（解決済み）: #73, #74, #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正 / 改善**
  * ゲーム送信のエラー分類とリトライ／再開判定を全面的に整理し、失敗時の復旧動作を安定化しました
  * 重複送信は成功扱いで結果画面へ遷移するようになりました
  * リダイレクトタイマーやリトライ回数の管理を強化し、不整合や無限リトライを防止しました

* **ユーザーインターフェース**
  * 完了／エラーオーバーレイを統一し、再試行／再開の選択肢と遷移が一貫して動作するよう改善しました
  * ボイスAPIエラー時の復旧フローとサウンド・BGM制御（トップへの遷移時の動作含む）を改善しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->