### PR TITLE
refactor: aggregator.ts 新規追加 + scoreCalculator 縮小 (#102)

### DIFF
--- a/backend/src/analysis/aggregator.ts
+++ b/backend/src/analysis/aggregator.ts
@@ -1,0 +1,86 @@
+import type { GameId } from '../schemas/results';
+import { BaselineScores, SCORE_KEYS } from '../types';
+import { safeScore } from './scoreUtils';
+
+/**
+ * 軸統合（ゲーム横断のスコア合算）の汎用ロジック（Issue #102 / Phase 3b）。
+ *
+ * 設計方針:
+ * - 「各軸ごとに、その軸を測定した全ゲームの平均」を取る純粋関数として定義する。
+ *   軸-ゲーム対応はゲームモジュール側（`analyze()` の戻り値 `scores` キー）に
+ *   集約されているため、本ファイルはどのゲームがどの軸を測るかを意識しない。
+ * - 旧 `scoreCalculator.ts` でハードコードしていた軸ごとの平均計算
+ *   （例: `(g1.caution + g3.caution) / 2`）を本関数に置き換える。
+ *   入力同一なら出力も同一になることを Issue #102 完了条件で要求しているため、
+ *   `safeScore`（既存の clamp + Math.round）で 0-100 整数化する点も維持する。
+ *
+ * 仕様の確認:
+ * - 軸ごとの集計対象は「scores[axis] !== undefined」のゲームのみ。
+ *   undefined（測定対象外）は集計から除外する。
+ * - 全ゲームで未測定の軸は中立値 50 を返す（旧実装ではコード上発生しないが、
+ *   将来的に「全ゲームで測られない軸」が追加されたケースの安全弁として設定）。
+ * - 平均は単純算術平均。重み付けはしない。
+ */
+
+/**
+ * 軸統合の入力単位。
+ *
+ * `game_id` は集計値そのものには影響しないが、デバッグ・ログ整合のために
+ * 各 contribution が「どのゲームから来たか」を明示する。
+ * `scores` は当該ゲームで測定した軸のみを含む `Partial<BaselineScores>`。
+ *
+ * 形状は `schemas/results.ts` の `gameBreakdownSchema` の各要素と同一のため、
+ * scoreCalculator では `game_breakdown` 配列をそのまま `aggregateScores` に
+ * 渡せる（同じ型として扱える）。
+ */
+export type GameContribution = {
+    readonly game_id: GameId;
+    readonly scores: Partial<BaselineScores>;
+};
+
+/**
+ * 全ゲームで未測定の軸に対するフォールバック値。
+ *
+ * 5 軸スコアの仕様上「測定不能」を表す中立値は 50（各ゲームモジュールの
+ * 早期 return も 50 を返している）。本値はあくまで保険であり、現状の
+ * 3 ゲーム構成では全 contributions に必ずいずれかの軸が含まれるため到達しない。
+ */
+const NEUTRAL_SCORE = 50;
+
+/**
+ * 5 軸の列挙（`SCORE_KEYS` から導出）。
+ *
+ * `BaselineScores` のキーと一致することを `satisfies` で保証する。
+ * 軸の追加・削除は `types/index.ts` の `SCORE_KEYS` 1 箇所で完結する。
+ */
+const AXES = Object.values(SCORE_KEYS) satisfies readonly (keyof BaselineScores)[];
+
+/**
+ * 各軸ごとに、その軸を測定したゲームのスコア平均を取って 5 軸スコアを構築する。
+ *
+ * 例: contributions = [
+ *   { game_id: 'terms_game',     scores: { caution: 60, logic: 70, calmness: 55 } },
+ *   { game_id: 'helpdesk_game',  scores: { positivity: 65, calmness: 50, logic: 75 } },
+ *   { game_id: 'group_chat_game', scores: { cooperativeness: 80, positivity: 70, caution: 45 } },
+ * ]
+ * → caution        = round((60 + 45) / 2) = 53
+ * → calmness       = round((55 + 50) / 2) = 53
+ * → logic          = round((70 + 75) / 2) = 73
+ * → cooperativeness = round(80) = 80
+ * → positivity     = round((65 + 70) / 2) = 68
+ *
+ * 入力が空 / 全軸 undefined の場合は全軸 NEUTRAL_SCORE を返す。
+ */
+export function aggregateScores(contributions: readonly GameContribution[]): BaselineScores {
+    const result = {} as BaselineScores;
+    for (const axis of AXES) {
+        const values = contributions
+            .map((c) => c.scores[axis])
+            .filter((v): v is number => v !== undefined);
+        result[axis] =
+            values.length > 0
+                ? safeScore(values.reduce((sum, v) => sum + v, 0) / values.length)
+                : NEUTRAL_SCORE;
+    }
+    return result;
+}

--- a/backend/src/analysis/aggregator.ts
+++ b/backend/src/analysis/aggregator.ts
@@ -72,15 +72,25 @@ const AXES = Object.values(SCORE_KEYS) satisfies readonly (keyof BaselineScores)
  * 入力が空 / 全軸 undefined の場合は全軸 NEUTRAL_SCORE を返す。
  */
 export function aggregateScores(contributions: readonly GameContribution[]): BaselineScores {
-    const result = {} as BaselineScores;
+    // 全軸を NEUTRAL_SCORE で初期化してから AXES ループで上書きする。
+    // 型注釈 `BaselineScores` により未来の軸追加（例: BaselineScores に新軸が追加されたが
+    // SCORE_KEYS / AXES に追加し忘れた場合）でコンパイル時に検出できるとともに、
+    // 万一 AXES が漏れていても result の値が undefined / NaN にならず NEUTRAL_SCORE に
+    // フォールバックする（aggregator 利用先での `gaps` 計算で NaN が伝播するのを防ぐ）。
+    const result: BaselineScores = {
+        caution: NEUTRAL_SCORE,
+        calmness: NEUTRAL_SCORE,
+        logic: NEUTRAL_SCORE,
+        cooperativeness: NEUTRAL_SCORE,
+        positivity: NEUTRAL_SCORE,
+    };
     for (const axis of AXES) {
         const values = contributions
             .map((c) => c.scores[axis])
             .filter((v): v is number => v !== undefined);
-        result[axis] =
-            values.length > 0
-                ? safeScore(values.reduce((sum, v) => sum + v, 0) / values.length)
-                : NEUTRAL_SCORE;
+        if (values.length > 0) {
+            result[axis] = safeScore(values.reduce((sum, v) => sum + v, 0) / values.length);
+        }
     }
     return result;
 }

--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -1,4 +1,5 @@
 import { Game3Data, game3DataSchema } from '../../schemas/games/groupChatGame';
+import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv, logNorm } from '../scoreUtils';
 
 /**
@@ -6,20 +7,16 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
  *
  * Issue #100 で `scoreCalculator.ts` の `calculateGame3` と
  * `phaseSummaryBuilder.ts` の Phase 3 テキスト生成ロジックを 1 ファイルに凝集。
- *
- * - `analyze(data)`: 行動データから 5 軸の中間集計（協調性・積極性・慎重さ）を算出
- * - `buildSummary(data)`: 行動データを日本語の要約テキストに整形
- *
- * 後続 Issue #101 で `analysis/registry.ts` の `GAME_MODULES` に登録される予定。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の Game3 要素も
+ * `buildDetails` として本ファイルに移管。
  */
 
 /**
- * `analyze()` の戻り値型。
+ * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
+ * 詳細は `termsGame.ts` の `Game1AnalyzeResult` コメント参照。
  */
