### PR TITLE
feat: Next.js Error Boundary を導入し想定外のクラッシュをフォールバック UI に置換

### DIFF
--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+import ErrorScreen from '@/components/common/ErrorScreen';
+
+/**
+ * Next.js App Router の Error Boundary（ページ単位）。
+ *
+ * 想定外のクラッシュ（render 中の TypeError、catch 漏れの Promise reject 等）を
+ * フォールバック UI に置換する最終防衛線。業務エラーは各画面の catch で個別に
+ * `ErrorScreen` を出しているため、ここでは「想定していないエラー」のみが流れてくる。
+ *
+ * - `'use client'` 必須（Next.js の制約）
+ * - `reset()` を呼ぶとエラーが起きたコンポーネントツリーが再 render される（フルリロードではない）
+ *
+ * 参考: https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // 開発者向けログ。本番では Sentry 等に流すことも検討（本 Issue では未対応）
+    console.error(error);
+  }, [error]);
+
+  return <ErrorScreen variant="retry" onRetry={reset} />;
+}

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -27,5 +27,5 @@ export default function Error({
     console.error(error);
   }, [error]);
 
-  return <ErrorScreen variant="retry" onRetry={reset} />;
+  return <ErrorScreen variant="unexpected" onRetry={reset} />;
 }

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -44,54 +44,80 @@ export default function GlobalError({
           textAlign: 'center',
         }}
       >
-        <h2 style={{ fontSize: '20px', fontWeight: 700, margin: '0 0 12px' }}>
-          エラーが発生しました
-        </h2>
-        <p style={{ fontSize: '14px', color: '#4b5563', margin: '0 0 24px' }}>
-          少し時間をおいて、もう一度お試しください。
-        </p>
         {/*
-         * autoFocus: ErrorScreen 側と同様に、表示時にフォーカスを主操作ボタンに移して
-         * キーボード操作・スクリーンリーダーで即座に操作できるようにする
+         * ErrorScreen と同じく、全画面でユーザー操作を促す緊急ダイアログとして
+         * 支援技術に伝えるため alertdialog ロールでラップする。
+         * - role="alertdialog": 緊急性のあるモーダルダイアログ
+         * - aria-modal: 背景操作を抑止することを支援技術に伝える
+         * - aria-labelledby / aria-describedby: 見出しと本文を関連付ける
+         * id は ErrorScreen 側（error-screen-*）と衝突しないよう global-error-* で分けている
          */}
-        <button
-          type="button"
-          autoFocus
-          onClick={reset}
+        <div
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="global-error-title"
+          aria-describedby="global-error-description"
           style={{
-            padding: '12px 32px',
-            fontSize: '14px',
-            fontWeight: 700,
-            color: '#ffffff',
-            backgroundColor: '#2563eb',
-            border: 'none',
-            borderRadius: '9999px',
-            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
           }}
         >
