### PR TITLE
refactor: FE 結果画面を配列スキーマで動的化

### DIFF
--- a/frontend/src/features/result/components/ResultReport.tsx
+++ b/frontend/src/features/result/components/ResultReport.tsx
@@ -94,17 +94,23 @@ export default function ResultReport({ data }: ResultReportProps) {
   }, [router]);
 
   // タブ一覧（overview + 各ゲーム）。ゲームタブは details の並び順に従う。
-  const gameTabs = data.details.map((detail) => {
+  // GAME_META に未登録の game_id（BE / FE の generated.ts が一時的にズレた場合等）が
+  // 含まれる可能性に備え、flatMap でスキップして安全側に倒す。
+  const gameTabs = data.details.flatMap((detail) => {
     const meta = GAME_META[detail.game_id];
-    return {
-      id: detail.game_id,
-      label: meta.label,
-      icon: meta.icon,
-      color: meta.color,
-      detail,
-      summary: summaryByGameId.get(detail.game_id) ?? '',
-    };
+    if (!meta) return [];
+    return [
+      {
+        id: detail.game_id,
+        label: meta.label,
+        icon: meta.icon,
+        color: meta.color,
+        detail,
+        summary: summaryByGameId.get(detail.game_id) ?? '',
+      },
+    ];
   });
+  const activeGameTab = gameTabs.find((tab) => tab.id === activeTab);
 
   return (
     <div
@@ -161,16 +167,12 @@ export default function ResultReport({ data }: ResultReportProps) {
 
         <div className="flex-1 bg-white border-4 border-black rounded-3xl rounded-tr-3xl shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] p-4 sm:p-8 min-h-125">
           {activeTab === 'overview' && <OverviewTab data={data} />}
-          {gameTabs.map(
-            (tab) =>
-              activeTab === tab.id && (
-                <GameDetailTab
-                  key={tab.id}
-                  detail={tab.detail}
-                  comment={tab.summary}
-                  tabColor={tab.color}
-                />
-              )
+          {activeGameTab && (
+            <GameDetailTab
+              detail={activeGameTab.detail}
+              comment={activeGameTab.summary}
+              tabColor={activeGameTab.color}
+            />
           )}
         </div>
 

--- a/frontend/src/features/result/components/ResultReport.tsx
+++ b/frontend/src/features/result/components/ResultReport.tsx
@@ -2,21 +2,14 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  LucideIcon,
-  Activity,
-  ShieldAlert,
-  Zap,
-  Users,
-  Star,
-  RefreshCw,
-} from 'lucide-react';
-import type { ResultResponse } from '../types';
+import { Activity, RefreshCw, Star, type LucideIcon } from 'lucide-react';
+import type { GameId, ResultResponse } from '../types';
+import { GAME_META } from '../data/gameMeta';
 import GameDetailTab from './GameDetailTab';
 import OverviewTab from './OverviewTab';
 import SharePanel from './SharePanel';
 
-type TabId = 'overview' | 'game_1' | 'game_2' | 'game_3';
+type TabId = 'overview' | GameId;
 
 const SOUNDS = {
   BGM: '/sounds/result-bgm.mp3',
@@ -24,17 +17,12 @@ const SOUNDS = {
   RETAKE: '/sounds/start-se.mp3',
 };
 
-const TABS: { id: TabId; label: string; icon: LucideIcon }[] = [
-  { id: 'overview', label: '総合診断', icon: Activity },
-  { id: 'game_1', label: '規約の罠', icon: ShieldAlert },
-  { id: 'game_2', label: 'AIバトル', icon: Zap },
-  { id: 'game_3', label: '空気読み', icon: Users },
-];
-
-const GAME_TAB_COLORS: Record<string, string> = {
-  game_1: '#ef4444',
-  game_2: '#f97316',
-  game_3: '#3b82f6',
+// overview タブはゲームではなく総合診断の表示なので個別に定義する。
+// ゲームタブは API レスポンスの `data.details` の順序から動的に構築する。
+const OVERVIEW_TAB: { id: 'overview'; label: string; icon: LucideIcon } = {
+  id: 'overview',
+  label: '総合診断',
+  icon: Activity,
 };
 
 type ResultReportProps = {
@@ -46,25 +34,11 @@ export default function ResultReport({ data }: ResultReportProps) {
   const [activeTab, setActiveTab] = useState<TabId>('overview');
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
-  // Phase 1（Issue #97）の暫定対応: details / phase_summaries が配列形式に変わったため、
-  // game_id で対応要素を取り出してから既存の game_1/2/3 タブに割り当てる。
-  // タブ動的化と gameMeta.ts 化は Issue #98 で対応するため、ここでは最小修正に留める。
-  const termsDetail = data.details.find((d) => d.game_id === 'terms_game');
-  const helpdeskDetail = data.details.find(
-    (d) => d.game_id === 'helpdesk_game'
+  // game_id をキーに phase_summaries を引けるようにしておく。
+  // タブ切り替え時に都度 find() しないよう一度マップ化する。
+  const summaryByGameId = new Map(
+    data.phase_summaries.map((p) => [p.game_id, p.summary])
   );
-  const groupChatDetail = data.details.find(
-    (d) => d.game_id === 'group_chat_game'
-  );
-
-  const termsSummary =
-    data.phase_summaries.find((p) => p.game_id === 'terms_game')?.summary ?? '';
-  const helpdeskSummary =
-    data.phase_summaries.find((p) => p.game_id === 'helpdesk_game')?.summary ??
-    '';
-  const groupChatSummary =
-    data.phase_summaries.find((p) => p.game_id === 'group_chat_game')
-      ?.summary ?? '';
 
   // SE再生用ヘルパー
   const playSE = (path: string) => {
@@ -99,7 +73,7 @@ export default function ResultReport({ data }: ResultReportProps) {
 
   const handleTabChange = (tabId: TabId) => {
     // 1. SEをロードして再生
-    const se = new Audio('/sounds/general-button-se.mp3');
+    const se = new Audio(SOUNDS.TAB_CLICK);
     se.volume = 0.5;
     se.play().catch(() => {
       /* 自動再生制限などで失敗してもエラーを出さない */
@@ -118,6 +92,19 @@ export default function ResultReport({ data }: ResultReportProps) {
       router.push('/');
     }, 500);
   }, [router]);
+
+  // タブ一覧（overview + 各ゲーム）。ゲームタブは details の並び順に従う。
+  const gameTabs = data.details.map((detail) => {
+    const meta = GAME_META[detail.game_id];
+    return {
+      id: detail.game_id,
+      label: meta.label,
+      icon: meta.icon,
+      color: meta.color,
+      detail,
+      summary: summaryByGameId.get(detail.game_id) ?? '',
+    };
+  });
 
   return (
     <div
@@ -145,7 +132,7 @@ export default function ResultReport({ data }: ResultReportProps) {
 
       <main className="relative z-10 w-full max-w-7xl flex flex-col max-h-[80vh]">
         <nav className="flex px-2 lg:px-10 items-end h-10">
-          {TABS.map((tab) => {
+          {[OVERVIEW_TAB, ...gameTabs].map((tab) => {
             const Icon = tab.icon;
             const isActive = activeTab === tab.id;
             return (
@@ -174,26 +161,16 @@ export default function ResultReport({ data }: ResultReportProps) {
 
         <div className="flex-1 bg-white border-4 border-black rounded-3xl rounded-tr-3xl shadow-[10px_10px_0px_0px_rgba(0,0,0,1)] p-4 sm:p-8 min-h-125">
           {activeTab === 'overview' && <OverviewTab data={data} />}
-          {activeTab === 'game_1' && termsDetail && (
-            <GameDetailTab
-              detail={termsDetail}
-              comment={termsSummary}
-              tabColor={GAME_TAB_COLORS.game_1}
-            />
-          )}
-          {activeTab === 'game_2' && helpdeskDetail && (
-            <GameDetailTab
-              detail={helpdeskDetail}
-              comment={helpdeskSummary}
-              tabColor={GAME_TAB_COLORS.game_2}
-            />
-          )}
-          {activeTab === 'game_3' && groupChatDetail && (
-            <GameDetailTab
-              detail={groupChatDetail}
-              comment={groupChatSummary}
-              tabColor={GAME_TAB_COLORS.game_3}
-            />
+          {gameTabs.map(
+            (tab) =>
+              activeTab === tab.id && (
+                <GameDetailTab
+                  key={tab.id}
+                  detail={tab.detail}
+                  comment={tab.summary}
+                  tabColor={tab.color}
+                />
+              )
           )}
         </div>
 

--- a/frontend/src/features/result/data/gameMeta.ts
+++ b/frontend/src/features/result/data/gameMeta.ts
@@ -1,0 +1,41 @@
+import { ShieldAlert, Users, Zap, type LucideIcon } from 'lucide-react';
+
+import type { GameId } from '../types';
+
+/**
+ * ゲームごとの結果画面 UI メタデータ（タブのラベル / アイコン / 色）。
+ *
+ * BE スキーマの `game_id` を単一ソースに、結果画面（タブ・コメントハイライト等）の
+ * 表示情報をここに集約する。新しいゲームを追加するときは generated.ts の `GameId`
+ * union が拡張されるので、本ファイルにも対応エントリを足す（`Record<GameId, ...>`
+ * によりコンパイル時に網羅性を保証）。
+ *
+ * 表示順は API レスポンスの `details` 配列の順序に従うため、本マップ自体は順序を
+ * 持たない。
+ */
+export type GameMeta = {
+  /** 結果画面タブのラベル（ゲームの愛称、画面設計書ベース） */
+  label: string;
+  /** タブアイコン（lucide-react） */
+  icon: LucideIcon;
+  /** タブの強調色 / コメント内ハイライト色 */
+  color: string;
+};
+
+export const GAME_META: Record<GameId, GameMeta> = {
+  terms_game: {
+    label: '規約の罠',
+    icon: ShieldAlert,
+    color: '#ef4444',
+  },
+  helpdesk_game: {
+    label: 'AIバトル',
+    icon: Zap,
+    color: '#f97316',
+  },
+  group_chat_game: {
+    label: '空気読み',
+    icon: Users,
+    color: '#3b82f6',
+  },
+};

--- a/frontend/src/features/result/types/index.ts
+++ b/frontend/src/features/result/types/index.ts
@@ -8,6 +8,9 @@
 
 import type { components } from '@/lib/api/generated';
 
+// ゲーム識別子（terms_game / helpdesk_game / group_chat_game）
+export type GameId = components['schemas']['GameId'];
+
 // 5 軸スコア（自己申告基準値・実測値・MBTI 理論値で共通利用）
 export type DiagnosisScores = components['schemas']['BaselineScores'];
 


### PR DESCRIPTION
## 概要

親 Issue #94 の一環。Issue #97 で BE 結果スキーマが配列形式に変わったのを受けて、FE の結果画面（タブ・各ゲーム詳細）を配列駆動でレンダリングするよう動的化する純粋なリファクタ。機能・挙動は変えない。

closes #98

## 変更内容

- `frontend/src/features/result/data/gameMeta.ts` を新規作成
  - ゲーム ID → ラベル / アイコン / 色 を `Record<GameId, GameMeta>` に集約
  - 新ゲーム追加時はこのファイルにエントリを足すだけで済む（網羅性は型でコンパイル時に保証）
- `frontend/src/features/result/components/ResultReport.tsx` をハードコードから配列ループ駆動に変更
  - `TABS` / `GAME_TAB_COLORS` 定数を撤廃し、`data.details` の順序 + `GAME_META` から動的構築
  - 3 箇所のハードコード `find()` を `summaryByGameId` Map にまとめ、各タブで 1 回引くだけに
  - `GAME_META` に未登録の `game_id` が `data.details` に含まれた場合は `flatMap` でスキップして安全側に倒す
  - `gameTabs.map × 条件レンダリング` を `activeGameTab = gameTabs.find(...)` 1 件描画に整理
- `frontend/src/features/result/types/index.ts` に `GameId` 型を追加再エクスポート（`components['schemas']['GameId']` を直接コンポーネントから参照しないよう既存パターンと統一）

## 確認事項

- `mockResult.ts` は Issue #97 で配列形式に対応済みのため変更なし
- 既存 3 ゲームのタブ並び・色・ラベル・アイコン・コメントハイライトはすべて従来と同一（`#ef4444` / `#f97316` / `#3b82f6`、`ShieldAlert` / `Zap` / `Users`、`規約の罠` / `AIバトル` / `空気読み`）
- BE / ゲーム本体には手を入れていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * リザルトレポート画面でゲームタブを動的に生成する方式に変更しました。今後のゲーム追加時の拡張性が向上します。

* **新機能**
  * ゲーム別のUIメタデータを一元管理するシステムを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->