### PR TITLE
refactor: BE 結果スキーマを配列形式に変更

### DIFF
--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -103,11 +103,12 @@ export function buildPhaseSummaries(
     }
 
     // 配列形式（Phase 1 / Issue #97）。game_id は Phase 3（registry 導入）で
-    // 正式定義予定の文字列 ID を先取りで使用している。配列順は NORMAL_FLOW
-    // （terms_game → helpdesk_game → group_chat_game）に揃える。
+    // 正式定義予定の文字列 ID を先取りで使用している。配列順は
+    // terms_game → helpdesk_game → group_chat_game の通常フロー順
+    // （Phase 3 で `analysis/registry.ts` の `NORMAL_FLOW` 定数として正式定義予定）。
     return [
-        { game_id: 'terms_game', summary: phase1Text },
-        { game_id: 'helpdesk_game', summary: phase2Text },
-        { game_id: 'group_chat_game', summary: phase3Text },
+        { game_id: 'terms_game' as const, summary: phase1Text },
+        { game_id: 'helpdesk_game' as const, summary: phase2Text },
+        { game_id: 'group_chat_game' as const, summary: phase3Text },
     ];
 }

--- a/backend/src/analysis/phaseSummaryBuilder.ts
+++ b/backend/src/analysis/phaseSummaryBuilder.ts
@@ -102,9 +102,12 @@ export function buildPhaseSummaries(
         phase3Text = `${socialText}、${speedText}`;
     }
 
-    return {
-        phase_1: phase1Text,
-        phase_2: phase2Text,
-        phase_3: phase3Text,
-    };
+    // 配列形式（Phase 1 / Issue #97）。game_id は Phase 3（registry 導入）で
+    // 正式定義予定の文字列 ID を先取りで使用している。配列順は NORMAL_FLOW
+    // （terms_game → helpdesk_game → group_chat_game）に揃える。
+    return [
+        { game_id: 'terms_game', summary: phase1Text },
+        { game_id: 'helpdesk_game', summary: phase2Text },
+        { game_id: 'group_chat_game', summary: phase3Text },
+    ];
 }

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -394,22 +394,36 @@ const feedback = generateFeedback(scores, gaps);
     scores: scores,
     baseline_scores: baseline_scores,
     gaps: gaps,
-    game_breakdown: {
-      game_1: { caution: g1.caution, logic: g1.logic, calmness: g1.calmness },
-      game_2: { positivity: g2.positivity, calmness: g2.calmness, logic: g2.logic },
-      game_3: { cooperativeness: g3.cooperativeness, positivity: g3.positivity, caution: g3.caution }
-    },
+    // game_breakdown は配列形式（Phase 1 / Issue #97）。
+    // game_id は Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している。
+    // 配列順は NORMAL_FLOW（terms_game → helpdesk_game → group_chat_game）に揃える。
+    game_breakdown: [
+      {
+        game_id: "terms_game",
+        scores: { caution: g1.caution, logic: g1.logic, calmness: g1.calmness },
+      },
+      {
+        game_id: "helpdesk_game",
+        scores: { positivity: g2.positivity, calmness: g2.calmness, logic: g2.logic },
+      },
+      {
+        game_id: "group_chat_game",
+        scores: { cooperativeness: g3.cooperativeness, positivity: g3.positivity, caution: g3.caution },
+      },
+    ],
     accuracy_score: accuracy_score,
     feedback: feedback,
-    phase_summaries: phaseSummaries, // buildPhaseSummaries関数で作ったテキストを渡す
-    
-    details: {
-      game_1: {
+    phase_summaries: phaseSummaries, // buildPhaseSummaries関数で作ったテキストを渡す（配列形式）
+
+    // details も配列形式（Phase 1 / Issue #97）。配列順は game_breakdown と揃える。
+    details: [
+      {
+        game_id: "terms_game",
         title: "利用規約ゲーム",
         feature_scores: [
           { axis: "caution", name: "慎重さ", score: g1.caution },
           { axis: "logic", name: "論理性", score: g1.logic },
-          { axis: "calmness", name: "冷静さ", score: g1.calmness }
+          { axis: "calmness", name: "冷静さ", score: g1.calmness },
         ],
         // g1.averageSpeed / g1.reversalCount は calculateGame1() 内で scrollEvents から算出済み
         // （仕様書上、FE は scrollEvents のみ送信する設計のため、raw_data には scrollMetrics は無い）
@@ -420,36 +434,38 @@ const feedback = generateFeedback(scores, gaps);
           { label: "チェック変更(回)", user: g1.changedCount, average: 3.2, category: "input" },
           { label: "逆行確認(回)", user: g1.reversalCount ?? 0, average: 2.1, category: "scroll" },
           { label: "マウスブレ(px)", user: game1Raw?.popupStats?.mouseJitter ?? 0, average: 12.0, category: "mouse" },
-          { label: "無駄クリック(回)", user: game1Raw?.popupStats?.clickCount ?? 0, average: 1.5, category: "mouse" }
-        ]
+          { label: "無駄クリック(回)", user: game1Raw?.popupStats?.clickCount ?? 0, average: 1.5, category: "mouse" },
+        ],
       },
-      game_2: {
+      {
+        game_id: "helpdesk_game",
         title: "AIカスタマーサポート",
         feature_scores: [
           { axis: "positivity", name: "積極性", score: g2.positivity },
           { axis: "calmness", name: "冷静さ", score: g2.calmness },
-          { axis: "logic", name: "論理性", score: g2.logic }
+          { axis: "logic", name: "論理性", score: g2.logic },
         ],
         metrics: [
           { label: "反応潜時(ms)", user: Math.round(g2.avgReact ?? 0), average: 2500, category: "time" },
           { label: "発話時間(秒)", user: Number(((g2.totalSpeech ?? 0) / 1000).toFixed(1)), average: 4.2, category: "time" },
           { label: "平均音量(dB)", user: Number((g2.avgVolume ?? 0).toFixed(1)), average: -25.0, category: "voice" },
-          { label: "論理的接続詞(回)", user: g2.logicWordsCount ?? 0, average: 0.5, category: "logic" }
-        ]
+          { label: "論理的接続詞(回)", user: g2.logicWordsCount ?? 0, average: 0.5, category: "logic" },
+        ],
       },
-      game_3: {
+      {
+        game_id: "group_chat_game",
         title: "空気読みグループチャット",
         feature_scores: [
           { axis: "cooperativeness", name: "協調性", score: g3.cooperativeness },
-          { axis: "positivity", name: "積極性", score: g3.positivity }
+          { axis: "positivity", name: "積極性", score: g3.positivity },
         ],
         metrics: [
           { label: "同調率(%)", user: Math.round(((g3.conformCount ?? 0) / (game3Raw?.stages?.length || 1)) * 100), average: 75, category: "social" },
           { label: "反応潜時(ms)", user: Math.round(g3.avgReact ?? 0), average: 3500, category: "time" },
           { label: "本音ホバー(回)", user: game3Raw?.hoveredOptions ?? 0, average: 2.4, category: "mouse" },
-          { label: "譲り合い待機(ms)", user: game3Raw?.typingIndicatorReactTimeMs ?? 0, average: 2000, category: "time" }
-        ]
-      }
-    }
+          { label: "譲り合い待機(ms)", user: game3Raw?.typingIndicatorReactTimeMs ?? 0, average: 2000, category: "time" },
+        ],
+      },
+    ],
 };
 }

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -396,18 +396,19 @@ const feedback = generateFeedback(scores, gaps);
     gaps: gaps,
     // game_breakdown は配列形式（Phase 1 / Issue #97）。
     // game_id は Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している。
