### PR TITLE
refactor: registry.ts でゲームを管理し DB 境界で INT ↔ 文字列 ID 変換

### DIFF
--- a/backend/src/analysis/registry.ts
+++ b/backend/src/analysis/registry.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodType } from 'zod';
 import type { GameId } from '../schemas/results';
 import { GAME_TYPES } from '../types';
 import { groupChatGameModule } from './games/groupChatGame';
@@ -42,12 +42,14 @@ import { termsGameModule } from './games/termsGame';
 type GameModuleEntry<TId extends GameId> = {
     readonly id: TId;
     readonly title: string;
-    // zod の `ZodTypeAny` を採用することで `safeParse(data: unknown): SafeParseReturnType`
+    // ジェネリックなしの `z.ZodType` を採用することで「任意の zod スキーマを受け付ける」
+    // 型として機能する（旧 `ZodTypeAny` と等価。v4 で `ZodTypeAny` が deprecated に
+    // なったため `ZodType` に揃える）。`safeParse(data: unknown): SafeParseReturnType`
     // の判別可能 union（success: true → data / success: false → error.issues）が
     // 呼び出し元で narrow できる。ゲームごとの具体型（Game1Data 等）は registry の
     // 値型として保持しないが、parseGameData 内のアサーションで判別可能 union 側に
     // 戻す形を取っている。
-    readonly schema: ZodTypeAny;
+    readonly schema: ZodType;
     readonly analyze: (data: never) => unknown;
     readonly buildSummary: (data: never) => string;
 };

--- a/backend/src/analysis/registry.ts
+++ b/backend/src/analysis/registry.ts
@@ -1,0 +1,107 @@
+import type { ZodTypeAny } from 'zod';
+import type { GameId } from '../schemas/results';
+import { groupChatGameModule } from './games/groupChatGame';
+import { helpdeskGameModule } from './games/helpdeskGame';
+import { termsGameModule } from './games/termsGame';
+
+/**
+ * ゲームモジュールの中央レジストリ（Issue #101 / Phase 3a）。
+ *
+ * 設計方針:
+ * - ドメイン層（services / analysis）は文字列 ID（`GameId`、例: `'terms_game'`）でゲームを扱う。
+ *   DB の数値 game_type（1/2/3）はこの層では意識せず、`repositories/` と `routes/` の
+ *   境界でのみ INT ↔ 文字列 ID 変換を行う（Anti-Corruption Layer パターン）。
+ * - 新ゲームの追加・差し替え・順序変更は本ファイルへの登録 1 行で済むことを目指す。
+ *   将来 aggregator（Issue #102）から `Object.values(GAME_MODULES)` で全モジュールを
+ *   走査して軸統合する流れになる。
+ *
+ * 真実の単一ソースについて:
+ * - `GameId` 型と `GAME_ID_VALUES` の真実は `schemas/results.ts` 側に置く（zod スキーマ
+ *   `gameIdSchema` と一体で管理する方が OpenAPI 公開や API 入出力の検証と整合する）。
+ * - 本ファイルは `GAME_MODULES` を `GameModulesMap` 型に縛ることで、各 GameId に対応する
+ *   モジュール登録を強制する。Issue 本文の参考設計（`type GameId = keyof typeof GAME_MODULES`）
+ *   とは型の派生方向が逆だが、`satisfies` 等価のキー網羅性 + キー名と `module.id` の一致まで
+ *   コンパイル時に強制できるため、実質的な型安全性は同一以上。schemas → analysis の逆方向
+ *   依存を避ける狙いもある（既存のレイヤー方向 `analysis → schemas` を維持）。
+ */
+
+/**
+ * ゲームモジュールが満たすべき最小インタフェース。
+ *
+ * `id` のキーごとの型パラメータ化（`{ readonly id: TId }`）により、
+ * `GAME_MODULES` のキー名と各モジュールの `id` プロパティが一致することを
+ * コンパイル時に強制する（例: `terms_game` キーに `id: 'helpdesk_game'` の
+ * モジュールを誤登録するとコンパイルエラー）。
+ *
+ * `analyze` / `buildSummary` の引数・戻り値はゲームごとに Game1Data / Game2Data
+ * 等で異なるため、本 registry レベルでは詳細型を保持しない（`unknown`）。
+ * 詳細型が必要な `scoreCalculator.ts` は各モジュールを直接 import して
+ * 既存の型を維持する（Issue #102 で aggregator に集約する予定）。
+ */
+type GameModuleEntry<TId extends GameId> = {
+    readonly id: TId;
+    readonly title: string;
+    // zod の `ZodTypeAny` を採用することで `safeParse(data: unknown): SafeParseReturnType`
+    // の判別可能 union（success: true → data / success: false → error.issues）が
+    // 呼び出し元で narrow できる。ゲームごとの具体型（Game1Data 等）は registry の
+    // 値型として保持しないが、parseGameData 内のアサーションで判別可能 union 側に
+    // 戻す形を取っている。
+    readonly schema: ZodTypeAny;
+    readonly analyze: (data: never) => unknown;
+    readonly buildSummary: (data: never) => string;
+};
+
+type GameModulesMap = { readonly [K in GameId]: GameModuleEntry<K> };
+
+/**
+ * ゲーム ID → 分析モジュールの対応表。
+ *
+ * 新ゲーム追加時は本オブジェクトに 1 行追加するだけで、aggregator（Issue #102 で導入予定）が
+ * 自動的に走査対象に含める想定。
+ *
+ * 型 `GameModulesMap` により以下をコンパイル時に強制する:
+ * - 各 GameId のキーが揃っていること（漏れがあれば「Property 'xxx' is missing」）
+ * - 余分なキーが無いこと（GameId 外のキーは型エラー）
+ * - 各モジュールの `id` プロパティと登録キー名が一致すること
+ *
+ * `as const` を付けないのは `GameModulesMap` の型定義側でキーごとの readonly 化が
+ * 効くため不要かつ、付けると既存モジュールの widening 抑制が過剰になるため。
+ */
+export const GAME_MODULES: GameModulesMap = {
+    terms_game: termsGameModule,
+    helpdesk_game: helpdeskGameModule,
+    group_chat_game: groupChatGameModule,
+};
+
+/**
+ * DB の数値 game_type（1/2/3）↔ ドメインの文字列 GameId の対応表。
+ *
+ * DB スキーマ（`game_logs.game_type` は INT）は本リファクタでは変更しない方針のため、
+ * 値表現の差異を境界レイヤー（repositories / routes）で吸収する。
+ *
+ * 参照箇所:
+ * - `repositories/gameRepository.ts`: SELECT/INSERT 時に変換
+ * - `routes/games.ts`: HTTP リクエストの `game_type`（INT）を service 層へ渡す前に変換
+ *
+ * services / analysis 層はこの存在を意識せず、常に文字列 ID で扱う。
+ */
+export const GAME_TYPE_TO_ID: Readonly<Record<number, GameId>> = {
+    1: 'terms_game',
+    2: 'helpdesk_game',
+    3: 'group_chat_game',
+};
+
+export const ID_TO_GAME_TYPE: Readonly<Record<GameId, number>> = {
+    terms_game: 1,
+    helpdesk_game: 2,
+    group_chat_game: 3,
+};
+
+/**
+ * 通常版のゲームプレイ順序。
+ *
+ * 結果レスポンスの配列順（`game_breakdown` / `details` / `phase_summaries`）や、
+ * 将来的なゲームフロー制御のソースとして利用する。
+ * ロング版や別フローを実装する際は別の FLOW 定数を追加する想定（本リファクタ範囲外）。
+ */
+export const NORMAL_FLOW: readonly GameId[] = ['terms_game', 'helpdesk_game', 'group_chat_game'];