-          もう一度試す
-        </button>
-        {/*
-         * ハードな脱出口。reset() で抜けられない layout 起因の永続的エラー（jotai の
-         * 不正状態など）に備え、フルナビゲーションでトップに戻る導線を併設する。
-         *
-         * ここでは Next.js の <Link> ではなく素の <a> を使う:
-         * - layout.tsx 自体が壊れている前提のため、SPA 内クライアントナビゲーションでは
-         *   壊れた React ツリーをそのまま引きずってしまい脱出できない
-         * - 素の <a> なら確実にフルロードが走り、SPA 内部状態をクリアできる
-         */}
-        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-        <a
-          href="/"
-          style={{
-            marginTop: '16px',
-            fontSize: '13px',
-            color: '#2563eb',
-            textDecoration: 'underline',
-          }}
-        >
-          トップページへ戻る
-        </a>
+          <h2
+            id="global-error-title"
+            style={{ fontSize: '20px', fontWeight: 700, margin: '0 0 12px' }}
+          >
+            エラーが発生しました
+          </h2>
+          <p
+            id="global-error-description"
+            style={{ fontSize: '14px', color: '#4b5563', margin: '0 0 24px' }}
+          >
+            少し時間をおいて、もう一度お試しください。
+          </p>
+          {/*
+           * autoFocus: ErrorScreen 側と同様に、表示時にフォーカスを主操作ボタンに移して
+           * キーボード操作・スクリーンリーダーで即座に操作できるようにする
+           */}
+          <button
+            type="button"
+            autoFocus
+            onClick={reset}
+            style={{
+              padding: '12px 32px',
+              fontSize: '14px',
+              fontWeight: 700,
+              color: '#ffffff',
+              backgroundColor: '#2563eb',
+              border: 'none',
+              borderRadius: '9999px',
+              cursor: 'pointer',
+            }}
+          >
+            もう一度試す
+          </button>
+          {/*
+           * ハードな脱出口。reset() で抜けられない layout 起因の永続的エラー（jotai の
+           * 不正状態など）に備え、フルナビゲーションでトップに戻る導線を併設する。
+           *
+           * ここでは Next.js の <Link> ではなく素の <a> を使う:
+           * - layout.tsx 自体が壊れている前提のため、SPA 内クライアントナビゲーションでは
+           *   壊れた React ツリーをそのまま引きずってしまい脱出できない
+           * - 素の <a> なら確実にフルロードが走り、SPA 内部状態をクリアできる
+           */}
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a
+            href="/"
+            style={{
+              marginTop: '16px',
+              fontSize: '13px',
+              color: '#2563eb',
+              textDecoration: 'underline',
+            }}
+          >
+            トップページへ戻る
+          </a>
+        </div>
       </body>
     </html>
   );

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Next.js App Router の Global Error Boundary（layout.tsx 自体のエラー用）。
+ *
+ * `app/error.tsx` は layout の内側でしか発火しないため、layout.tsx 自体が壊れた場合の
+ * 最終防衛線として `global-error.tsx` が必要になる。layout が機能しない前提のため、
+ * `<html>` / `<body>` を自前で出力する。
+ *
+ * - `'use client'` 必須
+ * - 外部 CSS（globals.css / Tailwind）が読めない可能性があるため、スタイルはインラインで完結させる
+ * - `ErrorScreen` を使わない（Tailwind 依存のため、ここでは fallback の fallback として使えない）
+ *
+ * 参考: https://nextjs.org/docs/app/building-your-application/routing/error-handling
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100dvh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '24px',
+          backgroundColor: '#ffffff',
+          color: '#111827',
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+          textAlign: 'center',
+        }}
+      >
+        <h2 style={{ fontSize: '20px', fontWeight: 700, margin: '0 0 12px' }}>
+          エラーが発生しました
+        </h2>
+        <p style={{ fontSize: '14px', color: '#4b5563', margin: '0 0 24px' }}>
+          少し時間をおいて、もう一度お試しください。
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            padding: '12px 32px',
+            fontSize: '14px',
+            fontWeight: 700,
+            color: '#ffffff',
+            backgroundColor: '#2563eb',
+            border: 'none',
+            borderRadius: '9999px',
+            cursor: 'pointer',
+          }}
+        >
+          もう一度試す
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -50,8 +50,13 @@ export default function GlobalError({
         <p style={{ fontSize: '14px', color: '#4b5563', margin: '0 0 24px' }}>
           少し時間をおいて、もう一度お試しください。
         </p>
+        {/*
+         * autoFocus: ErrorScreen 側と同様に、表示時にフォーカスを主操作ボタンに移して
+         * キーボード操作・スクリーンリーダーで即座に操作できるようにする
+         */}
         <button
           type="button"
+          autoFocus
           onClick={reset}
           style={{
             padding: '12px 32px',
@@ -66,6 +71,27 @@ export default function GlobalError({
         >
           もう一度試す
         </button>
+        {/*
+         * ハードな脱出口。reset() で抜けられない layout 起因の永続的エラー（jotai の
+         * 不正状態など）に備え、フルナビゲーションでトップに戻る導線を併設する。
+         *
+         * ここでは Next.js の <Link> ではなく素の <a> を使う:
+         * - layout.tsx 自体が壊れている前提のため、SPA 内クライアントナビゲーションでは
+         *   壊れた React ツリーをそのまま引きずってしまい脱出できない
+         * - 素の <a> なら確実にフルロードが走り、SPA 内部状態をクリアできる
+         */}
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a
+          href="/"
+          style={{
+            marginTop: '16px',
+            fontSize: '13px',
+            color: '#2563eb',
+            textDecoration: 'underline',
+          }}
+        >
+          トップページへ戻る
+        </a>
       </body>
     </html>
   );

--- a/frontend/src/components/common/ErrorScreen.tsx
+++ b/frontend/src/components/common/ErrorScreen.tsx
@@ -1,34 +1,47 @@
 'use client';
 
 /**
- * 通信エラー / 業務エラー時に表示する全画面エラー UI。
+ * 通信エラー / 業務エラー / 想定外クラッシュ時に表示する全画面エラー UI。
  *
- * - `variant: 'retry'`  … 一時的な通信エラー想定。リトライボタンで同じ操作を再試行する
- * - `variant: 'restart'` … `RESTART_CODES`（user_not_found 等）想定。トップから最初の操作をやり直してもらう
- *
- * 後続 Issue で各画面の catch から呼び出す。本 Issue ではコンポーネント本体のみ実装する。
+ * - `variant: 'retry'`      … 一時的な通信エラー想定。リトライボタンで同じ操作を再試行する
+ * - `variant: 'restart'`    … `RESTART_CODES`（user_not_found 等）想定。トップから最初の操作をやり直してもらう
+ * - `variant: 'unexpected'` … Next.js Error Boundary（`app/error.tsx`）からの想定外クラッシュ用。
+ *                              通信文脈に限定しない中立的な文言で誤解を防ぐ
  */
 
 type ErrorScreenProps =
   | { variant: 'retry'; onRetry: () => void }
-  | { variant: 'restart'; onGoTop: () => void };
+  | { variant: 'restart'; onGoTop: () => void }
+  | { variant: 'unexpected'; onRetry: () => void };
+
+const VARIANT_TEXT = {
+  retry: {
+    title: '通信に失敗しました',
+    description: '少し時間をおいて、もう一度お試しください。',
+    buttonLabel: 'もう一度試す',
+  },
+  restart: {
+    title: '最初からやり直してください',
+    description: 'セッションが切れている可能性があります。',
+    buttonLabel: 'トップへ戻る',
+  },
+  unexpected: {
+    title: '予期しないエラーが発生しました',
+    description:
+      'もう一度試してもうまくいかない場合は、最初からやり直してください。',
+    buttonLabel: 'もう一度試す',
+  },
+} as const;
 
 export default function ErrorScreen(props: ErrorScreenProps) {
-  const isRetry = props.variant === 'retry';
-
-  const title = isRetry ? '通信に失敗しました' : '最初からやり直してください';
-
-  const description = isRetry
-    ? '少し時間をおいて、もう一度お試しください。'
-    : 'セッションが切れている可能性があります。';
-
-  const buttonLabel = isRetry ? 'もう一度試す' : 'トップへ戻る';
+  const { title, description, buttonLabel } = VARIANT_TEXT[props.variant];
 
   const handleClick = () => {
-    if (props.variant === 'retry') {
-      props.onRetry();
-    } else {
+    if (props.variant === 'restart') {
       props.onGoTop();
+    } else {
+      // retry / unexpected は同じ「再試行」セマンティクス
+      props.onRetry();
     }
   };
 


### PR DESCRIPTION
## 概要

Next.js App Router の Error Boundary 機能（`error.tsx` / `global-error.tsx`）を導入し、想定外のクラッシュ（render 中の TypeError、catch 漏れの Promise reject 等）をフォールバック UI に置換する。業務エラーは #74〜#76 で各画面の catch から `ErrorScreen` を出すように実装済みのため、本 PR は最終防衛線として機能する。

## 変更内容

- `frontend/src/app/error.tsx` 新規作成
  - ページ単位の Error Boundary
  - `ErrorScreen` の variant: `'retry'` を再利用、`onRetry={reset}` で復帰可能
  - `useEffect` で `console.error(error)` を出力
- `frontend/src/app/global-error.tsx` 新規作成
  - layout.tsx 自体のエラー用（最終防衛線）
  - 外部 CSS が読めない可能性があるため `<html>` / `<body>` を含めたインラインスタイルで最低限のフォールバック UI を提示
  - `ErrorScreen` は使わない（Tailwind 依存のため fallback の fallback として使えない）

## 動作確認方法

1. 任意のページコンポーネント（例: `frontend/src/app/page.tsx`）の関数本体先頭に `throw new Error('test')` を仕込む
2. 該当ページを開いてフォールバック UI が表示されることを確認
3. 「もう一度試す」ボタンで再 render が走ることを確認（仕込んだ throw を消してから検証）

## 完了条件

- [x] `app/error.tsx` が任意のページの render エラーをフォールバック UI で受ける
- [x] `app/global-error.tsx` が layout.tsx 自体のエラーで最低限のフォールバック UI を出す
- [x] フォールバック UI からリロード or reset でアプリに戻れる
- [ ] 動作確認: 任意のコンポーネントで `throw new Error('test')` してフォールバック UI が出ることを確認（PR レビュー時）

closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エラーハンドリング機能を強化しました。アプリケーション全体のエラーを検出し、ユーザーフレンドリーなエラー画面を表示します。エラーが発生した場合、ユーザーは「もう一度試す」ボタンから操作を再開できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->