-export type Game3Result = {
-    cooperativeness: number;
-    positivity: number;
-    caution: number;
+export type Game3AnalyzeResult = {
+    scores: { cooperativeness: number; positivity: number; caution: number };
     conformCount: number;
     avgReact: number;
 };
@@ -32,14 +29,12 @@ export type Game3Result = {
  * - 積極性(positivity): 即応性
  * - 慎重さ(caution): チュートリアル確認・反応安定
  */
-function analyze(data: Game3Data | undefined): Game3Result {
-    // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+function analyze(data: Game3Data | undefined): Game3AnalyzeResult {
+    // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
     // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
         return {
-            cooperativeness: 50,
-            positivity: 50,
-            caution: 50,
+            scores: { cooperativeness: 50, positivity: 50, caution: 50 },
             conformCount: 0,
             avgReact: 0,
         };
@@ -78,15 +73,17 @@ function analyze(data: Game3Data | undefined): Game3Result {
 
     const caution = Math.round(sTutorial * 0.5 + sVariance * 0.5);
 
-    return { cooperativeness, positivity, caution, conformCount, avgReact };
+    return {
+        scores: { cooperativeness, positivity, caution },
+        conformCount,
+        avgReact,
+    };
 }
 
 /**
  * Game3 行動データ → 結果画面に表示するサマリーテキスト。
  *
  * 例: 「グループの空気を敏感に察知して周りに合わせ、即決でアクションを起こしました。」
- *
- * 旧 `phaseSummaryBuilder.ts` の Phase 3 ロジックをそのまま移管。
  */
 function buildSummary(data: Game3Data | undefined): string {
     if (!data) return 'データなし';
@@ -118,12 +115,60 @@ function buildSummary(data: Game3Data | undefined): string {
 }
 
 /**
+ * Game3 行動データ + analyze 結果 → 結果画面 details 用の構造体。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の Game3 要素を移管。挙動は完全同一。
+ */
+function buildDetails(data: Game3Data | undefined, result: Game3AnalyzeResult): GameDetail {
+    // 旧 scoreCalculator では `(g3.conformCount / (game3Raw?.stages?.length || 1)) * 100` で
+    // 同調率を算出していた。stages 件数は data 側、conformCount は analyze 結果側にあるため
+    // 両方を参照する（挙動は完全同一）。
+    return {
+        game_id: groupChatGameModule.id,
+        title: groupChatGameModule.title,
+        feature_scores: [
+            { axis: 'cooperativeness', name: '協調性', score: result.scores.cooperativeness },
+            { axis: 'positivity', name: '積極性', score: result.scores.positivity },
+        ],
+        metrics: [
+            {
+                label: '同調率(%)',
+                user: Math.round(((result.conformCount ?? 0) / (data?.stages?.length || 1)) * 100),
+                average: 75,
+                category: 'social',
+            },
+            {
+                label: '反応潜時(ms)',
+                user: Math.round(result.avgReact ?? 0),
+                average: 3500,
+                category: 'time',
+            },
+            {
+                label: '本音ホバー(回)',
+                user: data?.hoveredOptions ?? 0,
+                average: 2.4,
+                category: 'mouse',
+            },
+            {
+                label: '譲り合い待機(ms)',
+                user: data?.typingIndicatorReactTimeMs ?? 0,
+                average: 2000,
+                category: 'time',
+            },
+        ],
+    };
+}
+
+/**
  * Game3（空気読みグループチャット）モジュール。
+ * registry の `GameModuleEntry` 型に合わせて `unknown` 入力のアダプタを薄く挟む
+ * （詳細は `termsGame.ts` の export コメント参照）。
  */
 export const groupChatGameModule = {
     id: 'group_chat_game' as const,
     title: '空気読みグループチャット',
     schema: game3DataSchema,
-    analyze,
-    buildSummary,
+    analyze: (data: unknown) => analyze(data as Game3Data | undefined),
+    buildSummary: (data: unknown) => buildSummary(data as Game3Data | undefined),
+    buildDetails: (data: unknown, result: unknown) =>
+        buildDetails(data as Game3Data | undefined, result as Game3AnalyzeResult),
 };

--- a/backend/src/analysis/games/helpdeskGame.ts
+++ b/backend/src/analysis/games/helpdeskGame.ts
@@ -1,4 +1,5 @@
 import { Game2Data, game2DataSchema } from '../../schemas/games/helpdeskGame';
+import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
 
 /**
@@ -6,20 +7,16 @@ import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
  *
  * Issue #100 で `scoreCalculator.ts` の `calculateGame2` と
  * `phaseSummaryBuilder.ts` の Phase 2 テキスト生成ロジックを 1 ファイルに凝集。
- *
- * - `analyze(data)`: 行動データから 5 軸の中間集計（積極性・冷静さ・論理性）を算出
- * - `buildSummary(data)`: 行動データを日本語の要約テキストに整形
- *
- * 後続 Issue #101 で `analysis/registry.ts` の `GAME_MODULES` に登録される予定。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の Game2 要素も
+ * `buildDetails` として本ファイルに移管。
  */
 
 /**
- * `analyze()` の戻り値型。
+ * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
+ * 詳細は `termsGame.ts` の `Game1AnalyzeResult` コメント参照。
  */
-export type Game2Result = {
-    positivity: number;
-    calmness: number;
-    logic: number;
+export type Game2AnalyzeResult = {
+    scores: { positivity: number; calmness: number; logic: number };
     avgReact: number;
     totalSpeech: number;
     avgVolume: number;
@@ -34,14 +31,12 @@ export type Game2Result = {
  * - 冷静さ(calmness): 音量安定・沈黙率・打鍵安定
  * - 論理性(logic): 論理接続詞・不要語
  */
-function analyze(data: Game2Data | undefined): Game2Result {
-    // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+function analyze(data: Game2Data | undefined): Game2AnalyzeResult {
+    // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
     // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
         return {
-            positivity: 50,
-            calmness: 50,
-            logic: 50,
+            scores: { positivity: 50, calmness: 50, logic: 50 },
             avgReact: 0,
             totalSpeech: 0,
             avgVolume: 0,
@@ -110,9 +105,7 @@ function analyze(data: Game2Data | undefined): Game2Result {
     const logic = Math.round(sLogicWords * 0.6 + sFiller * 0.4);
 
     return {
-        positivity,
-        calmness,
-        logic,
+        scores: { positivity, calmness, logic },
         avgReact,
         totalSpeech,
         avgVolume,
@@ -124,8 +117,6 @@ function analyze(data: Game2Data | undefined): Game2Result {
  * Game2 行動データ → 結果画面に表示するサマリーテキスト。
  *
  * 例: 「AIの理不尽な対応に即座に反応し、音声で堂々と反論を展開しました。」
- *
- * 旧 `phaseSummaryBuilder.ts` の Phase 2 ロジックをそのまま移管。
  */
 function buildSummary(data: Game2Data | undefined): string {
     if (!data) return 'データなし';
@@ -173,12 +164,58 @@ function buildSummary(data: Game2Data | undefined): string {
 }
 
 /**
+ * Game2 行動データ + analyze 結果 → 結果画面 details 用の構造体。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の Game2 要素を移管。挙動は完全同一。
+ */
+function buildDetails(_data: Game2Data | undefined, result: Game2AnalyzeResult): GameDetail {
+    return {
+        game_id: helpdeskGameModule.id,
+        title: helpdeskGameModule.title,
+        feature_scores: [
+            { axis: 'positivity', name: '積極性', score: result.scores.positivity },
+            { axis: 'calmness', name: '冷静さ', score: result.scores.calmness },
+            { axis: 'logic', name: '論理性', score: result.scores.logic },
+        ],
+        metrics: [
+            {
+                label: '反応潜時(ms)',
+                user: Math.round(result.avgReact ?? 0),
+                average: 2500,
+                category: 'time',
+            },
+            {
+                label: '発話時間(秒)',
+                user: Number(((result.totalSpeech ?? 0) / 1000).toFixed(1)),
+                average: 4.2,
+                category: 'time',
+            },
+            {
+                label: '平均音量(dB)',
+                user: Number((result.avgVolume ?? 0).toFixed(1)),
+                average: -25.0,
+                category: 'voice',
+            },
+            {
+                label: '論理的接続詞(回)',
+                user: result.logicWordsCount ?? 0,
+                average: 0.5,
+                category: 'logic',
+            },
+        ],
+    };
+}
+
+/**
  * Game2（AI カスタマーサポート）モジュール。
+ * registry の `GameModuleEntry` 型に合わせて `unknown` 入力のアダプタを薄く挟む
+ * （詳細は `termsGame.ts` の export コメント参照）。
  */
 export const helpdeskGameModule = {
     id: 'helpdesk_game' as const,
     title: 'AIカスタマーサポート',
     schema: game2DataSchema,
-    analyze,
-    buildSummary,
+    analyze: (data: unknown) => analyze(data as Game2Data | undefined),
+    buildSummary: (data: unknown) => buildSummary(data as Game2Data | undefined),
+    buildDetails: (data: unknown, result: unknown) =>
+        buildDetails(data as Game2Data | undefined, result as Game2AnalyzeResult),
 };

--- a/backend/src/analysis/games/termsGame.ts
+++ b/backend/src/analysis/games/termsGame.ts
@@ -1,32 +1,36 @@
 import { Game1Data, game1DataSchema } from '../../schemas/games/termsGame';
+import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv, logNorm } from '../scoreUtils';
 
 /**
  * Game1（利用規約ゲーム）の分析モジュール。
  *
  * Issue #100 で `scoreCalculator.ts` の `calculateGame1` と
- * `phaseSummaryBuilder.ts` の Phase 1 テキスト生成ロジックを
- * 1 ファイルに凝集した（純粋なファイル分割。挙動は同一）。
+ * `phaseSummaryBuilder.ts` の Phase 1 テキスト生成ロジックを 1 ファイルに凝集した。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の Game1 要素
+ * （title / feature_scores / metrics）も `buildDetails` として本ファイルに移管し、
+ * scoreCalculator は薄い統合層に縮小した。
  *
- * - `analyze(data)`: 行動データから 5 軸の中間集計（慎重さ・論理性・冷静さ）を算出
+ * - `analyze(data)`: 行動データから 5 軸の中間集計（慎重さ・論理性・冷静さ）と
+ *   要約に使う中間メトリクスを算出
  * - `buildSummary(data)`: 行動データを日本語の要約テキストに整形
- *
- * 後続 Issue #101 で `analysis/registry.ts` の `GAME_MODULES` に登録される予定。
+ * - `buildDetails(data, result)`: 結果画面の details 用構造体（feature_scores / metrics）を構築
  */
 
 /**
  * `analyze()` の戻り値型。
  *
- * 早期 return（data が undefined のとき）と通常 return の shape が一致することを
- * TypeScript で検出可能にするため、ローカル type として明示する。
+ * Issue #102 で構造を 2 階層に変更:
+ * - `scores`: Partial<BaselineScores> 相当。aggregator の入力 / game_breakdown の
+ *   `scores` フィールドにそのまま使える（軸-ゲーム対応はモジュール側に集約）。
+ * - 残りのフィールド: 要約・details で使う中間統計量（averageSpeed 等）。
  *
- * 命名は `details.metrics` 等に出す統計量（changedCount / averageSpeed 等）を含む点で
- * 5 軸スコアそのものではなく「ゲームごとの中間集計」を表す。
+ * 旧構造（フラット）から `scores` を分離する目的は、scoreCalculator が
+ * 「軸スコアと中間メトリクス」を判別するロジックを持たずに済むようにするため。
+ * scores キーは `keyof BaselineScores` の部分集合で、当該ゲームが測定する軸のみ。
  */
-export type Game1Result = {
-    caution: number;
-    logic: number;
-    calmness: number;
+export type Game1AnalyzeResult = {
+    scores: { caution: number; logic: number; calmness: number };
     changedCount: number;
     averageSpeed: number;
     reversalCount: number;
@@ -69,14 +73,12 @@ function computeScrollMetrics(scrollEvents: Game1Data['scrollEvents']) {
  * - 論理性(logic): 再確認行動・逆行スクロール・ポップアップ処理
  * - 冷静さ(calmness): マウスブレ・無駄クリック
  */
-function analyze(data: Game1Data | undefined): Game1Result {
-    // 早期 return は通常 return と同じ shape を返す（details.metrics 側で欠損プロパティに
+function analyze(data: Game1Data | undefined): Game1AnalyzeResult {
+    // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
     // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
         return {
-            caution: 50,
-            logic: 50,
-            calmness: 50,
+            scores: { caution: 50, logic: 50, calmness: 50 },
             changedCount: 0,
             averageSpeed: 0,
             reversalCount: 0,
@@ -119,9 +121,7 @@ function analyze(data: Game1Data | undefined): Game1Result {
     const calmness = Math.round(sJitter * 0.6 + sClick * 0.4);
 
     return {
-        caution,
-        logic,
-        calmness,
+        scores: { caution, logic, calmness },
         changedCount: checkboxChanged,
         averageSpeed: speed,
         reversalCount,
@@ -132,8 +132,6 @@ function analyze(data: Game1Data | undefined): Game1Result {
  * Game1 行動データ → 結果画面に表示するサマリーテキスト。
  *
  * 例: 「規約をじっくりと読み込み、わずか12.3秒で同意ボタンを押しました。メルマガの罠に見事に引っかかりました。」
- *
- * 旧 `phaseSummaryBuilder.ts` の Phase 1 ロジックをそのまま移管。
  */
 function buildSummary(data: Game1Data | undefined): string {
     if (!data) return 'データなし';
@@ -156,16 +154,92 @@ function buildSummary(data: Game1Data | undefined): string {
 }
 
 /**
+ * Game1 行動データ + analyze 結果 → 結果画面 details 用の構造体。
+ *
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の Game1 要素を移管。
+ * scoreCalculator が「どの軸を測るか」「どのメトリクスを表示するか」を意識せず
+ * モジュール側から `GameDetail` を完成形で受け取れるようにした。挙動は完全同一。
+ *
+ * `feature_scores` / `metrics` の各値は仕様書「データ構造」→ `GameDetail` 準拠。
+ * `metrics` の平均値・カテゴリは旧 scoreCalculator の値をそのまま転記している。
+ */
+function buildDetails(data: Game1Data | undefined, result: Game1AnalyzeResult): GameDetail {
+    return {
+        game_id: termsGameModule.id,
+        title: termsGameModule.title,
+        feature_scores: [
+            { axis: 'caution', name: '慎重さ', score: result.scores.caution },
+            { axis: 'logic', name: '論理性', score: result.scores.logic },
+            { axis: 'calmness', name: '冷静さ', score: result.scores.calmness },
+        ],
+        // result.averageSpeed / result.reversalCount は analyze() 内で scrollEvents から
+        // 算出済み（仕様書上、FE は scrollEvents のみ送信する設計のため、raw_data には
+        // scrollMetrics は無い）
+        metrics: [
+            {
+                label: '読了速度(px/s)',
+                user: Math.round(result.averageSpeed ?? 0),
+                average: 800,
+                category: 'scroll',
+            },
+            {
+                label: '総滞在時間(秒)',
+                user: Number((data?.totalTime ?? 0).toFixed(1)),
+                average: 15.0,
+                category: 'time',
+            },
+            {
+                label: '決断前迷い(ms)',
+                user: data?.agreeButtonHoverTimeMs ?? 0,
+                average: 1200,
+                category: 'mouse',
+            },
+            {
+                label: 'チェック変更(回)',
+                user: result.changedCount,
+                average: 3.2,
+                category: 'input',
+            },
+            {
+                label: '逆行確認(回)',
+                user: result.reversalCount ?? 0,
+                average: 2.1,
+                category: 'scroll',
+            },
+            {
+                label: 'マウスブレ(px)',
+                user: data?.popupStats?.mouseJitter ?? 0,
+                average: 12.0,
+                category: 'mouse',
+            },
+            {
+                label: '無駄クリック(回)',
+                user: data?.popupStats?.clickCount ?? 0,
+                average: 1.5,
+                category: 'mouse',
+            },
+        ],
+    };
+}
+
+/**
  * Game1（利用規約ゲーム）モジュール。
  *
- * Issue #101 で `analysis/registry.ts` の `GAME_MODULES` から参照される予定。
- * `id` は `phase_summaries` / `details` / `game_breakdown` 配列内の `game_id`
- * として使われる文字列 ID（Phase 1 / Issue #97 で導入）と一致させる。
+ * `analysis/registry.ts` の `GAME_MODULES` から参照される。
+ * `id` は `phase_summaries` / `details` / `game_breakdown` 配列内の `game_id` として
+ * 使われる文字列 ID（Phase 1 / Issue #97 で導入）と一致させる。
+ *
+ * registry の `GameModuleEntry` 型は各メソッドを `(data: unknown) => ...` として
+ * 受け取るため、内部の typed 関数を薄いアダプタで unknown 入力に対応させる
+ * （`gameService.ts` の `parseGameData` と同じトラスト境界パターン）。
+ * data は registry の schema で zod-parsed されたものが境界を経て届く前提。
  */
 export const termsGameModule = {
     id: 'terms_game' as const,
     title: '利用規約ゲーム',
     schema: game1DataSchema,
-    analyze,
-    buildSummary,
+    analyze: (data: unknown) => analyze(data as Game1Data | undefined),
+    buildSummary: (data: unknown) => buildSummary(data as Game1Data | undefined),
+    buildDetails: (data: unknown, result: unknown) =>
+        buildDetails(data as Game1Data | undefined, result as Game1AnalyzeResult),
 };

--- a/backend/src/analysis/registry.ts
+++ b/backend/src/analysis/registry.ts
@@ -1,6 +1,6 @@
 import type { ZodType } from 'zod';
-import type { GameId } from '../schemas/results';
-import { GAME_TYPES } from '../types';
+import type { GameDetail, GameId } from '../schemas/results';
+import { BaselineScores, GAME_TYPES } from '../types';
 import { groupChatGameModule } from './games/groupChatGame';
 import { helpdeskGameModule } from './games/helpdeskGame';
 import { termsGameModule } from './games/termsGame';
@@ -13,8 +13,9 @@ import { termsGameModule } from './games/termsGame';
  *   DB の数値 game_type（1/2/3）はこの層では意識せず、`repositories/` と `routes/` の
  *   境界でのみ INT ↔ 文字列 ID 変換を行う（Anti-Corruption Layer パターン）。
  * - 新ゲームの追加・差し替え・順序変更は本ファイルへの登録 1 行で済むことを目指す。
- *   将来 aggregator（Issue #102）から `Object.values(GAME_MODULES)` で全モジュールを
- *   走査して軸統合する流れになる。
+ *   Issue #102 で `scoreCalculator` / `resultService` が `NORMAL_FLOW` をループして
+ *   各モジュールの `analyze` / `buildSummary` / `buildDetails` を呼び出し、軸統合は
+ *   `analysis/aggregator.ts` の `aggregateScores` に汎用化された。
  *
  * 真実の単一ソースについて:
  * - `GameId` 型と `GAME_ID_VALUES` の真実は `schemas/results.ts` 側に置く（zod スキーマ
@@ -27,6 +28,22 @@ import { termsGameModule } from './games/termsGame';
  */
 
 /**
+ * `analyze()` の戻り値が必ず満たす最低限の構造（Issue #102 で導入）。
+ *
+ * 各ゲームモジュールはこれを拡張した具体型（Game1AnalyzeResult 等）を返すが、
+ * registry レベルではゲーム横断で利用される `scores` のみ型情報を保持する。
+ * `scores` は当該ゲームが測定する軸の部分集合（`Partial<BaselineScores>`）で、
+ * scoreCalculator は `result.scores` をそのまま `aggregator.aggregateScores`
+ * に渡すことで軸統合を行う。
+ *
+ * 中間メトリクス（averageSpeed / avgReact 等）は同じモジュール内の
+ * `buildDetails` だけが参照するため、registry の型としては露出しない。
+ */
+export type GameAnalyzeResult = {
+    readonly scores: Partial<BaselineScores>;
+};
+
+/**
  * ゲームモジュールが満たすべき最小インタフェース。
  *
  * `id` のキーごとの型パラメータ化（`{ readonly id: TId }`）により、
@@ -34,10 +51,16 @@ import { termsGameModule } from './games/termsGame';
  * コンパイル時に強制する（例: `terms_game` キーに `id: 'helpdesk_game'` の
  * モジュールを誤登録するとコンパイルエラー）。
  *
- * `analyze` / `buildSummary` の引数・戻り値はゲームごとに Game1Data / Game2Data
- * 等で異なるため、本 registry レベルでは詳細型を保持しない（`unknown`）。
- * 詳細型が必要な `scoreCalculator.ts` は各モジュールを直接 import して
- * 既存の型を維持する（Issue #102 で aggregator に集約する予定）。
+ * Issue #102 で `analyze` の戻り値に共通の `scores` 構造を導入し、`buildDetails`
+ * を追加した。各メソッドの引数は `unknown` で受け取り、各モジュール側の
+ * アダプタが具体型（Game1Data 等）にキャストする方針（`gameService.parseGameData`
+ * と同じトラスト境界パターン）。これにより registry 経由のループ呼び出し
+ * （`scoreCalculator` / `resultService` 側）で型エラーにならず、かつ
+ * モジュール内部の typed 関数の契約は維持できる。
+ *
+ * `buildDetails` の第 2 引数は `analyze` の戻り値（モジュール固有の中間メトリクス
+ * を含む）。registry レベルでは詳細型を保持できないため `unknown` として受け、
+ * 各モジュールの adapter で具体型に narrow する。
  */
 type GameModuleEntry<TId extends GameId> = {
     readonly id: TId;
@@ -50,8 +73,9 @@ type GameModuleEntry<TId extends GameId> = {
     // 値型として保持しないが、parseGameData 内のアサーションで判別可能 union 側に
     // 戻す形を取っている。
     readonly schema: ZodType;
-    readonly analyze: (data: never) => unknown;
-    readonly buildSummary: (data: never) => string;
+    readonly analyze: (data: unknown) => GameAnalyzeResult;
+    readonly buildSummary: (data: unknown) => string;
+    readonly buildDetails: (data: unknown, result: unknown) => GameDetail;
 };
 
 type GameModulesMap = { readonly [K in GameId]: GameModuleEntry<K> };
@@ -59,8 +83,8 @@ type GameModulesMap = { readonly [K in GameId]: GameModuleEntry<K> };
 /**
  * ゲーム ID → 分析モジュールの対応表。
  *
- * 新ゲーム追加時は本オブジェクトに 1 行追加するだけで、aggregator（Issue #102 で導入予定）が
- * 自動的に走査対象に含める想定。
+ * 新ゲーム追加時は本オブジェクトに 1 行追加するだけで、`NORMAL_FLOW` のループ
+ * （scoreCalculator / resultService）が自動的に走査対象に含める。
  *
  * 型 `GameModulesMap` により以下をコンパイル時に強制する:
  * - 各 GameId のキーが揃っていること（漏れがあれば「Property 'xxx' is missing」）

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -1,249 +1,122 @@
+import type { GameId } from '../schemas/results';
 import { BaselineScores } from '../types';
-import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
+import { aggregateScores } from './aggregator';
 import { generateFeedback } from './feedbackGenerator';
-import { termsGameModule } from './games/termsGame';
-import { helpdeskGameModule } from './games/helpdeskGame';
-import { groupChatGameModule } from './games/groupChatGame';
+import { GAME_MODULES, NORMAL_FLOW } from './registry';
 import { safeScore } from './scoreUtils';
 
 /**
- * 3ゲームの行動データから5軸特性を連続値(0-100)で算出する統合分析ロジック。
+ * 結果レスポンスを組み立てる薄い統合層（Issue #102 で縮小）。
  *
- * Issue #100 で各ゲームの計算ロジック（旧 calculateGame1/2/3）と要約テキスト生成
- * （旧 buildPhaseSummaries）は `analysis/games/<game>.ts` に分離され、本ファイルは
- * 各モジュールの結果を統合してレスポンスに整形する役割に絞られた。
+ * 旧 `scoreCalculator.ts`（約 250 行）はゲームごとの計算・要約・details 構築を
+ * 直接抱えていたが、Phase 1〜3 を通じて以下のように責務を移譲した:
  *
- * 後続 Issue #102（aggregator 導入）で軸統合ロジック（5 軸の合算 / details / metrics 構築）
- * は更に `analysis/aggregator.ts` に切り出される予定。
+ * - 各ゲームの分析・要約・details 構築 → `analysis/games/<game>.ts`
+ * - 軸統合（5 軸スコアの合算）            → `analysis/aggregator.ts`
+ * - ゲームの登録・順序                    → `analysis/registry.ts`
+ *
+ * 本ファイルに残るのは:
+ *   - registry でループしてモジュール出力（breakdown / summary / detail）を集約
+ *   - aggregator で 5 軸スコアを算出
+ *   - gaps と accuracy_score の単純計算
+ *   - feedbackGenerator の呼び出し
+ *
+ * これにより「軸-ゲーム対応の変更」「新ゲームの追加」は当該モジュール
+ * （`analysis/games/<game>.ts`）と registry への登録のみで完結する。
  *
  * ▼評価軸定義
- * 慎重さ(caution):
- *   情報確認・迷い時間・再確認行動の多さから算出。
- *
- * 冷静さ(calmness):
- *   マウスのブレ、無駄操作、音量安定性、打鍵安定性から算出。
- *
- * 論理性(logic):
- *   再確認行動、論理接続詞使用、不要語の少なさから算出。
- *
- * 協調性(cooperativeness):
- *   同調率、譲り待機時間、本音葛藤行動から算出。
- *
- * 積極性(positivity):
- *   反応速度、発話量、即応性から算出。
+ * 慎重さ(caution):       情報確認・迷い時間・再確認行動
+ * 冷静さ(calmness):      マウスのブレ・無駄操作・音量安定性・打鍵安定性
+ * 論理性(logic):         再確認行動・論理接続詞使用・不要語の少なさ
+ * 協調性(cooperativeness): 同調率・譲り待機時間・本音葛藤行動
+ * 積極性(positivity):    反応速度・発話量・即応性
  */
 
-//統合生成
+/**
+ * ゲーム ID → 該当ゲームの行動データ（zod-parsed 後の `unknown`）の対応マップ。
+ *
+ * resultService 側で `GAME_MODULES[gameId].schema` で parse 済みの値が入る。
+ * 値の具体型（Game1Data 等）は registry レベルでは保持できないため `unknown` だが、
+ * 各モジュールの adapter（`termsGameModule.analyze` 等）が具体型に narrow する。
+ *
+ * 未送信ゲームの値は undefined（`incomplete_games` ガード後は実質起こらないが、
+ * モジュール側の早期 return で安全に扱える）。
+ */
+export type GameDataByGameId = Readonly<Record<GameId, unknown>>;
 
+/**
+ * 5 軸スコアからベースラインとの差分を計算する。負値はベースライン下回り。
+ */
+function computeGaps(scores: BaselineScores, baseline: BaselineScores): BaselineScores {
+    return {
+        caution: scores.caution - baseline.caution,
+        calmness: scores.calmness - baseline.calmness,
+        logic: scores.logic - baseline.logic,
+        cooperativeness: scores.cooperativeness - baseline.cooperativeness,
+        positivity: scores.positivity - baseline.positivity,
+    };
+}
+
+/**
+ * gaps の絶対値平均から自己認識精度（0-100 の整数）を算出する。
+ * `safeScore` は 0-100 への clamp と Math.round を行う既存ユーティリティ。
+ */
+function computeAccuracyScore(gaps: BaselineScores): number {
+    const totalAbsGap =
+        Math.abs(gaps.caution) +
+        Math.abs(gaps.calmness) +
+        Math.abs(gaps.logic) +
+        Math.abs(gaps.cooperativeness) +
+        Math.abs(gaps.positivity);
+    return safeScore(100 - totalAbsGap / 5);
+}
+
+/**
+ * 3 ゲームの行動データから 5 軸スコア・gaps・feedback・details 等の結果レスポンス
+ * オブジェクトを組み立てる。
+ *
+ * 配列順は `NORMAL_FLOW`（terms_game → helpdesk_game → group_chat_game の通常フロー）に
+ * 合わせる。FE は配列内を `find(game_id === '...')` で参照する設計のため、配列順は
+ * セマンティクスに影響しないが、API レスポンスの安定化のため固定順で出力する。
+ */
 export function generateAnalysisResult(
     userId: string,
     selfMbti: string | undefined,
-    game1Raw: Game1Data | undefined,
-    game2Raw: Game2Data | undefined,
-    game3Raw: Game3Data | undefined,
+    dataByGameId: GameDataByGameId,
     baseline_scores: BaselineScores,
 ) {
-    const g1 = termsGameModule.analyze(game1Raw);
-    const g2 = helpdeskGameModule.analyze(game2Raw);
-    const g3 = groupChatGameModule.analyze(game3Raw);
+    // モジュールごとの出力を一度の loop で組み立てる。各モジュールの adapter が
+    // unknown データを内部の concrete 型に narrow するため、ここでは型を意識しない。
+    const moduleOutputs = NORMAL_FLOW.map((gameId) => {
+        const gameModule = GAME_MODULES[gameId];
+        const data = dataByGameId[gameId];
+        const analyzeResult = gameModule.analyze(data);
+        return {
+            breakdown: { game_id: gameId, scores: analyzeResult.scores },
+            summary: { game_id: gameId, summary: gameModule.buildSummary(data) },
+            detail: gameModule.buildDetails(data, analyzeResult),
+        };
+    });
 
-    // 配列形式（Phase 1 / Issue #97）。game_id は各モジュールの `id` フィールドを参照する
-    // （Phase 3 / Issue #101 で `analysis/registry.ts` の `NORMAL_FLOW` 経由に置き換える予定）。
-    // 配列順は terms_game → helpdesk_game → group_chat_game の通常フロー順。
-    const phaseSummaries = [
-        { game_id: termsGameModule.id, summary: termsGameModule.buildSummary(game1Raw) },
-        { game_id: helpdeskGameModule.id, summary: helpdeskGameModule.buildSummary(game2Raw) },
-        { game_id: groupChatGameModule.id, summary: groupChatGameModule.buildSummary(game3Raw) },
-    ];
+    const game_breakdown = moduleOutputs.map((m) => m.breakdown);
+    const phase_summaries = moduleOutputs.map((m) => m.summary);
+    const details = moduleOutputs.map((m) => m.detail);
 
-    const scores = {
-        caution: safeScore((g1.caution + g3.caution) / 2),
-        calmness: safeScore((g1.calmness + g2.calmness) / 2),
-        logic: safeScore((g1.logic + g2.logic) / 2),
-        cooperativeness: safeScore(g3.cooperativeness),
-        positivity: safeScore((g2.positivity + g3.positivity) / 2),
-    };
-
-    const gaps = {
-        caution: scores.caution - baseline_scores.caution,
-        calmness: scores.calmness - baseline_scores.calmness,
-        logic: scores.logic - baseline_scores.logic,
-        cooperativeness: scores.cooperativeness - baseline_scores.cooperativeness,
-        positivity: scores.positivity - baseline_scores.positivity,
-    };
-
-    const avgGap =
-        (Math.abs(gaps.caution) +
-            Math.abs(gaps.calmness) +
-            Math.abs(gaps.logic) +
-            Math.abs(gaps.cooperativeness) +
-            Math.abs(gaps.positivity)) /
-        5;
-
-    const accuracy_score = safeScore(100 - avgGap);
+    const scores = aggregateScores(game_breakdown);
+    const gaps = computeGaps(scores, baseline_scores);
+    const accuracy_score = computeAccuracyScore(gaps);
     const feedback = generateFeedback(scores, gaps);
 
     return {
         user_id: userId,
         self_mbti: selfMbti,
-        scores: scores,
-        baseline_scores: baseline_scores,
-        gaps: gaps,
-        // game_breakdown は配列形式（Phase 1 / Issue #97）。game_id は各モジュールの `id`
-        // フィールドを参照する（Phase 3 / Issue #101 で registry 経由に置き換え予定）。
-        // 配列順は terms_game → helpdesk_game → group_chat_game の通常フロー順。
-        game_breakdown: [
-            {
-                game_id: termsGameModule.id,
-                scores: { caution: g1.caution, logic: g1.logic, calmness: g1.calmness },
-            },
-            {
-                game_id: helpdeskGameModule.id,
-                scores: { positivity: g2.positivity, calmness: g2.calmness, logic: g2.logic },
-            },
-            {
-                game_id: groupChatGameModule.id,
-                scores: {
-                    cooperativeness: g3.cooperativeness,
-                    positivity: g3.positivity,
-                    caution: g3.caution,
-                },
-            },
-        ],
-        accuracy_score: accuracy_score,
-        feedback: feedback,
-        phase_summaries: phaseSummaries,
-
-        // details も配列形式（Phase 1 / Issue #97）。配列順は game_breakdown と揃える
-        // （terms_game → helpdesk_game → group_chat_game の通常フロー順）。
-        details: [
-            {
-                game_id: termsGameModule.id,
-                title: termsGameModule.title,
-                feature_scores: [
-                    { axis: 'caution', name: '慎重さ', score: g1.caution },
-                    { axis: 'logic', name: '論理性', score: g1.logic },
-                    { axis: 'calmness', name: '冷静さ', score: g1.calmness },
-                ],
-                // g1.averageSpeed / g1.reversalCount は termsGameModule.analyze() 内で
-                // scrollEvents から算出済み（仕様書上、FE は scrollEvents のみ送信する設計のため、
-                // raw_data には scrollMetrics は無い）
-                metrics: [
-                    {
-                        label: '読了速度(px/s)',
-                        user: Math.round(g1.averageSpeed ?? 0),
-                        average: 800,
-                        category: 'scroll',
-                    },
-                    {
-                        label: '総滞在時間(秒)',
-                        user: Number((game1Raw?.totalTime ?? 0).toFixed(1)),
-                        average: 15.0,
-                        category: 'time',
-                    },
-                    {
-                        label: '決断前迷い(ms)',
-                        user: game1Raw?.agreeButtonHoverTimeMs ?? 0,
-                        average: 1200,
-                        category: 'mouse',
-                    },
-                    {
-                        label: 'チェック変更(回)',
-                        user: g1.changedCount,
-                        average: 3.2,
-                        category: 'input',
-                    },
-                    {
-                        label: '逆行確認(回)',
-                        user: g1.reversalCount ?? 0,
-                        average: 2.1,
-                        category: 'scroll',
-                    },
-                    {
-                        label: 'マウスブレ(px)',
-                        user: game1Raw?.popupStats?.mouseJitter ?? 0,
-                        average: 12.0,
-                        category: 'mouse',
-                    },
-                    {
-                        label: '無駄クリック(回)',
-                        user: game1Raw?.popupStats?.clickCount ?? 0,
-                        average: 1.5,
-                        category: 'mouse',
-                    },
-                ],
-            },
-            {
-                game_id: helpdeskGameModule.id,
-                title: helpdeskGameModule.title,
-                feature_scores: [
-                    { axis: 'positivity', name: '積極性', score: g2.positivity },
-                    { axis: 'calmness', name: '冷静さ', score: g2.calmness },
-                    { axis: 'logic', name: '論理性', score: g2.logic },
-                ],
-                metrics: [
-                    {
-                        label: '反応潜時(ms)',
-                        user: Math.round(g2.avgReact ?? 0),
-                        average: 2500,
-                        category: 'time',
-                    },
-                    {
-                        label: '発話時間(秒)',
-                        user: Number(((g2.totalSpeech ?? 0) / 1000).toFixed(1)),
-                        average: 4.2,
-                        category: 'time',
-                    },
-                    {
-                        label: '平均音量(dB)',
-                        user: Number((g2.avgVolume ?? 0).toFixed(1)),
-                        average: -25.0,
-                        category: 'voice',
-                    },
-                    {
-                        label: '論理的接続詞(回)',
-                        user: g2.logicWordsCount ?? 0,
-                        average: 0.5,
-                        category: 'logic',
-                    },
-                ],
-            },
-            {
-                game_id: groupChatGameModule.id,
-                title: groupChatGameModule.title,
-                feature_scores: [
-                    { axis: 'cooperativeness', name: '協調性', score: g3.cooperativeness },
-                    { axis: 'positivity', name: '積極性', score: g3.positivity },
-                ],
-                metrics: [
-                    {
-                        label: '同調率(%)',
-                        user: Math.round(
-                            ((g3.conformCount ?? 0) / (game3Raw?.stages?.length || 1)) * 100,
-                        ),
-                        average: 75,
-                        category: 'social',
-                    },
-                    {
-                        label: '反応潜時(ms)',
-                        user: Math.round(g3.avgReact ?? 0),
-                        average: 3500,
-                        category: 'time',
-                    },
-                    {
-                        label: '本音ホバー(回)',
-                        user: game3Raw?.hoveredOptions ?? 0,
-                        average: 2.4,
-                        category: 'mouse',
-                    },
-                    {
-                        label: '譲り合い待機(ms)',
-                        user: game3Raw?.typingIndicatorReactTimeMs ?? 0,
-                        average: 2000,
-                        category: 'time',
-                    },
-                ],
-            },
-        ],
+        scores,
+        baseline_scores,
+        gaps,
+        game_breakdown,
+        accuracy_score,
+        feedback,
+        phase_summaries,
+        details,
     };
 }

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -1,19 +1,12 @@
 import { ZodType } from 'zod';
 import { userRepository } from '../repositories/userRepository';
 import { gameRepository } from '../repositories/gameRepository';
-import { generateAnalysisResult } from '../analysis/scoreCalculator';
+import { GameDataByGameId, generateAnalysisResult } from '../analysis/scoreCalculator';
+import { GAME_MODULES, NORMAL_FLOW } from '../analysis/registry';
 import { analysisResultRepository, AnalysisResultRow } from '../repositories/analysisResultRepository';
-import {
-    Game1Data,
-    Game2Data,
-    Game3Data,
-    game1DataSchema,
-    game2DataSchema,
-    game3DataSchema,
-} from '../schemas/gameData';
 
 import { getMbtiScores } from '../analysis/mbtiScoreTable';
-import { BaselineScores, GameLog, ResultResponse } from '../types';
+import { BaselineScores, GameId, GameLog, ResultResponse } from '../types';
 import { ERROR_CODES } from '../schemas/errorCodes';
 
 /**
@@ -23,12 +16,12 @@ import { ERROR_CODES } from '../schemas/errorCodes';
  * 500 `server_error` を throw する（運用上ほぼ起きない異常系。ログに詳細を残し、
  * クライアントへの message は固定文言にして内部情報の漏洩を防ぐ）。
  */
-function parseGameLogOrThrow<T>(
+function parseGameLogOrThrow(
     log: GameLog | undefined,
-    schema: ZodType<T>,
+    schema: ZodType,
     gameLabel: string,
     userId: string,
-): T | undefined {
+): unknown {
     if (!log) return undefined;
 
     const result = schema.safeParse(log.raw_data);
@@ -80,30 +73,30 @@ export const resultService = {
 
         // キャッシュなし → ゲームログから計算
         const gameLogs = await gameRepository.findLogsByUserId(userId);
-        if (gameLogs.length < 3) {
+        if (gameLogs.length < NORMAL_FLOW.length) {
             throw { status: 400, code: ERROR_CODES.INCOMPLETE_GAMES, message: 'All games must be completed' };
         }
 
         // 分析（analysis/ に委譲）。Issue #101 で GameLog はドメイン文字列 ID
         // （`game_id: GameId`）を保持する形に変更されたため、find のキーは文字列リテラル
         // で照合する（DB の数値 game_type は repositories 層で吸収済み）。
-        const game1Log = gameLogs.find(log => log.game_id === 'terms_game');
-        const game2Log = gameLogs.find(log => log.game_id === 'helpdesk_game');
-        const game3Log = gameLogs.find(log => log.game_id === 'group_chat_game');
-
+        // Issue #102 で registry でループする形に変更し、新ゲーム追加時は GAME_MODULES /
+        // NORMAL_FLOW への登録だけで scoreCalculator まで反映される設計にした。
+        //
         // raw_data は GameLog.raw_data: unknown のため、scoreCalculator に渡す前に
-        // game_id ごとの zod スキーマで parse する。DB 整合性が壊れていた場合は
+        // 各モジュールの zod スキーマで parse する。DB 整合性が壊れていた場合は
         // 500 `server_error` で明示的に失敗させる（parseGameLogOrThrow 内で throw）。
-        const game1Data: Game1Data | undefined = parseGameLogOrThrow(game1Log, game1DataSchema, 'game1', userId);
-        const game2Data: Game2Data | undefined = parseGameLogOrThrow(game2Log, game2DataSchema, 'game2', userId);
-        const game3Data: Game3Data | undefined = parseGameLogOrThrow(game3Log, game3DataSchema, 'game3', userId);
+        const dataByGameId = NORMAL_FLOW.reduce((acc, gameId) => {
+            const log = gameLogs.find((l) => l.game_id === gameId);
+            const gameModule = GAME_MODULES[gameId];
+            acc[gameId] = parseGameLogOrThrow(log, gameModule.schema, gameId, userId);
+            return acc;
+        }, {} as Record<GameId, unknown>) satisfies GameDataByGameId;
 
         const analysisResult = generateAnalysisResult(
             userId,
             user.self_mbti ?? undefined,
-            game1Data,
-            game2Data,
-            game3Data,
+            dataByGameId,
             baseline_scores
         );
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -78,7 +78,8 @@ export interface GameLog {
   game_id: GameId;
   // raw_data は JSONB カラム。型は Game1Data / Game2Data / Game3Data のいずれかで、
   // game_id に応じて分かれるが、DB 読み出し時点では構造の整合性は未検証のため `unknown` とする。
-  // service 境界（resultService）で zod スキーマ（schemas/gameData.ts）により parse する。
+  // service 境界（resultService）で対応モジュール（`GAME_MODULES[gameId].schema`）により
+  // parse する（Issue #102 で registry でループする形に変更）。
   raw_data: unknown;
   played_at: string;
 }


### PR DESCRIPTION
## 概要

親 Issue #96 の Phase 3b。軸統合を `analysis/aggregator.ts` に汎用化し、`analysis/scoreCalculator.ts` を「registry を呼んで aggregator に通す」だけの薄い統合層に縮小した。軸-ゲーム対応の変更が aggregator または該当モジュールの修正だけで完結する設計になる。

closes #102

## 変更内容

### 新規

- `backend/src/analysis/aggregator.ts`
  - 「各軸ごとに、その軸を測定した全ゲームの平均」を取る純粋関数 `aggregateScores`
  - AXES は `SCORE_KEYS`（`types/index.ts`）から導出、`safeScore` で 0-100 整数化
  - `result` を `BaselineScores` 注釈 + `NEUTRAL_SCORE` 初期化し、将来軸追加時の NaN 伝播を防止

### 修正

- `backend/src/analysis/scoreCalculator.ts`
  - 約 250 行 → 約 120 行（コード行数では ~50 行）。`NORMAL_FLOW` でループしてモジュール出力（breakdown / summary / detail）を集約し、`aggregateScores` で 5 軸を算出する形に
  - `gaps` / `accuracy_score` は局所ヘルパに切り出し、`generateFeedback` の呼び出しは既存通り
  - 入力を `dataByGameId: Record<GameId, unknown>` に変更（resultService 側でループ生成）
- `backend/src/analysis/games/{termsGame,helpdeskGame,groupChatGame}.ts`
  - `analyze()` の戻り値を `{ scores: Partial<BaselineScores>, ...intermediate metrics }` の 2 階層に再構成
  - `buildDetails(data, result): GameDetail` を追加（旧 scoreCalculator の `details` 配列の各ゲーム要素を移管。挙動完全同一）
  - registry 経由のループ呼び出しに合わせて、export の `analyze` / `buildSummary` / `buildDetails` は `unknown` を受けるアダプタ（内部関数は typed のまま）
- `backend/src/analysis/registry.ts`
  - `GameModuleEntry` 型に `buildDetails` を追加、`analyze` の戻り値型を `GameAnalyzeResult`（`scores: Partial<BaselineScores>`）に
  - `GAME_MODULES` / `ID_TO_GAME_TYPE` / `NORMAL_FLOW` のデータ構造は変更なし（#101 の成果を維持）
- `backend/src/services/resultService.ts`
  - `gameLogs.find(...) × 3` のハードコードを `NORMAL_FLOW.reduce` に置換
  - 完走判定 `gameLogs.length < 3` を `NORMAL_FLOW.length` に変更
  - `parseGameLogOrThrow` の戻り値を `unknown` に簡素化（registry 経由で各モジュールが narrow するため）
- `backend/src/types/index.ts`
  - `GameLog.raw_data` のコメントを registry 経由 parse 方針に追従

## 完了条件（Issue #102）

- [x] aggregator.ts が軸統合を汎用化している
- [x] scoreCalculator.ts が薄い統合層に縮小されている
- [x] 軸-ゲーム対応の変更が aggregator または該当モジュールの修正だけで完結する設計になっている
- [x] 既存 3 ゲームの結果が完全に同じ（5 軸全ての計算経路を旧 vs 新で手計算検証済み）
- [x] BE のテストが通る（tsc / build 通過）
- [x] 機能・挙動が変わっていない

## 動作検証ポイント

- 5 軸の集計式は旧コードと完全同一（caution: terms+groupChat / calmness: terms+helpdesk / logic: terms+helpdesk / cooperativeness: groupChat のみ / positivity: helpdesk+groupChat）
- 各ゲームの `details` の `feature_scores` / `metrics` 配列は旧コードからフィールド単位で転記
- 配列順は `NORMAL_FLOW`（terms_game → helpdesk_game → group_chat_game）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 分析エンジンのアーキテクチャを統合し、ゲーム分析結果の構造を標準化しました。スコア計算と詳細情報の生成ロジックを各ゲーム分析モジュールに整理し、システムの堅牢性と保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->