--- a/backend/src/analysis/registry.ts
+++ b/backend/src/analysis/registry.ts
@@ -1,5 +1,6 @@
 import type { ZodTypeAny } from 'zod';
 import type { GameId } from '../schemas/results';
+import { GAME_TYPES } from '../types';
 import { groupChatGameModule } from './games/groupChatGame';
 import { helpdeskGameModule } from './games/helpdeskGame';
 import { termsGameModule } from './games/termsGame';
@@ -74,10 +75,15 @@ export const GAME_MODULES: GameModulesMap = {
 };
 
 /**
- * DB の数値 game_type（1/2/3）↔ ドメインの文字列 GameId の対応表。
+ * ドメインの文字列 GameId → DB の数値 game_type の対応表。
  *
  * DB スキーマ（`game_logs.game_type` は INT）は本リファクタでは変更しない方針のため、
  * 値表現の差異を境界レイヤー（repositories / routes）で吸収する。
+ *
+ * 真実の単一ソースは `types/index.ts` の `GAME_TYPES` 定数（HTTP wire format / OpenAPI 公開で
+ * 既に「数値 1/2/3」を表す唯一のソースとして定義済み）。本マップでは GameId →
+ * `GAME_TYPES.*` の対応だけを書き、INT 値そのものは重複定義しない。これにより新ゲーム
+ * 追加時の更新箇所が `GAME_TYPES` に集約される。
  *
  * 参照箇所:
  * - `repositories/gameRepository.ts`: SELECT/INSERT 時に変換
@@ -85,17 +91,26 @@ export const GAME_MODULES: GameModulesMap = {
  *
  * services / analysis 層はこの存在を意識せず、常に文字列 ID で扱う。
  */