-    // 配列順は NORMAL_FLOW（terms_game → helpdesk_game → group_chat_game）に揃える。
+    // 配列順は terms_game → helpdesk_game → group_chat_game の通常フロー順
+    // （Phase 3 で `analysis/registry.ts` の `NORMAL_FLOW` 定数として正式定義予定）。
     game_breakdown: [
       {
-        game_id: "terms_game",
+        game_id: "terms_game" as const,
         scores: { caution: g1.caution, logic: g1.logic, calmness: g1.calmness },
       },
       {
-        game_id: "helpdesk_game",
+        game_id: "helpdesk_game" as const,
         scores: { positivity: g2.positivity, calmness: g2.calmness, logic: g2.logic },
       },
       {
-        game_id: "group_chat_game",
+        game_id: "group_chat_game" as const,
         scores: { cooperativeness: g3.cooperativeness, positivity: g3.positivity, caution: g3.caution },
       },
     ],
@@ -415,10 +416,11 @@ const feedback = generateFeedback(scores, gaps);
     feedback: feedback,
     phase_summaries: phaseSummaries, // buildPhaseSummaries関数で作ったテキストを渡す（配列形式）
 
-    // details も配列形式（Phase 1 / Issue #97）。配列順は game_breakdown と揃える。
+    // details も配列形式（Phase 1 / Issue #97）。配列順は game_breakdown と揃える
+    // （terms_game → helpdesk_game → group_chat_game の通常フロー順）。
     details: [
       {
-        game_id: "terms_game",
+        game_id: "terms_game" as const,
         title: "利用規約ゲーム",
         feature_scores: [
           { axis: "caution", name: "慎重さ", score: g1.caution },
@@ -438,7 +440,7 @@ const feedback = generateFeedback(scores, gaps);
         ],
       },
       {
-        game_id: "helpdesk_game",
+        game_id: "helpdesk_game" as const,
         title: "AIカスタマーサポート",
         feature_scores: [
           { axis: "positivity", name: "積極性", score: g2.positivity },
@@ -453,7 +455,7 @@ const feedback = generateFeedback(scores, gaps);
         ],
       },
       {
-        game_id: "group_chat_game",
+        game_id: "group_chat_game" as const,
         title: "空気読みグループチャット",
         feature_scores: [
           { axis: "cooperativeness", name: "協調性", score: g3.cooperativeness },

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -280,7 +280,8 @@ export const voiceRespondResponseExample = {
  * 実際のレスポンスでは複数要素の配列になる点に注意。
  *
  * game_id は Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している。
- * 配列順は NORMAL_FLOW（terms_game → helpdesk_game → group_chat_game）に揃える。
+ * 配列順は terms_game → helpdesk_game → group_chat_game の通常フロー順
+ * （Phase 3 で `analysis/registry.ts` の `NORMAL_FLOW` 定数として正式定義予定）。
  */
 export const resultsResponseExample = {
     user_id: SAMPLE_USER_ID,

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -275,9 +275,12 @@ export const voiceRespondResponseExample = {
  * （Swagger UI の閲覧者が実際のレスポンスと突合しても齟齬が出ないようにするため）。
  * 値自体は「形を示すための代表値」で、特定ユーザーの実測値ではない。
  *
- * `details.game_*.feature_scores` は実装側では複数軸（game_1: 3 軸 / game_2: 3 軸 /
- * game_3: 2 軸）を返す。本 example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、
+ * `details[*].feature_scores` は実装側では複数軸（terms_game: 3 軸 / helpdesk_game: 3 軸 /
+ * group_chat_game: 2 軸）を返す。本 example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、
  * 実際のレスポンスでは複数要素の配列になる点に注意。
+ *
+ * game_id は Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している。
+ * 配列順は NORMAL_FLOW（terms_game → helpdesk_game → group_chat_game）に揃える。
  */
 export const resultsResponseExample = {
     user_id: SAMPLE_USER_ID,
@@ -310,26 +313,27 @@ export const resultsResponseExample = {
         cooperativeness: 5,
         positivity: -5,
     },
-    game_breakdown: {
-        game_1: { caution: 45, logic: 75, calmness: 55 },
-        game_2: { positivity: 70, calmness: 55, logic: 75 },
-        game_3: { cooperativeness: 60, positivity: 70, caution: 45 },
-    },
+    game_breakdown: [
+        { game_id: 'terms_game', scores: { caution: 45, logic: 75, calmness: 55 } },
+        { game_id: 'helpdesk_game', scores: { positivity: 70, calmness: 55, logic: 75 } },
+        { game_id: 'group_chat_game', scores: { cooperativeness: 60, positivity: 70, caution: 45 } },
+    ],
     feedback: {
         title: '直感ドリブン',
         description: 'あなたは論理よりも直感を優先して意思決定する傾向があります。',
         gap_point: '論理性',
     },
     accuracy_score: 78,
-    phase_summaries: {
-        phase_1: '規約を爆速でスクロールし、最後まで読まずに同意しました。',
-        phase_2: 'AI の理不尽な対応に感情的に反応する場面が見られました。',
-        phase_3: 'グループの空気を読みつつ、自分の意見も主張していました。',
-    },
-    details: {
-        // タイトル文字列は analysis/scoreCalculator.ts の実装値に合わせる
-        // （game_2: 'AIカスタマーサポート' / game_3: '空気読みグループチャット'）
-        game_1: {
+    phase_summaries: [
+        { game_id: 'terms_game', summary: '規約を爆速でスクロールし、最後まで読まずに同意しました。' },
+        { game_id: 'helpdesk_game', summary: 'AI の理不尽な対応に感情的に反応する場面が見られました。' },
+        { game_id: 'group_chat_game', summary: 'グループの空気を読みつつ、自分の意見も主張していました。' },
+    ],
+    // タイトル文字列は analysis/scoreCalculator.ts の実装値に合わせる
+    // （helpdesk_game: 'AIカスタマーサポート' / group_chat_game: '空気読みグループチャット'）
+    details: [
+        {
+            game_id: 'terms_game',
             title: '利用規約ゲーム',
             feature_scores: [
                 { axis: 'caution', name: '慎重さ', score: 45 },
@@ -338,7 +342,8 @@ export const resultsResponseExample = {
                 { label: '読了速度(px/s)', user: 2500, average: 800, category: 'scroll' },
             ],
         },
-        game_2: {
+        {
+            game_id: 'helpdesk_game',
             title: 'AIカスタマーサポート',
             feature_scores: [
                 { axis: 'positivity', name: '積極性', score: 70 },
@@ -347,7 +352,8 @@ export const resultsResponseExample = {
                 { label: '発話数', user: 8, average: 5, category: 'message' },
             ],
         },
-        game_3: {
+        {
+            game_id: 'group_chat_game',
             title: '空気読みグループチャット',
             feature_scores: [
                 { axis: 'cooperativeness', name: '協調性', score: 60 },
@@ -356,7 +362,7 @@ export const resultsResponseExample = {
                 { label: '発言数', user: 4, average: 3, category: 'message' },
             ],
         },
-    },
+    ],
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -46,21 +46,33 @@ export const resultsParamsSchema = z.object({
 const partialBaselineScoresSchema = baselineScoresSchema.partial();
 
 /**
- * ゲームごとのスコア内訳。
- * 各ゲームキー（game_1 / game_2 / game_3）は optional。
+ * ゲームごとのスコア内訳（配列形式）。
+ *
+ * 各要素は `{ game_id, scores }` の構造で、`game_id` はゲームを識別する文字列
+ * （現状は 'terms_game' / 'helpdesk_game' / 'group_chat_game'）。
+ * 配列化の理由は将来のゲーム追加・差し替えに耐えるため（Phase 1 / Issue #97）。
+ *
+ * `scores` は当該ゲームで測定する軸のみを含む（例: terms_game は caution / logic / calmness のみ）。
  */
 export const gameBreakdownSchema = registry.register(
     'GameBreakdown',
     z
-        .object({
-            game_1: partialBaselineScoresSchema.optional(),
-            game_2: partialBaselineScoresSchema.optional(),
-            game_3: partialBaselineScoresSchema.optional(),
-        })
+        .array(
+            z.object({
+                game_id: z.string().openapi({
+                    description:
+                        'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
+                }),
+                scores: partialBaselineScoresSchema.openapi({
+                    description:
+                        '当該ゲームで測定した軸のスコア（測定軸のみ含むため 5 軸すべては揃わない）',
+                }),
+            }),
+        )
         .openapi({
             description:
-                'ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため ' +
-                '5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）',
+                'ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため ' +
+                '5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）',
             example: resultsResponseExample.game_breakdown,
         }),
 );
@@ -92,24 +104,27 @@ export const diagnosisFeedbackSchema = registry.register(
 );
 
 /**
- * 各フェーズ（ゲーム）の振り返りテキスト。
+ * 各ゲーム終了後の行動要約（配列形式）。
+ *
+ * 各要素は `{ game_id, summary }` で、`game_id` は gameBreakdown と同じ識別子。
+ * 配列化の理由は gameBreakdown と同じ（将来のゲーム追加・差し替え対応 / Phase 1）。
  */
 export const phaseSummariesSchema = registry.register(
     'PhaseSummaries',
     z
-        .object({
-            phase_1: z.string().openapi({
-                description: 'Game 1（利用規約）の行動要約',
+        .array(
+            z.object({
+                game_id: z.string().openapi({
+                    description:
+                        'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
+                }),
+                summary: z.string().openapi({
+                    description: '当該ゲームの行動を日本語テキストで振り返ったサマリー',
+                }),
             }),
-            phase_2: z.string().openapi({
-                description: 'Game 2（AI カスタマーサポート）の行動要約',
-            }),
-            phase_3: z.string().openapi({
-                description: 'Game 3（グループチャット）の行動要約',
-            }),
-        })
+        )
         .openapi({
-            description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリー',
+            description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列',
             example: resultsResponseExample.phase_summaries,
         }),
 );
@@ -134,6 +149,10 @@ export const gameDetailSchema = registry.register(
     'GameDetail',
     z
         .object({
+            game_id: z.string().openapi({
+                description:
+                    'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
+            }),
             title: z.string().openapi({
                 description: 'ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット）',
             }),
@@ -177,27 +196,24 @@ export const gameDetailSchema = registry.register(
         })
         .openapi({
             description: 'ゲーム単位の詳細情報。仕様書「データ構造」→ GameDetail 参照',
-            example: resultsResponseExample.details.game_1,
+            example: resultsResponseExample.details[0],
         }),
 );
 
 /**
- * 全 3 ゲームの詳細情報をまとめたオブジェクト。
+ * 全ゲームの詳細情報をまとめた配列。
  *
- * 全フィールド必須（3 ゲーム完了が `incomplete_games` でガードされているため、
- * results レスポンス到達時には必ず 3 ゲーム分の details が揃う前提）。
+ * 配列化の理由は gameBreakdown / phaseSummaries と同じ（将来のゲーム追加・差し替え対応 / Phase 1）。
+ * 3 ゲーム完了が `incomplete_games` でガードされているため、results レスポンス到達時には
+ * 必ず登録済みゲーム分の要素が揃う前提（現状は 3 要素）。
  */
 export const detailsSchema = registry.register(
     'Details',
     z
-        .object({
-            game_1: gameDetailSchema,
-            game_2: gameDetailSchema,
-            game_3: gameDetailSchema,
-        })
+        .array(gameDetailSchema)
         .openapi({
             description:
-                '各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）。' +
+                '各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）の配列。' +
                 '構造は仕様書「データ構造」→ GameDetail を参照',
             example: resultsResponseExample.details,
         }),

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -52,10 +52,13 @@ const partialBaselineScoresSchema = baselineScoresSchema.partial();
  * Phase 3 で導入予定の `analysis/registry.ts` の `GameId` 型と同値（先取り定義）。
  * Phase 3 で `Object.keys(GAME_MODULES)` から導出する形に置換する想定。
  *
- * `.claude/rules/backend.md` の zod スキーマ規約に従い、
- * 「OpenAPI 公開 × 文字列リテラル × エラーコード差別化不要」のため `z.enum` を採用。
+ * 文字列リテラル列挙で OpenAPI に公開する用途、かつエラーコード差別化が不要な
+ * ケースのため `z.enum` を採用（数値リテラルなら `z.literal(VALUES)`、
+ * `invalid_request` と業務エラーコードを区別する必要があれば `z.string().refine()` を使う）。
  * これにより FE 生成型でも `'terms_game' | 'helpdesk_game' | 'group_chat_game'` の
  * リテラル絞り込みが効き、Swagger UI でも enum が明示される。
+ *
+ * 同パターンの先行例: `schemas/voice.ts` の `conversationMessageSchema.role`（`z.enum(['user', 'assistant'])`）。
  */
 const GAME_ID_VALUES = ['terms_game', 'helpdesk_game', 'group_chat_game'] as const;
 

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -37,13 +37,39 @@ export const resultsParamsSchema = z.object({
 /**
  * 5 軸各軸ごとのスコアを optional にした構造。
  *
- * ゲームごとにどの軸を測るかが異なるため（例: game_1 は caution/logic/calmness のみ）、
+ * ゲームごとにどの軸を測るかが異なるため（例: terms_game は caution/logic/calmness のみ）、
  * Partial 相当として各軸を optional にしている。
  *
  * `baselineScoresSchema.partial()` を使うことで、キー定義の単一ソース化と
  * 0-100 の範囲制約の継承を同時に実現している。
  */
 const partialBaselineScoresSchema = baselineScoresSchema.partial();
+
+/**
+ * ゲーム識別子（文字列リテラル列挙）。
+ *
+ * `game_breakdown` / `phase_summaries` / `details` の各要素を識別するキー。
+ * Phase 3 で導入予定の `analysis/registry.ts` の `GameId` 型と同値（先取り定義）。
+ * Phase 3 で `Object.keys(GAME_MODULES)` から導出する形に置換する想定。
+ *
+ * `.claude/rules/backend.md` の zod スキーマ規約に従い、
+ * 「OpenAPI 公開 × 文字列リテラル × エラーコード差別化不要」のため `z.enum` を採用。
+ * これにより FE 生成型でも `'terms_game' | 'helpdesk_game' | 'group_chat_game'` の
+ * リテラル絞り込みが効き、Swagger UI でも enum が明示される。
+ */
+const GAME_ID_VALUES = ['terms_game', 'helpdesk_game', 'group_chat_game'] as const;
+
+export const gameIdSchema = registry.register(
+    'GameId',
+    z.enum(GAME_ID_VALUES).openapi({
+        description:
+            'ゲーム識別子。terms_game = 利用規約ゲーム / helpdesk_game = AIカスタマーサポート / ' +
+            'group_chat_game = 空気読みグループチャット',
+        example: 'terms_game',
+    }),
+);
+
+export type GameId = z.infer<typeof gameIdSchema>;
 
 /**
  * ゲームごとのスコア内訳（配列形式）。
@@ -59,10 +85,7 @@ export const gameBreakdownSchema = registry.register(
     z
         .array(
             z.object({
-                game_id: z.string().openapi({
-                    description:
-                        'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
-                }),
+                game_id: gameIdSchema,
                 scores: partialBaselineScoresSchema.openapi({
                     description:
                         '当該ゲームで測定した軸のスコア（測定軸のみ含むため 5 軸すべては揃わない）',
@@ -114,10 +137,7 @@ export const phaseSummariesSchema = registry.register(
     z
         .array(
             z.object({
-                game_id: z.string().openapi({
-                    description:
-                        'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
-                }),
+                game_id: gameIdSchema,
                 summary: z.string().openapi({
                     description: '当該ゲームの行動を日本語テキストで振り返ったサマリー',
                 }),
@@ -149,10 +169,7 @@ export const gameDetailSchema = registry.register(
     'GameDetail',
     z
         .object({
-            game_id: z.string().openapi({
-                description:
-                    'ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game）',
-            }),
+            game_id: gameIdSchema,
             title: z.string().openapi({
                 description: 'ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット）',
             }),

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -53,7 +53,7 @@ const partialBaselineScoresSchema = baselineScoresSchema.partial();
  * Phase 3 で `Object.keys(GAME_MODULES)` から導出する形に置換する想定。
  *
  * 文字列リテラル列挙で OpenAPI に公開する用途、かつエラーコード差別化が不要な
- * ケースのため `z.enum` を採用（数値リテラルなら `z.literal(VALUES)`、
+ * ケースのため `z.enum` を採用（数値リテラルなら `z.literal(VALUES).openapi({ enum: VALUES })`、
  * `invalid_request` と業務エラーコードを区別する必要があれば `z.string().refine()` を使う）。
  * これにより FE 生成型でも `'terms_game' | 'helpdesk_game' | 'group_chat_game'` の
  * リテラル絞り込みが効き、Swagger UI でも enum が明示される。

--- a/frontend/src/features/result/components/ResultReport.tsx
+++ b/frontend/src/features/result/components/ResultReport.tsx
@@ -46,6 +46,26 @@ export default function ResultReport({ data }: ResultReportProps) {
   const [activeTab, setActiveTab] = useState<TabId>('overview');
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
+  // Phase 1（Issue #97）の暫定対応: details / phase_summaries が配列形式に変わったため、
+  // game_id で対応要素を取り出してから既存の game_1/2/3 タブに割り当てる。
+  // タブ動的化と gameMeta.ts 化は Issue #98 で対応するため、ここでは最小修正に留める。
+  const termsDetail = data.details.find((d) => d.game_id === 'terms_game');
+  const helpdeskDetail = data.details.find(
+    (d) => d.game_id === 'helpdesk_game'
+  );
+  const groupChatDetail = data.details.find(
+    (d) => d.game_id === 'group_chat_game'
+  );
+
+  const termsSummary =
+    data.phase_summaries.find((p) => p.game_id === 'terms_game')?.summary ?? '';
+  const helpdeskSummary =
+    data.phase_summaries.find((p) => p.game_id === 'helpdesk_game')?.summary ??
+    '';
+  const groupChatSummary =
+    data.phase_summaries.find((p) => p.game_id === 'group_chat_game')
+      ?.summary ?? '';
+
   // SE再生用ヘルパー
   const playSE = (path: string) => {
     const audio = new Audio(path);
@@ -154,24 +174,24 @@ export default function ResultReport({ data }: ResultReportProps) {
 
         <div className="flex-1 bg-white border-4 border-black rounded-3xl rounded-tr-3xl shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] p-4 sm:p-8 min-h-125">
           {activeTab === 'overview' && <OverviewTab data={data} />}
-          {activeTab === 'game_1' && (
+          {activeTab === 'game_1' && termsDetail && (
             <GameDetailTab
-              detail={data.details.game_1}
-              comment={data.phase_summaries.phase_1}
+              detail={termsDetail}
+              comment={termsSummary}
               tabColor={GAME_TAB_COLORS.game_1}
             />
           )}
-          {activeTab === 'game_2' && (
+          {activeTab === 'game_2' && helpdeskDetail && (
             <GameDetailTab
-              detail={data.details.game_2}
-              comment={data.phase_summaries.phase_2}
+              detail={helpdeskDetail}
+              comment={helpdeskSummary}
               tabColor={GAME_TAB_COLORS.game_2}
             />
           )}
-          {activeTab === 'game_3' && (
+          {activeTab === 'game_3' && groupChatDetail && (
             <GameDetailTab
-              detail={data.details.game_3}
-              comment={data.phase_summaries.phase_3}
+              detail={groupChatDetail}
+              comment={groupChatSummary}
               tabColor={GAME_TAB_COLORS.game_3}
             />
           )}

--- a/frontend/src/features/result/data/mockResult.ts
+++ b/frontend/src/features/result/data/mockResult.ts
@@ -36,7 +36,9 @@ export const MOCK_RESULT: ResultResponse = {
     positivity: 20,
   },
   // 配列形式（Phase 1 / Issue #97）。game_id は Phase 3（registry 導入）で
-  // 正式定義予定の文字列 ID を先取り使用。配列順は NORMAL_FLOW に揃える。
+  // 正式定義予定の文字列 ID を先取り使用。配列順は
+  // terms_game → helpdesk_game → group_chat_game の通常フロー順
+  // （Phase 3 で `analysis/registry.ts` の `NORMAL_FLOW` 定数として正式定義予定）。
   game_breakdown: [
     { game_id: 'terms_game', scores: { caution: 20 } },
     {

--- a/frontend/src/features/result/data/mockResult.ts
+++ b/frontend/src/features/result/data/mockResult.ts
@@ -35,11 +35,19 @@ export const MOCK_RESULT: ResultResponse = {
     cooperativeness: -20,
     positivity: 20,
   },
-  game_breakdown: {
-    game_1: { caution: 20 },
-    game_2: { logic: 60, calmness: 80, positivity: 90 },
-    game_3: { cooperativeness: 10, positivity: 85 },
-  },
+  // 配列形式（Phase 1 / Issue #97）。game_id は Phase 3（registry 導入）で
+  // 正式定義予定の文字列 ID を先取り使用。配列順は NORMAL_FLOW に揃える。
+  game_breakdown: [
+    { game_id: 'terms_game', scores: { caution: 20 } },
+    {
+      game_id: 'helpdesk_game',
+      scores: { logic: 60, calmness: 80, positivity: 90 },
+    },
+    {
+      game_id: 'group_chat_game',
+      scores: { cooperativeness: 10, positivity: 85 },
+    },
+  ],
   feedback: {
     title: '暴走する機関車',
     description:
@@ -47,13 +55,23 @@ export const MOCK_RESULT: ResultResponse = {
     gap_point: '慎重さ',
   },
   accuracy_score: 50,
-  phase_summaries: {
-    phase_1: '規約を2秒で読み飛ばし、即座に同意ボタンを押しました',
-    phase_2: 'AIの理不尽な対応に0.5秒で反応し、論理的に反論しました',
-    phase_3: 'グループの空気を読んで、全員と同じ選択をしました',
-  },
-  details: {
-    game_1: {
+  phase_summaries: [
+    {
+      game_id: 'terms_game',
+      summary: '規約を2秒で読み飛ばし、即座に同意ボタンを押しました',
+    },
+    {
+      game_id: 'helpdesk_game',
+      summary: 'AIの理不尽な対応に0.5秒で反応し、論理的に反論しました',
+    },
+    {
+      game_id: 'group_chat_game',
+      summary: 'グループの空気を読んで、全員と同じ選択をしました',
+    },
+  ],
+  details: [
+    {
+      game_id: 'terms_game',
       title: '利用規約ゲーム',
       feature_scores: [
         { axis: 'caution', name: '慎重さ', score: 20 },
@@ -85,7 +103,8 @@ export const MOCK_RESULT: ResultResponse = {
         { label: '無駄クリック(回)', user: 0, average: 1.5, category: 'mouse' },
       ],
     },
-    game_2: {
+    {
+      game_id: 'helpdesk_game',
       title: 'AIカスタマーサポート',
       feature_scores: [
         { axis: 'positivity', name: '積極性', score: 90 },
@@ -105,7 +124,8 @@ export const MOCK_RESULT: ResultResponse = {
         { label: '論理的接続詞(回)', user: 2, average: 0.5, category: 'logic' },
       ],
     },
-    game_3: {
+    {
+      game_id: 'group_chat_game',
       title: '空気読みグループチャット',
       feature_scores: [
         { axis: 'cooperativeness', name: '協調性', score: 10 },
@@ -124,5 +144,5 @@ export const MOCK_RESULT: ResultResponse = {
         },
       ],
     },
-  },
+  ],
 };

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -711,27 +711,39 @@ export interface components {
             confidence: number;
         };
         /**
-         * @description ゲームごとのスコア内訳。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: game_1 は caution / logic / calmness のみ）
-         * @example {
-         *       "game_1": {
-         *         "caution": 45,
-         *         "logic": 75,
-         *         "calmness": 55
+         * @description ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）
+         * @example [
+         *       {
+         *         "game_id": "terms_game",
+         *         "scores": {
+         *           "caution": 45,
+         *           "logic": 75,
+         *           "calmness": 55
+         *         }
          *       },
-         *       "game_2": {
-         *         "positivity": 70,
-         *         "calmness": 55,
-         *         "logic": 75
+         *       {
+         *         "game_id": "helpdesk_game",
+         *         "scores": {
+         *           "positivity": 70,
+         *           "calmness": 55,
+         *           "logic": 75
+         *         }
          *       },
-         *       "game_3": {
-         *         "cooperativeness": 60,
-         *         "positivity": 70,
-         *         "caution": 45
+         *       {
+         *         "game_id": "group_chat_game",
+         *         "scores": {
+         *           "cooperativeness": 60,
+         *           "positivity": 70,
+         *           "caution": 45
+         *         }
          *       }
-         *     }
+         *     ]
          */
         GameBreakdown: {
-            game_1?: {
+            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
+            game_id: string;
+            /** @description 当該ゲームで測定した軸のスコア（測定軸のみ含むため 5 軸すべては揃わない） */
+            scores: {
                 /** @description 慎重さ（0-100） */
                 caution?: number;
                 /** @description 冷静さ（0-100） */
@@ -743,31 +755,7 @@ export interface components {
                 /** @description 積極性（0-100） */
                 positivity?: number;
             };
-            game_2?: {
-                /** @description 慎重さ（0-100） */
-                caution?: number;
-                /** @description 冷静さ（0-100） */
-                calmness?: number;
-                /** @description 論理性（0-100） */
-                logic?: number;
-                /** @description 協調性（0-100） */
-                cooperativeness?: number;
-                /** @description 積極性（0-100） */
-                positivity?: number;
-            };
-            game_3?: {
-                /** @description 慎重さ（0-100） */
-                caution?: number;
-                /** @description 冷静さ（0-100） */
-                calmness?: number;
-                /** @description 論理性（0-100） */
-                logic?: number;
-                /** @description 協調性（0-100） */
-                cooperativeness?: number;
-                /** @description 積極性（0-100） */
-                positivity?: number;
-            };
-        };
+        }[];
         /**
          * @description 診断フィードバック（最大ギャップ軸に基づく見出し・説明・指摘点）
          * @example {
@@ -794,24 +782,32 @@ export interface components {
             gap_point: string;
         };
         /**
-         * @description 各ゲーム終了後の行動を日本語テキストで振り返ったサマリー
-         * @example {
-         *       "phase_1": "規約を爆速でスクロールし、最後まで読まずに同意しました。",
-         *       "phase_2": "AI の理不尽な対応に感情的に反応する場面が見られました。",
-         *       "phase_3": "グループの空気を読みつつ、自分の意見も主張していました。"
-         *     }
+         * @description 各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列
+         * @example [
+         *       {
+         *         "game_id": "terms_game",
+         *         "summary": "規約を爆速でスクロールし、最後まで読まずに同意しました。"
+         *       },
+         *       {
+         *         "game_id": "helpdesk_game",
+         *         "summary": "AI の理不尽な対応に感情的に反応する場面が見られました。"
+         *       },
+         *       {
+         *         "game_id": "group_chat_game",
+         *         "summary": "グループの空気を読みつつ、自分の意見も主張していました。"
+         *       }
+         *     ]
          */
         PhaseSummaries: {
-            /** @description Game 1（利用規約）の行動要約 */
-            phase_1: string;
-            /** @description Game 2（AI カスタマーサポート）の行動要約 */
-            phase_2: string;
-            /** @description Game 3（グループチャット）の行動要約 */
-            phase_3: string;
-        };
+            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
+            game_id: string;
+            /** @description 当該ゲームの行動を日本語テキストで振り返ったサマリー */
+            summary: string;
+        }[];
         /**
          * @description ゲーム単位の詳細情報。仕様書「データ構造」→ GameDetail 参照
          * @example {
+         *       "game_id": "terms_game",
          *       "title": "利用規約ゲーム",
          *       "feature_scores": [
          *         {
@@ -831,6 +827,8 @@ export interface components {
          *     }
          */
         GameDetail: {
+            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
+            game_id: string;
             /** @description ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット） */
             title: string;
             /** @description 当該ゲームで測定した軸ごとのスコア配列（測定軸数はゲームごとに異なる） */
@@ -855,9 +853,10 @@ export interface components {
             }[];
         };
         /**
-         * @description 各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）。構造は仕様書「データ構造」→ GameDetail を参照
-         * @example {
-         *       "game_1": {
+         * @description 各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）の配列。構造は仕様書「データ構造」→ GameDetail を参照
+         * @example [
+         *       {
+         *         "game_id": "terms_game",
          *         "title": "利用規約ゲーム",
          *         "feature_scores": [
          *           {
@@ -875,7 +874,8 @@ export interface components {
          *           }
          *         ]
          *       },
-         *       "game_2": {
+         *       {
+         *         "game_id": "helpdesk_game",
          *         "title": "AIカスタマーサポート",
          *         "feature_scores": [
          *           {
@@ -893,7 +893,8 @@ export interface components {
          *           }
          *         ]
          *       },
-         *       "game_3": {
+         *       {
+         *         "game_id": "group_chat_game",
          *         "title": "空気読みグループチャット",
          *         "feature_scores": [
          *           {
@@ -911,13 +912,9 @@ export interface components {
          *           }
          *         ]
          *       }
-         *     }
+         *     ]
          */
-        Details: {
-            game_1: components["schemas"]["GameDetail"];
-            game_2: components["schemas"]["GameDetail"];
-            game_3: components["schemas"]["GameDetail"];
-        };
+        Details: components["schemas"]["GameDetail"][];
         /**
          * @description 診断結果レスポンス（200 OK）
          * @example {
@@ -951,36 +948,55 @@ export interface components {
          *         "cooperativeness": 5,
          *         "positivity": -5
          *       },
-         *       "game_breakdown": {
-         *         "game_1": {
-         *           "caution": 45,
-         *           "logic": 75,
-         *           "calmness": 55
+         *       "game_breakdown": [
+         *         {
+         *           "game_id": "terms_game",
+         *           "scores": {
+         *             "caution": 45,
+         *             "logic": 75,
+         *             "calmness": 55
+         *           }
          *         },
-         *         "game_2": {
-         *           "positivity": 70,
-         *           "calmness": 55,
-         *           "logic": 75
+         *         {
+         *           "game_id": "helpdesk_game",
+         *           "scores": {
+         *             "positivity": 70,
+         *             "calmness": 55,
+         *             "logic": 75
+         *           }
          *         },
-         *         "game_3": {
-         *           "cooperativeness": 60,
-         *           "positivity": 70,
-         *           "caution": 45
+         *         {
+         *           "game_id": "group_chat_game",
+         *           "scores": {
+         *             "cooperativeness": 60,
+         *             "positivity": 70,
+         *             "caution": 45
+         *           }
          *         }
-         *       },
+         *       ],
          *       "feedback": {
          *         "title": "直感ドリブン",
          *         "description": "あなたは論理よりも直感を優先して意思決定する傾向があります。",
          *         "gap_point": "論理性"
          *       },
          *       "accuracy_score": 78,
-         *       "phase_summaries": {
-         *         "phase_1": "規約を爆速でスクロールし、最後まで読まずに同意しました。",
-         *         "phase_2": "AI の理不尽な対応に感情的に反応する場面が見られました。",
-         *         "phase_3": "グループの空気を読みつつ、自分の意見も主張していました。"
-         *       },
-         *       "details": {
-         *         "game_1": {
+         *       "phase_summaries": [
+         *         {
+         *           "game_id": "terms_game",
+         *           "summary": "規約を爆速でスクロールし、最後まで読まずに同意しました。"
+         *         },
+         *         {
+         *           "game_id": "helpdesk_game",
+         *           "summary": "AI の理不尽な対応に感情的に反応する場面が見られました。"
+         *         },
+         *         {
+         *           "game_id": "group_chat_game",
+         *           "summary": "グループの空気を読みつつ、自分の意見も主張していました。"
+         *         }
+         *       ],
+         *       "details": [
+         *         {
+         *           "game_id": "terms_game",
          *           "title": "利用規約ゲーム",
          *           "feature_scores": [
          *             {
@@ -998,7 +1014,8 @@ export interface components {
          *             }
          *           ]
          *         },
-         *         "game_2": {
+         *         {
+         *           "game_id": "helpdesk_game",
          *           "title": "AIカスタマーサポート",
          *           "feature_scores": [
          *             {
@@ -1016,7 +1033,8 @@ export interface components {
          *             }
          *           ]
          *         },
-         *         "game_3": {
+         *         {
+         *           "game_id": "group_chat_game",
          *           "title": "空気読みグループチャット",
          *           "feature_scores": [
          *             {
@@ -1034,7 +1052,7 @@ export interface components {
          *             }
          *           ]
          *         }
-         *       }
+         *       ]
          *     }
          */
         ResultResponse: {

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -711,6 +711,12 @@ export interface components {
             confidence: number;
         };
         /**
+         * @description ゲーム識別子。terms_game = 利用規約ゲーム / helpdesk_game = AIカスタマーサポート / group_chat_game = 空気読みグループチャット
+         * @example terms_game
+         * @enum {string}
+         */
+        GameId: "terms_game" | "helpdesk_game" | "group_chat_game";
+        /**
          * @description ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）
          * @example [
          *       {
@@ -740,8 +746,7 @@ export interface components {
          *     ]
          */
         GameBreakdown: {
-            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
-            game_id: string;
+            game_id: components["schemas"]["GameId"];
             /** @description 当該ゲームで測定した軸のスコア（測定軸のみ含むため 5 軸すべては揃わない） */
             scores: {
                 /** @description 慎重さ（0-100） */
@@ -799,8 +804,7 @@ export interface components {
          *     ]
          */
         PhaseSummaries: {
-            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
-            game_id: string;
+            game_id: components["schemas"]["GameId"];
             /** @description 当該ゲームの行動を日本語テキストで振り返ったサマリー */
             summary: string;
         }[];
@@ -827,8 +831,7 @@ export interface components {
          *     }
          */
         GameDetail: {
-            /** @description ゲーム識別子（例: terms_game / helpdesk_game / group_chat_game） */
-            game_id: string;
+            game_id: components["schemas"]["GameId"];
             /** @description ゲーム名（例: 利用規約ゲーム / AIカスタマーサポート / 空気読みグループチャット） */
             title: string;
             /** @description 当該ゲームで測定した軸ごとのスコア配列（測定軸数はゲームごとに異なる） */


### PR DESCRIPTION
## 概要

リファクタ計画 Phase 1 / 子 Issue 1a。BE の結果スキーマ（`game_breakdown` / `phase_summaries` / `details`）を `game_1/2/3` 固定キーから `{ game_id, ... }` の配列形式に変更する。

FE 結果画面の本格的な動的化は次 PR (#98) で対応する。本 PR では型エラーを回避する最小修正のみ。

## 変更内容

### BE
- `schemas/results.ts`: `gameBreakdownSchema` / `phaseSummariesSchema` / `detailsSchema` を配列スキーマに変更。`gameDetailSchema` に `game_id` フィールドを追加
- `analysis/scoreCalculator.ts`: 戻り値の `game_breakdown` / `details` を配列に書き換え（中身ロジックは触らず）
- `analysis/phaseSummaryBuilder.ts`: 戻り値を配列に書き換え
- `openapi/examples.ts`: `resultsResponseExample` を配列形式に追従
- `repositories/analysisResultRepository.ts`: zod 由来の型経由で JSONB を保持しているため自動追従（変更不要）

### FE
- `lib/api/generated.ts`: `npm run gen:api-types` で再生成
- `features/result/data/mockResult.ts`: 配列形式に追従
- `features/result/components/ResultReport.tsx`: 既存の `game_1/2/3` タブ ID を維持しつつ、配列要素を `game_id` で find して `GameDetailTab` に渡す最小修正

## game_id について

Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している:

| game_id | 対応 |
|---|---|
| `terms_game` | 利用規約ゲーム |
| `helpdesk_game` | AI カスタマーサポート |
| `group_chat_game` | 空気読みグループチャット |

配列順は `[terms, helpdesk, group_chat]` で固定。

## マージ後の作業

開発環境の Supabase で以下を実行する:

```sql
TRUNCATE TABLE analysis_results;
```

理由:
- 結果スキーマ JSONB の構造（オブジェクト → 配列）が変わるため、既存キャッシュは新コードで読むと表示崩れになる
- カラム定義のマイグレーションは不要（データを消すだけ）
- `game_logs`（生データ）は触らないので、結果画面を再度開けば自動で再計算 → 新形式で再キャッシュされる

closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **リファクタリング**
  * ゲーム別データやフェーズ要約をオブジェクトから配列形式へ統一し、応答形式を一貫化しました。
* **機能変更（可視）**
  * 各ゲームの詳細表示がデータ駆動で条件表示されるよう改善。
  * 詳細データに新しいゲーム別メトリクス（例：無駄クリック、論理的接続詞、本音ホバー、譲り合い待機など）を追加しました。
* **ドキュメント／モック**
  * APIサンプル、スキーマ、モックデータ、例示レスポンスを新形式に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->