### PR TITLE
refactor: errorCodeSchema の値列挙を ERROR_CODES 単一ソースに集約

### DIFF
--- a/backend/src/schemas/errorCodes.ts
+++ b/backend/src/schemas/errorCodes.ts
@@ -25,35 +25,39 @@ export const ERROR_CODES = {
 export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];
 
 /**
- * エラーコードの zod スキーマ。
- * 仕様書で列挙されたコードのみに縛るため、`ERROR_CODES` の値を z.literal に展開する。
- * 値を追加する際は `ERROR_CODES` と本配列の両方を更新すること。
+ * `ERROR_CODES` の全値を 1 箇所に集約した配列。
  *
- * OpenAPI では `.openapi({ enum: [...] })` で enum として出力する。
- * z.union<z.literal> の構成から OpenAPI 側で `anyOf` に落ちてしまうのを避け、
- * 単一の string enum として Swagger UI / IDE 補完で扱いやすくするため。
+ * `z.literal(...)` の引数と `.openapi({ enum: [...] })` の両方から参照することで、
+ * 値の追加時に `ERROR_CODES` のみを更新すれば
+ * 型と OpenAPI enum が自動で追随する（二重管理を解消）。
+ *
+ * `Object.values(ERROR_CODES)` の戻り値型は `ErrorCode[]`（9 個の文字列リテラル union 配列）で、
+ * `z.literal<const T extends ReadonlyArray<Literal>>(value: T)` の T[number] 推論により
+ * 内部型は `'invalid_request' | 'invalid_mbti' | ... | 'server_error'` の union が維持される。
  */
-const errorCodeSchema = z
-    .union([
-        z.literal(ERROR_CODES.INVALID_REQUEST),
-        z.literal(ERROR_CODES.INVALID_MBTI),
-        z.literal(ERROR_CODES.INVALID_ANSWERS),
-        z.literal(ERROR_CODES.INVALID_USER_ID),
-        z.literal(ERROR_CODES.INVALID_GAME_TYPE),
-        z.literal(ERROR_CODES.INCOMPLETE_GAMES),
-        z.literal(ERROR_CODES.USER_NOT_FOUND),
-        z.literal(ERROR_CODES.DUPLICATE_SUBMISSION),
-        z.literal(ERROR_CODES.SERVER_ERROR),
-    ])
-    .openapi({
-        description:
-            'API 設計書「エラーレスポンス」で規定された業務エラーコード。 ' +
-            '400: invalid_mbti / invalid_answers / invalid_request / invalid_user_id / ' +
-            'invalid_game_type / incomplete_games、404: user_not_found、' +
-            '409: duplicate_submission、500: server_error。',
-        enum: Object.values(ERROR_CODES),
-        example: ERROR_CODES.INVALID_REQUEST,
-    });
+const ERROR_CODE_VALUES = Object.values(ERROR_CODES);
+
+/**
+ * エラーコードの zod スキーマ。
+ *
+ * `ERROR_CODES` 定数を唯一の真実とし、`ERROR_CODE_VALUES` 経由で
+ * zod スキーマと OpenAPI enum の両方に展開する。
+ *
+ * NOTE: zod v4 の `z.literal(array)` は内部的に `'invalid_request' | ...` の literal union として
+ * 振る舞うが、`@asteasolutions/zod-to-openapi` v8.5 の `LiteralTransformer` は
+ * multi-value literal を `enum: [values[0]]`（先頭 1 要素のみ）にしか展開しない。
+ * よって OpenAPI で正しい enum を出すには `.openapi({ enum: [...] })` で全値を
+ * 明示する必要がある。値のソースは同じ `ERROR_CODE_VALUES` なので二重管理にはならない。
+ */
+const errorCodeSchema = z.literal(ERROR_CODE_VALUES).openapi({
+    description:
+        'API 設計書「エラーレスポンス」で規定された業務エラーコード。 ' +
+        '400: invalid_mbti / invalid_answers / invalid_request / invalid_user_id / ' +
+        'invalid_game_type / incomplete_games、404: user_not_found、' +
+        '409: duplicate_submission、500: server_error。',
+    enum: ERROR_CODE_VALUES,
+    example: ERROR_CODES.INVALID_REQUEST,
+});
 
 /**
  * API 共通エラーレスポンス。

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -392,7 +392,7 @@ export interface components {
             /**
              * @description API 設計書「エラーレスポンス」で規定された業務エラーコード。 400: invalid_mbti / invalid_answers / invalid_request / invalid_user_id / invalid_game_type / incomplete_games、404: user_not_found、409: duplicate_submission、500: server_error。
              * @example invalid_request
-             * @enum {unknown}
+             * @enum {string}
              */
             error: "invalid_request" | "invalid_mbti" | "invalid_answers" | "invalid_user_id" | "invalid_game_type" | "incomplete_games" | "user_not_found" | "duplicate_submission" | "server_error";
             /**


### PR DESCRIPTION
## 概要

`backend/src/schemas/errorCodes.ts` の `errorCodeSchema` で発生していた、runtime 側（`z.union` で 9 個の `z.literal` を手動列挙）と OpenAPI 側（`.openapi.enum: Object.values(ERROR_CODES)`）の二重管理を解消する。

`ERROR_CODES` 定数を単一ソースとし、`Object.values(ERROR_CODES)` を `z.literal()` と `.openapi({ enum })` の両方から参照する形に統一。Issue #19 の `gameTypeSchema`（PR #92）で確立したパターンの横展開。

## 変更内容

### `backend/src/schemas/errorCodes.ts`
- `ERROR_CODE_VALUES = Object.values(ERROR_CODES)` 定数を導入
- `errorCodeSchema` を `z.union<z.literal>` から `z.literal(ERROR_CODE_VALUES).openapi({ enum: ERROR_CODE_VALUES, ... })` に書き換え
- JSDoc を `gameTypeSchema` と同じ調子で書き換え（`zod-to-openapi` v8.5 の `LiteralTransformer` 制約と `.openapi.enum` override が必要な理由を記述）

### `frontend/src/lib/api/generated.ts`
- `npm run gen:api-types` で再生成
- 差分は `@enum {unknown}` → `@enum {string}` の JSDoc 注釈の改善のみ
- `ApiError.error` の union 型自体は変化なし（9 個の文字列リテラル union を維持）

## 完了条件チェック

- [x] 値の列挙が `Object.values(ERROR_CODES)` 1 箇所にまとまっている
- [x] `ApiError.error` の TS 型が文字列リテラル union を維持（`string` に広がらない）
- [x] `as` を使った型アサーションに依存しない
- [x] OpenAPI ドキュメント生成時に全 9 個が `enum` として出力される
- [x] FE の `generated.ts` を再生成し、型が変わっていない（または改善されている）

closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エラー処理スキーマの内部実装を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->