-export const GAME_TYPE_TO_ID: Readonly<Record<number, GameId>> = {
-    1: 'terms_game',
-    2: 'helpdesk_game',
-    3: 'group_chat_game',
+export const ID_TO_GAME_TYPE: Readonly<Record<GameId, number>> = {
+    terms_game: GAME_TYPES.TERMS_GAME,
+    helpdesk_game: GAME_TYPES.AI_CHAT,
+    group_chat_game: GAME_TYPES.GROUP_CHAT,
 };
 
-export const ID_TO_GAME_TYPE: Readonly<Record<GameId, number>> = {
-    terms_game: 1,
-    helpdesk_game: 2,
-    group_chat_game: 3,
-};
+/**
+ * `ID_TO_GAME_TYPE` を反転して導出する INT → GameId マップ。
+ *
+ * モジュールロード時に 1 回だけ計算され、以降は固定値として参照される。
+ * `GAME_TYPE_TO_ID` を独立にハードコードするとペアの片方だけ更新し忘れるリスクが
+ * あるため、`ID_TO_GAME_TYPE` を真実とし反転で導出する。
+ *
+ * `Object.fromEntries` の戻り値型は弱いため `as Readonly<Record<number, GameId>>` で
+ * 補強する（型と実体の一致は `ID_TO_GAME_TYPE` が `Record<GameId, number>` であることで
+ * 担保される）。
+ */
+export const GAME_TYPE_TO_ID = Object.fromEntries(
+    Object.entries(ID_TO_GAME_TYPE).map(([id, type]) => [type, id]),
+) as Readonly<Record<number, GameId>>;
 
 /**
  * 通常版のゲームプレイ順序。

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -77,6 +77,8 @@ export const gameRepository = {
                 console.error('Unknown game_type in game_logs:', { userId, row });
                 continue;
             }
+            // DB 行から数値 `game_type` を取り除き、ドメインの文字列 `game_id` に置換する。
+            // `_omit` という名前は ESLint の `no-unused-vars` 規約（`_` 始まりは未使用許容）に従う。
             const { game_type: _omit, ...rest } = row;
             logs.push({ ...rest, game_id: gameId });
         }

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,27 +1,42 @@
+import { GAME_TYPE_TO_ID, ID_TO_GAME_TYPE } from '../analysis/registry';
 import { supabase } from '../db/client';
-import { GAME_TYPES, GameLog, GameType } from '../types';
 import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
+import { GameId, GameLog } from '../types';
 
 /**
- * 各 game_type に対応する raw_data の組（判別可能 union）。
+ * 各 GameId に対応する raw_data の組（判別可能 union）。
  *
- * saveLog の引数として `gameType` と `rawData` を一緒に受け取ることで、
- * 「Game1 の gameType に Game2 の rawData が渡る」といったミスマッチを
+ * saveLog の引数として `gameId` と `rawData` を一緒に受け取ることで、
+ * 「terms_game の gameId に Game2Data の rawData が渡る」といったミスマッチを
  * コンパイル時に弾ける。呼び出し元（service 層）が zod スキーマで parse して
  * narrow 済みであることを型レベルで担保する想定で、repositories 層では構造検証しない。
+ *
+ * Issue #101 で従来の数値 game_type ベースから文字列 GameId ベースに変更した。
+ * DB の `game_logs.game_type` は INT のままで、`saveLog` 内で `ID_TO_GAME_TYPE` で
+ * INT に変換して INSERT する（Anti-Corruption Layer パターン）。
  */
 export type GameRawDataPayload =
-    | { gameType: typeof GAME_TYPES.TERMS_GAME; rawData: Game1Data }
-    | { gameType: typeof GAME_TYPES.AI_CHAT;    rawData: Game2Data }
-    | { gameType: typeof GAME_TYPES.GROUP_CHAT; rawData: Game3Data };
+    | { gameId: 'terms_game'; rawData: Game1Data }
+    | { gameId: 'helpdesk_game'; rawData: Game2Data }
+    | { gameId: 'group_chat_game'; rawData: Game3Data };
+
+/**
+ * DB 行（game_logs）の生レコード型。
+ *
+ * ドメイン層に出る `GameLog`（types/index.ts）は `game_id: GameId` の文字列 ID を持つが、
+ * DB レイヤでは `game_type: number` の INT のままで保持している。本型は
+ * `findLogsByUserId` 内の SELECT 結果を一時的に表現するためだけに使い、外部には公開しない。
+ */
+type GameLogDbRow = Omit<GameLog, 'game_id'> & { game_type: number };
 
 export const gameRepository = {
     async saveLog(userId: string, payload: GameRawDataPayload) {
+        // ドメインの文字列 GameId を DB の数値 game_type に変換して INSERT する（Anti-Corruption Layer）。
         const { error } = await supabase
             .from('game_logs')
             .insert({
                 user_id: userId,
-                game_type: payload.gameType,
+                game_type: ID_TO_GAME_TYPE[payload.gameId],
                 raw_data: payload.rawData,
             });
 
@@ -29,10 +44,17 @@ export const gameRepository = {
     },
 
     /**
-     * ユーザーのゲームログを game_type 昇順で取得する。
+     * ユーザーのゲームログを game_type 昇順で取得し、ドメイン文字列 GameId に変換して返す。
      *
      * 戻り値の `raw_data` は `unknown`（GameLog.raw_data の定義どおり）。
      * 構造の検証は呼び出し元（resultService）が zod スキーマで parse して行う。
+     *
+     * `order` は DB カラム名（game_type）で行う。出力上の並び順は
+     * `terms_game` (1) → `helpdesk_game` (2) → `group_chat_game` (3) になり、
+     * `analysis/registry.ts` の `NORMAL_FLOW` と一致する。
+     * 未知の game_type が DB に紛れていた場合（DB 整合性破壊）はその行をスキップしつつ
+     * `console.error` で報告する（呼び出し元の `gameLogs.length < 3` 判定で
+     * 400 incomplete_games に倒れる流れになり、レスポンスに不整合行が漏れない）。
      */
     async findLogsByUserId(userId: string): Promise<GameLog[]> {
         const { data, error } = await supabase
@@ -42,19 +64,33 @@ export const gameRepository = {
             .order('game_type', { ascending: true });
 
         if (error) throw error;
-        // Supabase は select('*') の戻り値を `any` で返すため、ここで明示的に GameLog[] に寄せる。
-        // 構造の妥当性は呼び出し元の zod parse で担保する。
-        return (data ?? []) as GameLog[];
+        // Supabase は select('*') の戻り値を `any` で返すため、ここで明示的に DB 行型に寄せる。
+        const rows = (data ?? []) as GameLogDbRow[];
+
+        const logs: GameLog[] = [];
+        for (const row of rows) {
+            const gameId = GAME_TYPE_TO_ID[row.game_type];
+            if (!gameId) {
+                // GAME_TYPES の範囲外（CHECK 制約破壊 / 旧データ等）は DB 整合性異常として
+                // 警告ログに残しつつスキップする。呼び出し元は length チェックで
+                // 「未完了」として 400 incomplete_games に振る。
+                console.error('Unknown game_type in game_logs:', { userId, row });
+                continue;
+            }
+            const { game_type: _omit, ...rest } = row;
+            logs.push({ ...rest, game_id: gameId });
+        }
+        return logs;
     },
 
-    async existsLog(userId: string, gameType: GameType): Promise<boolean> {
+    async existsLog(userId: string, gameId: GameId): Promise<boolean> {
         const { data } = await supabase
             .from('game_logs')
             .select('id')
             .eq('user_id', userId)
-            .eq('game_type', gameType)
+            .eq('game_type', ID_TO_GAME_TYPE[gameId])
             .limit(1);
 
         return (data?.length ?? 0) > 0;
-    }
+    },
 };

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -1,11 +1,12 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { gameService } from '../services/gameService';
+import { GAME_TYPE_TO_ID } from '../analysis/registry';
 import { validate } from '../middleware/validate';
 import {
     submitGameRequestSchema,
     SubmitGameRequest,
     SubmitGameResponse,
 } from '../schemas/games';
+import { gameService } from '../services/gameService';
 
 const router = Router();
 
@@ -15,7 +16,16 @@ router.post(
     async (req: Request, res: Response, next: NextFunction) => {
         try {
             const { user_id, game_type, data } = req.body as SubmitGameRequest;
-            await gameService.submitGame(user_id, game_type, data);
+
+            // HTTP 境界（Anti-Corruption Layer / Issue #101）。
+            // 仕様維持のため API の wire format は数値 game_type のままとし、
+            // service 層へ渡す前にドメインの文字列 GameId に変換する。
+            // game_type は zod スキーマで 1/2/3 のいずれかに narrow 済みのため、
+            // GAME_TYPE_TO_ID のキー網羅性が保証される（ID_TO_GAME_TYPE と
+            // 対称な定数を `analysis/registry.ts` に集約してある）。
+            const gameId = GAME_TYPE_TO_ID[game_type];
+
+            await gameService.submitGame(user_id, gameId, data);
 
             const response: SubmitGameResponse = {
                 status: 'success',

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -46,21 +46,73 @@ export const resultsParamsSchema = z.object({
 const partialBaselineScoresSchema = baselineScoresSchema.partial();
 
 /**
- * ゲーム識別子（文字列リテラル列挙）。
+ * ゲーム識別子（文字列リテラル列挙）の値。
  *
- * `game_breakdown` / `phase_summaries` / `details` の各要素を識別するキー。
- * Phase 3 で導入予定の `analysis/registry.ts` の `GameId` 型と同値（先取り定義）。
- * Phase 3 で `Object.keys(GAME_MODULES)` から導出する形に置換する想定。
+ * `game_breakdown` / `phase_summaries` / `details` の各要素を識別するキーで、
+ * `analysis/registry.ts` の `GAME_MODULES` のキーと一致する必要がある（registry.ts 側で
+ * `Record<GameId, ...>` の型整合性が強制される）。
+ *
+ * `analysis/registry.ts` の真実の単一ソース問題:
+ * - 本ファイル（schemas）が `analysis/registry.ts` を import すると schemas → analysis の
+ *   逆方向依存になる。既存のレイヤー方針（routes → services → repositories と並列で
+ *   schemas は analysis に依存されるが逆は持たない）を尊重するため、`GameId` の真実は
+ *   本ファイル側に維持する。
+ * - registry 側で `as const satisfies Record<GameId, ...>`（実装は GameModulesMap 型）を
+ *   使うことで「GAME_MODULES の登録漏れ・余分・キー名と module.id の不一致」を
+ *   コンパイル時に検出するため、Issue 本文の参考設計（GAME_MODULES 由来）と同等の
+ *   型安全性が得られる。
+ *
+ * 配列スキーマ（gameBreakdownSchema / phaseSummariesSchema / detailsSchema）の
+ * `.length()` 制約も `GAME_ID_VALUES.length` から導出する（registry を参照しない）。
  *
  * 文字列リテラル列挙で OpenAPI に公開する用途、かつエラーコード差別化が不要な
- * ケースのため `z.enum` を採用（数値リテラルなら `z.literal(VALUES).openapi({ enum: VALUES })`、
- * `invalid_request` と業務エラーコードを区別する必要があれば `z.string().refine()` を使う）。
- * これにより FE 生成型でも `'terms_game' | 'helpdesk_game' | 'group_chat_game'` の
- * リテラル絞り込みが効き、Swagger UI でも enum が明示される。
- *
- * 同パターンの先行例: `schemas/voice.ts` の `conversationMessageSchema.role`（`z.enum(['user', 'assistant'])`）。
+ * ケースのため `z.enum` を採用（同パターンの先行例: `schemas/voice.ts` の
+ * `conversationMessageSchema.role`）。
  */
 const GAME_ID_VALUES = ['terms_game', 'helpdesk_game', 'group_chat_game'] as const;
+
+/**
+ * 登録済みゲーム数（= 結果レスポンスの配列長制約）。
+ *
+ * `gameBreakdownSchema` / `phaseSummariesSchema` / `detailsSchema` は登録ゲーム分の
+ * 要素を必ず含む配列として扱い、`.length()` で長さを強制する。これは結果レスポンスの
+ * 上流で `incomplete_games` ガード（services/resultService.ts）により 3 ゲーム揃った
+ * ケースのみがレスポンスに到達する設計のため、欠落・重複を zod 層で検出する。
+ *
+ * `GAME_ID_VALUES` から導出するため、ゲームを追加したときは本ファイルの `GAME_ID_VALUES`
+ * と `analysis/registry.ts` の `GAME_MODULES` の両方を更新すれば自動で追従する
+ * （`GAME_MODULES` の登録漏れは registry 側の型 `GameModulesMap` で検出される）。
+ */
+const GAME_COUNT = GAME_ID_VALUES.length;
+
+/**
+ * 配列要素の `game_id` がユニークか判定する `.refine` 用ヘルパ。
+ *
+ * `gameBreakdownSchema` / `phaseSummariesSchema` / `detailsSchema` で共通利用する。
+ * 上流の `incomplete_games` ガードで 3 ゲーム完走が保証されている前提でも、
+ * バリデーション層で重複 `game_id` を弾くことで FE 側の `find(game_id === 'xxx')`
+ * が静かに `undefined` を返す状況を構造的に防止する（PR #104 レビュー指摘）。
+ */
+const hasUniqueGameIds = <T extends { game_id: string }>(arr: readonly T[]): boolean =>
+    new Set(arr.map((e) => e.game_id)).size === arr.length;
+const uniqueGameIdRefineMessage = 'game_id must be unique within the array';
+
+/**
+ * `.length(N).refine(...)` で zod runtime 検証を入れた配列スキーマに対し、
+ * OpenAPI 側で `minItems / maxItems` を明示するためのメタデータ片。
+ *
+ * 現状の `@asteasolutions/zod-to-openapi` v8 は `.refine()` でラップされた
+ * ZodEffects から内側の `.length()` 制約を辿らないため、`.length()` だけでは
+ * OpenAPI ドキュメントに `minItems/maxItems` が出ない。`.openapi({ minItems, maxItems })`
+ * で明示することで Swagger UI と FE 生成型の双方に長さ制約を伝える。
+ *
+ * runtime 検証は `.length()` チェーン側で担保しているので、本メタデータは
+ * ドキュメント表現の補強に過ぎない（値の二重管理は GAME_COUNT に集約済み）。
+ */
+const fixedGameCountOpenApi = {
+    minItems: GAME_COUNT,
+    maxItems: GAME_COUNT,
+} as const;
 
 export const gameIdSchema = registry.register(
     'GameId',
@@ -95,10 +147,17 @@ export const gameBreakdownSchema = registry.register(
                 }),
             }),
         )
+        // 配列長は登録ゲーム数に固定し、`game_id` の重複を弾く（PR #104 レビュー対応）。
+        // 上流の `incomplete_games` ガード（services/resultService.ts）で 3 ゲーム完走が
+        // 保証されている前提だが、欠落・重複をバリデーション層で構造的に防止する。
+        .length(GAME_COUNT)
+        .refine(hasUniqueGameIds, { message: uniqueGameIdRefineMessage })
         .openapi({
+            ...fixedGameCountOpenApi,
             description:
                 'ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため ' +
-                '5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）',
+                '5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）。' +
+                `配列長は登録ゲーム数（${GAME_COUNT}）に固定され、game_id はユニーク。`,
             example: resultsResponseExample.game_breakdown,
         }),
 );
@@ -146,8 +205,15 @@ export const phaseSummariesSchema = registry.register(
                 }),
             }),
         )
+        // 配列長 = 登録ゲーム数 + `game_id` ユニーク強制（PR #104 レビュー対応）。
+        // 詳細は gameBreakdownSchema 側のコメント参照。
+        .length(GAME_COUNT)
+        .refine(hasUniqueGameIds, { message: uniqueGameIdRefineMessage })
         .openapi({
-            description: '各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列',
+            ...fixedGameCountOpenApi,
+            description:
+                '各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列。' +
+                `配列長は登録ゲーム数（${GAME_COUNT}）に固定され、game_id はユニーク。`,
             example: resultsResponseExample.phase_summaries,
         }),
 );
