### PR TITLE
トップページの遊び方 説明ボタンとポップアップの雛形追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -60,6 +60,8 @@ const SparklesExplosion = () => {
 export default function TopPage() {
   const router = useRouter();
   const [showExplosion, setShowExplosion] = useState(false);
+  const [showHowToPlay, setShowHowToPlay] = useState(false);
+  const [howToPlayPage, setHowToPlayPage] = useState(1);
 
   // BGMを保持するための Ref
   const bgmRef = useRef<HTMLAudioElement | null>(null);
@@ -110,6 +112,41 @@ export default function TopPage() {
     }, 800);
   };
 
+  const openHowToPlay = () => {
+    setHowToPlayPage(1);
+    setShowHowToPlay(true);
+  };
+
+  const closeHowToPlay = () => {
+    setShowHowToPlay(false);
+  };
+
+  // あそびかたの内容
+  const howToPlaySteps = [
+    {
+      title: 'Real Youとは？',
+      subtitle: '3つのミニゲームで本当の性格を知ろう！！',
+      bullets: [
+        '3つのミニゲームを通して、本当の性格に迫る診断です。',
+        'ひとつずつじっくり答えていきましょう。',
+      ],
+    },
+    {
+      title: '所要時間は約5分！',
+      subtitle: 'スキマ時間でサクッと診断⭐︎',
+      bullets: ['短時間で遊べるので、休憩時間や移動中にもおすすめです！'],
+    },
+    {
+      title: '始める前に',
+      subtitle: '注意事項をチェック⚠️',
+      bullets: [
+        'マイクを使用します🎤',
+        'BGM・効果音が流れます🎵',
+        'イヤホン推奨🎧',
+      ],
+    },
+  ];
+
   return (
     <div
       className="flex h-dvh w-full flex-col items-center justify-center overflow-hidden bg-top-pattern"
@@ -129,10 +166,10 @@ export default function TopPage() {
           alt="Real You -本当の私じゃだめですか？-"
           width={800}
           height={500}
-          className="max-h-[65vh] w-auto object-contain drop-shadow-2xl"
+          className="max-h-[65vh] w-auto object-contain drop-shadow-2xl animate-[fadeInUp_0.5s_ease-out]"
         />
 
-        <div className="relative">
+        <div className="relative flex flex-col items-center gap-4">
           <button
             onClick={handleStartClick}
             className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
@@ -146,8 +183,107 @@ export default function TopPage() {
             />
           </button>
 
+          <button
+            onClick={openHowToPlay}
+            className="rounded-full border border-black bg-white/90 px-6 py-3 text-sm font-bold text-black shadow-md transition hover:bg-white active:scale-95"
+          >
+            あそびかた
+          </button>
+
           {showExplosion && <SparklesExplosion />}
         </div>
+
+        {showHowToPlay && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 py-6"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="how-to-play-title"
+            onClick={closeHowToPlay}
+          >
+            {/* ポップアップ本体 */}
+            <div
+              className="relative w-full max-w-xl min-h-[460px] rounded-[24px] border-[6px] border-black bg-white p-5 shadow-[8px_8px_0_0_#000] animate-[fadeInUp_0.35s_ease-out] flex flex-col mx-auto"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <button
+                type="button"
+                onClick={closeHowToPlay}
+                className="absolute top-3 right-3 inline-flex rounded-full border border-zinc-900 px-3 py-1.5 text-sm font-bold text-zinc-900 transition hover:bg-zinc-100"
+              >
+                ✕
+              </button>
+
+              {/* 進行状況バー */}
+              <div className="mb-3">
+                <div className="mb-2 flex items-center justify-between text-sm font-bold text-zinc-700">
+                  <span>
+                    {howToPlayPage} / {howToPlaySteps.length}
+                  </span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-zinc-200">
+                  <div
+                    className="h-full rounded-full bg-black transition-all duration-300"
+                    style={{
+                      width: `${(howToPlayPage / howToPlaySteps.length) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* メインコンテンツ */}
+              <div className="flex-1 flex flex-col justify-center">
+                <h2
+                  id="how-to-play-title"
+                  className="mb-4 text-3xl font-bold leading-relaxed text-center"
+                >
+                  {howToPlaySteps[howToPlayPage - 1].title}
+                </h2>
+
+                <div className="mt-8">
+                  <p className="mb-4 text-base font-semibold text-zinc-600 leading-relaxed">
+                    {howToPlaySteps[howToPlayPage - 1].subtitle}
+                  </p>
+
+                  <ul className="min-h-[130px] space-y-3 text-base leading-relaxed text-[#111] list-disc pl-5">
+                    {howToPlaySteps[howToPlayPage - 1].bullets.map(
+                      (line, index) => (
+                        <li key={index}>{line}</li>
+                      )
+                    )}
+                  </ul>
+                </div>
+              </div>
+
+              {/* ナビゲーションボタン */}
+              <div className="mt-5 flex min-h-[64px] items-center justify-center gap-4">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setHowToPlayPage((page) => Math.max(1, page - 1))
+                  }
+                  disabled={howToPlayPage === 1}
+                  className="inline-flex rounded-full border border-zinc-900 px-8 py-3 text-base font-bold transition disabled:cursor-not-allowed disabled:opacity-40 hover:bg-zinc-100"
+                >
+                  前へ
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (howToPlayPage < howToPlaySteps.length) {
+                      setHowToPlayPage((page) => page + 1);
+                    } else {
+                      closeHowToPlay();
+                    }
+                  }}
+                  className="inline-flex rounded-full bg-black px-8 py-3 text-base font-bold text-white transition hover:bg-zinc-900"
+                >
+                  {howToPlayPage < howToPlaySteps.length ? '次へ' : '完了'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
トップページの遊び方 説明ボタンとポップアップの雛形追加

## 変更内容
-スタートボタンの下に新たにあそびかた説明用のボタンを-配置する
-ボタンを押した後、説明用のポップアップが表示される
-説明の下の「前へ」・「次へ」ボタンで操作
-右上には閉じるボタン「×」
-1枚目にはこのゲームの簡単な説明、2枚目には所要時間、3枚目にはマイクなどの注意事項を掲載する

## 関連 Issue
closes #82 

## 動作確認
<img width="581" height="466" alt="スクリーンショット 2026-05-05 0 40 42" src="https://github.com/user-attachments/assets/7c35c9cb-465d-4b97-992b-1b36cc03dd8f" />
<img width="583" height="470" alt="スクリーンショット 2026-05-05 0 40 51" src="https://github.com/user-attachments/assets/3923d784-5712-43b3-9274-50a646a177fe" />
<img width="579" height="465" alt="スクリーンショット 2026-05-05 0 40 59" src="https://github.com/user-attachments/assets/24840cd4-8e6b-4128-b5e3-99cd745e67b9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲームの遊び方を段階的に説明する「あそびかた」モーダルを追加。進捗バーを表示し、複数ステップを前後のボタンで移動可能。モーダルは任意の時点で閉じられます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->