@@ -231,10 +297,16 @@ export const detailsSchema = registry.register(
     'Details',
     z
         .array(gameDetailSchema)
+        // 配列長 = 登録ゲーム数 + `game_id` ユニーク強制（PR #104 レビュー対応）。
+        // 詳細は gameBreakdownSchema 側のコメント参照。
+        .length(GAME_COUNT)
+        .refine(hasUniqueGameIds, { message: uniqueGameIdRefineMessage })
         .openapi({
+            ...fixedGameCountOpenApi,
             description:
                 '各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）の配列。' +
-                '構造は仕様書「データ構造」→ GameDetail を参照',
+                '構造は仕様書「データ構造」→ GameDetail を参照。' +
+                `配列長は登録ゲーム数（${GAME_COUNT}）に固定され、game_id はユニーク。`,
             example: resultsResponseExample.details,
         }),
 );

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -1,62 +1,50 @@
+import { GAME_MODULES } from '../analysis/registry';
+import { GameRawDataPayload, gameRepository } from '../repositories/gameRepository';
 import { userRepository } from '../repositories/userRepository';
-import { gameRepository, GameRawDataPayload } from '../repositories/gameRepository';
-import { GAME_TYPES, GameType } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
-import {
-    game1DataSchema,
-    game2DataSchema,
-    game3DataSchema,
-} from '../schemas/gameData';
+import type { GameId } from '../types';
 
 /**
- * game_type に応じて、受け取った data を対応する zod スキーマで parse する。
+ * GameId に応じて、受け取った data を対応する zod スキーマで parse する。
  *
- * route 層の `submitGameRequestSchema`（discriminatedUnion 化済み）で data の
- * 構造は既に検証されているため、本関数の safeParse は実質的にはパススルーになる。
- * ただし以下の理由で safeParse + switch の構造を残している:
+ * route 層の `submitGameRequestSchema`（discriminatedUnion）で data の構造は既に検証
+ * されているため、本関数の safeParse は実質的にはパススルーになる。それでも残すのは
+ * 以下の理由:
  * - service が将来 route 以外（CLI / batch ジョブ等）から呼ばれた場合の防御
- * - `gameType` と `rawData` を組（判別可能 union `GameRawDataPayload`）として
- *   返すことで、`gameRepository.saveLog` の引数で gameType と rawData の
+ * - `gameId` と `rawData` を組（判別可能 union `GameRawDataPayload`）として
+ *   返すことで、`gameRepository.saveLog` の引数で gameId と rawData の
  *   ミスマッチを型レベルで弾く
+ *
+ * 実装は `analysis/registry.ts` の `GAME_MODULES` から対応モジュールの schema を
+ * 引いて parse する。新ゲーム追加時は GAME_MODULES に登録するだけで自動的に
+ * 検証対象に含まれる（旧実装の switch 文は不要）。
  *
  * 構造違反（必須フィールド欠落・型違い等）はクライアント起因の不正リクエストとして
  * 400 `invalid_request` を throw する。詳細な issue は warn ログに残し、
  * クライアントへの message は固定文言にして内部構造の漏洩を防ぐ。
  */
-function parseGameData(gameType: GameType, data: Record<string, unknown>): GameRawDataPayload {
-    switch (gameType) {
-        case GAME_TYPES.TERMS_GAME: {
-            const result = game1DataSchema.safeParse(data);
-            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
-            return { gameType, rawData: result.data };
-        }
-        case GAME_TYPES.AI_CHAT: {
-            const result = game2DataSchema.safeParse(data);
-            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
-            return { gameType, rawData: result.data };
-        }
-        case GAME_TYPES.GROUP_CHAT: {
-            const result = game3DataSchema.safeParse(data);
-            if (!result.success) throw invalidGameDataError(gameType, result.error.issues);
-            return { gameType, rawData: result.data };
-        }
-        default: {
-            // 網羅性チェック: GameType に新しい値を追加した際、ここで型エラーを出して
-            // case 追加を強制する（型システム上は到達不能なため、ランタイム throw も保険として残す）
-            const _exhaustive: never = gameType;
-            throw new Error(`Unknown game type: ${_exhaustive}`);
-        }
-    }
+function parseGameData(gameId: GameId, data: Record<string, unknown>): GameRawDataPayload {
+    const module = GAME_MODULES[gameId];
+    const result = module.schema.safeParse(data);
+    if (!result.success) throw invalidGameDataError(gameId, result.error.issues);
+
+    // GameRawDataPayload は `gameId` ごとに rawData の型が異なる判別可能 union。
+    // GAME_MODULES[gameId] の schema は対応する Game1Data / Game2Data / Game3Data を
+    // parse するが、registry の `GameModuleEntry` では schema を `ZodTypeAny` として
+    // 保持しており parse 戻り値が unknown 化する。型整合性はキー名と `module.id` の
+    // 一致を `GameModulesMap` で強制した上で確保しているため、ここでアサーションして
+    // 上位の判別可能 union（GameRawDataPayload）に詳細型を伝える。
+    return { gameId, rawData: result.data } as GameRawDataPayload;
 }
 
 /**
  * Game data の zod parse 失敗時に throw する API エラーオブジェクトを生成する。
  *
- * `parseGameData` の各 case で同じ形のエラーを throw するため、ヘルパに切り出して
- * 詳細な issue は warn ログに残し、クライアントには固定文言だけを返す。
+ * `parseGameData` から呼ばれる。詳細な issue は warn ログに残し、
+ * クライアントには固定文言だけを返す。
  */
-function invalidGameDataError(gameType: GameType, issues: unknown) {
-    console.warn('Game data validation failed:', { gameType, issues });
+function invalidGameDataError(gameId: GameId, issues: unknown) {
+    console.warn('Game data validation failed:', { gameId, issues });
     return {
         status: 400,
         code: ERROR_CODES.INVALID_REQUEST,
@@ -69,12 +57,15 @@ export const gameService = {
      * ゲームプレイデータを保存する。
      *
      * リクエスト形状の検証（必須・型・game_type の範囲・data が空でないこと）は
-     * route 層の zod ミドルウェアで完了している前提。
+     * route 層の zod ミドルウェアで完了している前提。route 層は HTTP リクエストの
+     * 数値 game_type を文字列 GameId に変換した上で本メソッドを呼ぶ
+     * （Anti-Corruption Layer / Issue #101）。
+     *
      * ここでは DB を参照しないと判定できない業務ルール
-     * （ユーザー存在確認・同一ゲーム重複送信）と、game_type に応じた data 構造の
+     * （ユーザー存在確認・同一ゲーム重複送信）と、gameId に応じた data 構造の
      * 検証（parseGameData）を行う。
      */
-    async submitGame(userId: string, gameType: GameType, data: Record<string, unknown>) {
+    async submitGame(userId: string, gameId: GameId, data: Record<string, unknown>) {
         // ユーザー存在確認
         const exists = await userRepository.exists(userId);
         if (!exists) {
@@ -82,13 +73,17 @@ export const gameService = {
         }
 
         // 重複送信チェック
-        const alreadySubmitted = await gameRepository.existsLog(userId, gameType);
+        const alreadySubmitted = await gameRepository.existsLog(userId, gameId);
         if (alreadySubmitted) {
-            throw { status: 409, code: ERROR_CODES.DUPLICATE_SUBMISSION, message: `Game ${gameType} is already submitted` };
+            throw {
+                status: 409,
+                code: ERROR_CODES.DUPLICATE_SUBMISSION,
+                message: `Game ${gameId} is already submitted`,
+            };
         }
 
-        // game_type に応じた構造検証 → 判別可能 union として保存
-        const parsedPayload = parseGameData(gameType, data);
+        // gameId に応じた構造検証 → 判別可能 union として保存
+        const parsedPayload = parseGameData(gameId, data);
         await gameRepository.saveLog(userId, parsedPayload);
-    }
+    },
 };

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -24,8 +24,10 @@ import type { GameId } from '../types';
  * クライアントへの message は固定文言にして内部構造の漏洩を防ぐ。
  */
 function parseGameData(gameId: GameId, data: Record<string, unknown>): GameRawDataPayload {
-    const module = GAME_MODULES[gameId];
-    const result = module.schema.safeParse(data);
+    // 変数名は CommonJS のグローバル `module` と衝突しないよう `gameModule` にする
+    // （tsconfig: "module": "commonjs" 環境ではシャドーするため）。
+    const gameModule = GAME_MODULES[gameId];
+    const result = gameModule.schema.safeParse(data);
     if (!result.success) throw invalidGameDataError(gameId, result.error.issues);
 
     // GameRawDataPayload は `gameId` ごとに rawData の型が異なる判別可能 union。

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -32,10 +32,10 @@ function parseGameData(gameId: GameId, data: Record<string, unknown>): GameRawDa
 
     // GameRawDataPayload は `gameId` ごとに rawData の型が異なる判別可能 union。
     // GAME_MODULES[gameId] の schema は対応する Game1Data / Game2Data / Game3Data を
-    // parse するが、registry の `GameModuleEntry` では schema を `ZodTypeAny` として
-    // 保持しており parse 戻り値が unknown 化する。型整合性はキー名と `module.id` の
-    // 一致を `GameModulesMap` で強制した上で確保しているため、ここでアサーションして
-    // 上位の判別可能 union（GameRawDataPayload）に詳細型を伝える。
+    // parse するが、registry の `GameModuleEntry` では schema をジェネリックなしの
+    // `ZodType` として保持しており parse 戻り値が unknown 化する。型整合性はキー名と
+    // `module.id` の一致を `GameModulesMap` で強制した上で確保しているため、ここで
+    // アサーションして上位の判別可能 union（GameRawDataPayload）に詳細型を伝える。
     return { gameId, rawData: result.data } as GameRawDataPayload;
 }
 

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -13,7 +13,7 @@ import {
 } from '../schemas/gameData';
 
 import { getMbtiScores } from '../analysis/mbtiScoreTable';
-import { BaselineScores, GAME_TYPES, GameLog, ResultResponse } from '../types';
+import { BaselineScores, GameLog, ResultResponse } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
 
 /**
@@ -84,13 +84,15 @@ export const resultService = {
             throw { status: 400, code: ERROR_CODES.INCOMPLETE_GAMES, message: 'All games must be completed' };
         }
 
-        // 分析（analysis/ に委譲）
-        const game1Log = gameLogs.find(log => log.game_type === GAME_TYPES.TERMS_GAME);
-        const game2Log = gameLogs.find(log => log.game_type === GAME_TYPES.AI_CHAT);
-        const game3Log = gameLogs.find(log => log.game_type === GAME_TYPES.GROUP_CHAT);
+        // 分析（analysis/ に委譲）。Issue #101 で GameLog はドメイン文字列 ID
+        // （`game_id: GameId`）を保持する形に変更されたため、find のキーは文字列リテラル
+        // で照合する（DB の数値 game_type は repositories 層で吸収済み）。
+        const game1Log = gameLogs.find(log => log.game_id === 'terms_game');
+        const game2Log = gameLogs.find(log => log.game_id === 'helpdesk_game');
+        const game3Log = gameLogs.find(log => log.game_id === 'group_chat_game');
 
         // raw_data は GameLog.raw_data: unknown のため、scoreCalculator に渡す前に
-        // game_type ごとの zod スキーマで parse する。DB 整合性が壊れていた場合は
+        // game_id ごとの zod スキーマで parse する。DB 整合性が壊れていた場合は
         // 500 `server_error` で明示的に失敗させる（parseGameLogOrThrow 内で throw）。
         const game1Data: Game1Data | undefined = parseGameLogOrThrow(game1Log, game1DataSchema, 'game1', userId);
         const game2Data: Game2Data | undefined = parseGameLogOrThrow(game2Log, game2DataSchema, 'game2', userId);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -24,11 +24,14 @@ export type {
 } from '../schemas/games';
 
 // results エンドポイントの型は schemas/results.ts に集約済み
+// GameId は schemas/results.ts の gameIdSchema からの導出型を再エクスポート
+// （`analysis/registry.ts` の GAME_MODULES のキーとも一致）。
 export type {
   Details,
   DiagnosisFeedback,
   GameBreakdown,
   GameDetail,
+  GameId,
   PhaseSummaries,
   ResultResponse,
 } from '../schemas/results';
@@ -59,12 +62,19 @@ export interface User {
   created_at: string;
 }
 
+// GameId のドメイン文字列 ID を `game_id` として保持する。GameLog はドメイン層
+// （services / analysis）で参照される型のため、Issue #101 の Anti-Corruption Layer 設計に
+// 従い文字列 ID で扱う。DB の game_logs テーブル自体は `game_type INT` のままで、
+// `repositories/gameRepository.ts` が SELECT/INSERT 時に GAME_TYPE_TO_ID / ID_TO_GAME_TYPE で
+// 双方向変換する責務を持つ。
+import type { GameId } from '../schemas/results';
+
 export interface GameLog {
   id: number;
   user_id: string;
-  game_type: number;
+  game_id: GameId;
   // raw_data は JSONB カラム。型は Game1Data / Game2Data / Game3Data のいずれかで、
-  // game_type に応じて分かれるが、DB 読み出し時点では構造の整合性は未検証のため `unknown` とする。
+  // game_id に応じて分かれるが、DB 読み出し時点では構造の整合性は未検証のため `unknown` とする。
   // service 境界（resultService）で zod スキーマ（schemas/gameData.ts）により parse する。
   raw_data: unknown;
   played_at: string;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,3 +1,8 @@
+// 値ではなく型のみ参照する import は通常の `export type { ... } from ...` では
+// このファイル内のスコープには値が入らない（再エクスポート専用）ため、`GameLog`
+// の型注釈用に別途明示的に import する。
+import type { GameId } from '../schemas/results';
+
 // ========================================
 // API Request/Response型
 // ========================================
@@ -62,13 +67,11 @@ export interface User {
   created_at: string;
 }
 
-// GameId のドメイン文字列 ID を `game_id` として保持する。GameLog はドメイン層
-// （services / analysis）で参照される型のため、Issue #101 の Anti-Corruption Layer 設計に
-// 従い文字列 ID で扱う。DB の game_logs テーブル自体は `game_type INT` のままで、
+// GameLog はドメイン層（services / analysis）で参照される型のため、Issue #101 の
+// Anti-Corruption Layer 設計に従い文字列 ID（`game_id: GameId`）で扱う。
+// DB の game_logs テーブル自体は `game_type INT` のままで、
 // `repositories/gameRepository.ts` が SELECT/INSERT 時に GAME_TYPE_TO_ID / ID_TO_GAME_TYPE で
 // 双方向変換する責務を持つ。
-import type { GameId } from '../schemas/results';
-
 export interface GameLog {
   id: number;
   user_id: string;

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -717,7 +717,7 @@ export interface components {
          */
         GameId: "terms_game" | "helpdesk_game" | "group_chat_game";
         /**
-         * @description ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）
+         * @description ゲームごとのスコア内訳の配列。各ゲームで測定される軸のみが含まれるため 5 軸すべてが揃うとは限らない（例: terms_game は caution / logic / calmness のみ）。配列長は登録ゲーム数（3）に固定され、game_id はユニーク。
          * @example [
          *       {
          *         "game_id": "terms_game",
@@ -787,7 +787,7 @@ export interface components {
             gap_point: string;
         };
         /**
-         * @description 各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列
+         * @description 各ゲーム終了後の行動を日本語テキストで振り返ったサマリーの配列。配列長は登録ゲーム数（3）に固定され、game_id はユニーク。
          * @example [
          *       {
          *         "game_id": "terms_game",
@@ -856,7 +856,7 @@ export interface components {
             }[];
         };
         /**
-         * @description 各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）の配列。構造は仕様書「データ構造」→ GameDetail を参照
+         * @description 各ゲーム固有の詳細情報（タイトル / feature_scores / metrics）の配列。構造は仕様書「データ構造」→ GameDetail を参照。配列長は登録ゲーム数（3）に固定され、game_id はユニーク。
          * @example [
          *       {
          *         "game_id": "terms_game",


### PR DESCRIPTION
## 概要

Issue #101 / Phase 3a の実装。ゲーム ID の中央レジストリ（`analysis/registry.ts`）を作成し、ドメイン層を文字列 ID（`'terms_game'` / `'helpdesk_game'` / `'group_chat_game'`）で扱うよう変更した。DB との境界（`repositories/`）と HTTP との境界（`routes/`）でのみ INT ↔ 文字列 ID 変換を行う（Anti-Corruption Layer パターン）。DB スキーマと HTTP API の wire format は変更していない。

PR #104 のレビュー指摘（結果配列スキーマの長さ・`game_id` ユニーク制約）も併せて反映。

## 変更内容

### registry + DB 境界変換
- `backend/src/analysis/registry.ts` を新規追加
  - `GAME_MODULES`（`Record<GameId, GameModuleEntry>` 型でキー網羅性と `module.id` 一致をコンパイル時に強制）
  - `GAME_TYPE_TO_ID` / `ID_TO_GAME_TYPE`（双方向変換マップ）
  - `NORMAL_FLOW`（通常版のゲームプレイ順序）
- `backend/src/repositories/gameRepository.ts`: SELECT/INSERT 時に INT ↔ 文字列 ID 変換、`existsLog` の引数を `GameId` に変更
- `backend/src/routes/games.ts`: HTTP リクエストの数値 `game_type` を service 層へ渡す前に `GameId` に変換
- `backend/src/services/gameService.ts`: `submitGame` の引数を `GameId` に変更し、`parseGameData` の switch を `GAME_MODULES` 参照に置換
- `backend/src/services/resultService.ts`: `gameLogs.find` の照合キーを `log.game_id === 'xxx'` に変更、不要な `GAME_TYPES` import を削除
- `backend/src/types/index.ts`: `GameLog.game_type: number` → `game_id: GameId` に変更し、`GameId` 型を re-export

### 結果配列スキーマの制約強化
- `backend/src/schemas/results.ts`: `gameBreakdownSchema` / `phaseSummariesSchema` / `detailsSchema` に `.length(GAME_COUNT)` と `game_id` ユニーク性の `.refine` を追加。`zod-to-openapi` v8 が `.refine` でラップされた ZodEffects から内側の `.length` を辿らないため、`.openapi({ minItems, maxItems })` で OpenAPI 側を補強
- `frontend/src/lib/api/generated.ts`: 上記スキーマ変更に伴う再生成（description のみの差分）

## 設計上の判断

Issue 本文の参考設計では `type GameId = keyof typeof GAME_MODULES` だったが、`schemas → analysis` の逆方向依存を避けるため案 A を採用した:

- `GameId` の真実の単一ソースは `schemas/results.ts`（zod スキーマ `gameIdSchema` と一体管理）
- `analysis/registry.ts` は `Record<GameId, GameModuleEntry<K>>` 型で、各キーに対する登録漏れ・余分・キー名と `module.id` の不一致をコンパイル時に検出

参考設計と等価以上の型安全性を確保しつつ、レイヤー方向（`analysis → schemas`）を維持している。

## スコープ外

- aggregator 導入（Issue #102）
- DB スキーマの変更（リファクタ全体方針として変更しない）
- 機能・挙動の変更

## 完了条件

- [x] `registry.ts` に `GAME_MODULES` / 変換マップ / `NORMAL_FLOW` が定義されている
- [x] ドメイン層（services / analysis）が文字列 ID で扱われている
- [x] DB との境界でのみ INT ↔ 文字列 ID 変換が行われている
- [x] DB スキーマが変わっていない
- [x] 機能・挙動が変わっていない
- [x] `detailsSchema` / `gameBreakdownSchema` / `phaseSummariesSchema` に `.length(N)` と `game_id` ユニーク性の `.refine` が追加されている

closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ゲームモジュールの中央化された管理により、ゲーム識別子の一貫した扱いを導入しました。
* **改善・最適化**
  * サービスとルート間でドメインIDを使用する流れに移行し、データ処理の整合性を向上しました。
  * 結果スキーマに固定長・一意性の検証を追加し、入力データの堅牢性を強化しました。
* **ドキュメント**
  * APIドキュメントに固定長配列と識別子要件を明記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->