### PR TITLE
refactor: terms_game の型名を game_id ベースに統一 (1/3)

### DIFF
--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -13,7 +13,7 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
 
 /**
  * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
- * 詳細は `termsGame.ts` の `Game1AnalyzeResult` コメント参照。
+ * 詳細は `termsGame.ts` の `TermsGameAnalyzeResult` コメント参照。
  */
 export type Game3AnalyzeResult = {
     scores: { cooperativeness: number; positivity: number; caution: number };

--- a/backend/src/analysis/games/helpdeskGame.ts
+++ b/backend/src/analysis/games/helpdeskGame.ts
@@ -13,7 +13,7 @@ import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
 
 /**
  * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
- * 詳細は `termsGame.ts` の `Game1AnalyzeResult` コメント参照。
+ * 詳細は `termsGame.ts` の `TermsGameAnalyzeResult` コメント参照。
  */
 export type Game2AnalyzeResult = {
     scores: { positivity: number; calmness: number; logic: number };

--- a/backend/src/analysis/games/termsGame.ts
+++ b/backend/src/analysis/games/termsGame.ts
@@ -1,13 +1,13 @@
-import { Game1Data, game1DataSchema } from '../../schemas/games/termsGame';
+import { TermsGameData, termsGameDataSchema } from '../../schemas/games/termsGame';
 import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv, logNorm } from '../scoreUtils';
 
 /**
- * Game1（利用規約ゲーム）の分析モジュール。
+ * 利用規約ゲーム（terms_game）の分析モジュール。
  *
  * Issue #100 で `scoreCalculator.ts` の `calculateGame1` と
  * `phaseSummaryBuilder.ts` の Phase 1 テキスト生成ロジックを 1 ファイルに凝集した。
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の Game1 要素
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の terms_game 要素
  * （title / feature_scores / metrics）も `buildDetails` として本ファイルに移管し、
  * scoreCalculator は薄い統合層に縮小した。
  *
@@ -29,7 +29,7 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
  * 「軸スコアと中間メトリクス」を判別するロジックを持たずに済むようにするため。
  * scores キーは `keyof BaselineScores` の部分集合で、当該ゲームが測定する軸のみ。
  */
-export type Game1AnalyzeResult = {
+export type TermsGameAnalyzeResult = {
     scores: { caution: number; logic: number; calmness: number };
     changedCount: number;
     averageSpeed: number;
@@ -44,7 +44,7 @@ export type Game1AnalyzeResult = {
  * モジュール分割後は両関数が独立呼び出しになるため、内部で再計算する。
  * O(N) で軽量、計測値も同一になる。
  */
-function computeScrollMetrics(scrollEvents: Game1Data['scrollEvents']) {
+function computeScrollMetrics(scrollEvents: TermsGameData['scrollEvents']) {
     let totalDistance = 0;
     let reversalCount = 0;
 
@@ -66,14 +66,14 @@ function computeScrollMetrics(scrollEvents: Game1Data['scrollEvents']) {
 }
 
 /**
- * Game1 行動データ → 慎重さ・論理性・冷静さの中間集計。
+ * 利用規約ゲームの行動データ → 慎重さ・論理性・冷静さの中間集計。
  *
  * 評価軸:
  * - 慎重さ(caution): 滞在時間・スクロール速度・迷い時間・チェック変更
  * - 論理性(logic): 再確認行動・逆行スクロール・ポップアップ処理
  * - 冷静さ(calmness): マウスブレ・無駄クリック
  */
-function analyze(data: Game1Data | undefined): Game1AnalyzeResult {
+function analyze(data: TermsGameData | undefined): TermsGameAnalyzeResult {
     // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
     // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
@@ -90,7 +90,7 @@ function analyze(data: Game1Data | undefined): Game1AnalyzeResult {
     const { averageSpeed: speed, reversalCount } = computeScrollMetrics(scrollEvents);
 
     // checkboxStates の各エントリは { checked, changed } 形式。
-    // 型は Game1Data の indexed access で導出する（gameData.ts 側に新規 export を作らない）。
+    // 型は TermsGameData の indexed access で導出する（gameData.ts 側に新規 export を作らない）。
     const checkboxChanged = Object.values(data.checkboxStates).filter((c) => c.changed).length;
 
     //慎重さ: 滞在時間・スクロール速度・迷い時間・チェック変更
@@ -129,11 +129,11 @@ function analyze(data: Game1Data | undefined): Game1AnalyzeResult {
 }
 
 /**
- * Game1 行動データ → 結果画面に表示するサマリーテキスト。
+ * 利用規約ゲームの行動データ → 結果画面に表示するサマリーテキスト。
  *
  * 例: 「規約をじっくりと読み込み、わずか12.3秒で同意ボタンを押しました。メルマガの罠に見事に引っかかりました。」
  */
-function buildSummary(data: Game1Data | undefined): string {
+function buildSummary(data: TermsGameData | undefined): string {
     if (!data) return 'データなし';
 
     const timeSec = (data.totalTime ?? 0).toFixed(1);
@@ -143,7 +143,7 @@ function buildSummary(data: Game1Data | undefined): string {
     const speedText =
         speed > 2000 ? '爆速でスクロールし' : speed < 1000 ? 'じっくりと読み込み' : '平均的な速度で確認し';
 
-    // 仕様書「データ構造 → Game1Data → checkboxStates」で mailMagazine は { checked, changed } 形式
+    // 仕様書「データ構造 → TermsGameData → checkboxStates」で mailMagazine は { checked, changed } 形式
     // mailMagazine は初期値 ON のため checked === true が「外し忘れ＝罠にひっかかった」判定
     let trapText = '';
     const mailChecked = data.checkboxStates?.mailMagazine?.checked;
@@ -154,16 +154,16 @@ function buildSummary(data: Game1Data | undefined): string {
 }
 
 /**
- * Game1 行動データ + analyze 結果 → 結果画面 details 用の構造体。
+ * 利用規約ゲームの行動データ + analyze 結果 → 結果画面 details 用の構造体。
  *
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の Game1 要素を移管。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の terms_game 要素を移管。
  * scoreCalculator が「どの軸を測るか」「どのメトリクスを表示するか」を意識せず
  * モジュール側から `GameDetail` を完成形で受け取れるようにした。挙動は完全同一。
  *
  * `feature_scores` / `metrics` の各値は仕様書「データ構造」→ `GameDetail` 準拠。
  * `metrics` の平均値・カテゴリは旧 scoreCalculator の値をそのまま転記している。
  */
-function buildDetails(data: Game1Data | undefined, result: Game1AnalyzeResult): GameDetail {
+function buildDetails(data: TermsGameData | undefined, result: TermsGameAnalyzeResult): GameDetail {
     return {
         game_id: termsGameModule.id,
         title: termsGameModule.title,
@@ -223,7 +223,7 @@ function buildDetails(data: Game1Data | undefined, result: Game1AnalyzeResult): 
 }
 
 /**
- * Game1（利用規約ゲーム）モジュール。
+ * 利用規約ゲーム（terms_game）モジュール。
  *
  * `analysis/registry.ts` の `GAME_MODULES` から参照される。
  * `id` は `phase_summaries` / `details` / `game_breakdown` 配列内の `game_id` として
@@ -237,9 +237,9 @@ function buildDetails(data: Game1Data | undefined, result: Game1AnalyzeResult): 
 export const termsGameModule = {
     id: 'terms_game' as const,
     title: '利用規約ゲーム',
-    schema: game1DataSchema,
-    analyze: (data: unknown) => analyze(data as Game1Data | undefined),
-    buildSummary: (data: unknown) => buildSummary(data as Game1Data | undefined),
+    schema: termsGameDataSchema,
+    analyze: (data: unknown) => analyze(data as TermsGameData | undefined),
+    buildSummary: (data: unknown) => buildSummary(data as TermsGameData | undefined),
     buildDetails: (data: unknown, result: unknown) =>
-        buildDetails(data as Game1Data | undefined, result as Game1AnalyzeResult),
+        buildDetails(data as TermsGameData | undefined, result as TermsGameAnalyzeResult),
 };

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -129,11 +129,11 @@ export const registerResponseExample = {
 /**
  * game_type = 1（利用規約ゲーム）の data サンプル。
  *
- * data 構造の詳細は仕様書「データ構造」→ Game1Data を参照。OpenAPI の example は
+ * data 構造の詳細は仕様書「データ構造」→ TermsGameData を参照。OpenAPI の example は
  * 「何を送るべきか」をざっくり示すだけなので、全フィールド網羅ではなく
  * 代表的な値を入れる（仕様書の最小例）。
  */
-export const submitGameRequestExampleGame1 = {
+export const submitGameRequestExampleTermsGame = {
     user_id: SAMPLE_USER_ID,
     game_type: 1,
     data: {

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,6 +1,6 @@
 import { GAME_TYPE_TO_ID, ID_TO_GAME_TYPE } from '../analysis/registry';
 import { supabase } from '../db/client';
-import { Game1Data, Game2Data, Game3Data } from '../schemas/gameData';
+import { TermsGameData, Game2Data, Game3Data } from '../schemas/gameData';
 import { GameId, GameLog } from '../types';
 
 /**
@@ -16,7 +16,7 @@ import { GameId, GameLog } from '../types';
  * INT に変換して INSERT する（Anti-Corruption Layer パターン）。
  */
 export type GameRawDataPayload =
-    | { gameId: 'terms_game'; rawData: Game1Data }
+    | { gameId: 'terms_game'; rawData: TermsGameData }
     | { gameId: 'helpdesk_game'; rawData: Game2Data }
     | { gameId: 'group_chat_game'; rawData: Game3Data };
 

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -5,11 +5,11 @@
  * 再エクスポート専用にした。新規コードは `schemas/games/<game>.ts` を直接 import するか、
  * 本 barrel 経由でも構わない（既存 import パスを壊さない方針）。
  *
- * - Game1（利用規約ゲーム）: `./games/termsGame`
+ * - 利用規約ゲーム（terms_game / 旧 Game 1）: `./games/termsGame`
  * - Game2（AI カスタマーサポート）: `./games/helpdeskGame`
  * - Game3（空気読みグループチャット）: `./games/groupChatGame`
  */
 
-export { game1DataSchema, type Game1Data } from './games/termsGame';
+export { termsGameDataSchema, type TermsGameData } from './games/termsGame';
 export { game2DataSchema, type Game2Data } from './games/helpdeskGame';
 export { game3DataSchema, type Game3Data } from './games/groupChatGame';

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -6,12 +6,12 @@ import { registry } from '../openapi/registry';
 import { userIdSchema } from './common';
 import { GAME_TYPES } from '../types';
 import {
-    game1DataSchema,
+    termsGameDataSchema,
     game2DataSchema,
     game3DataSchema,
 } from './gameData';
 import {
-    submitGameRequestExampleGame1,
+    submitGameRequestExampleTermsGame,
     submitGameRequestExampleGame2,
     submitGameRequestExampleGame3,
     submitGameResponseExample,
@@ -75,7 +75,7 @@ export const gameTypeSchema = registry.register(
  *
  * `z.discriminatedUnion('game_type', [...])` で `game_type` × `data` の対応を
  * 型レベルで強制する（Issue #58）:
- * - game_type === 1 のとき data は Game1Data
+ * - game_type === 1 のとき data は TermsGameData
  * - game_type === 2 のとき data は Game2Data
  * - game_type === 3 のとき data は Game3Data
  *
@@ -104,12 +104,12 @@ export const submitGameRequestSchema = registry.register(
                 .object({
                     user_id: userIdSchema,
                     game_type: z.literal(GAME_TYPES.TERMS_GAME),
-                    data: game1DataSchema,
+                    data: termsGameDataSchema,
                 })
                 .openapi({
                     description:
-                        'Game1（利用規約ゲーム）の終了時に送るリクエスト',
-                    example: submitGameRequestExampleGame1,
+                        '利用規約ゲーム（game_type=1）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleTermsGame,
                 }),
             z
                 .object({

--- a/backend/src/schemas/games/termsGame.ts
+++ b/backend/src/schemas/games/termsGame.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { registry } from '../../openapi/registry';
 
 /**
- * Game1（利用規約ゲーム）の行動データ（raw_data）の zod スキーマ群。
+ * 利用規約ゲーム（terms_game / 旧 Game 1）の行動データ（raw_data）の zod スキーマ群。
  *
  * 設計方針:
  * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
@@ -19,7 +19,7 @@ import { registry } from '../../openapi/registry';
  */
 
 /**
- * Game1 のスクロールイベント（200ms 間隔のサンプリングログ）。
+ * 利用規約ゲームのスクロールイベント（200ms 間隔のサンプリングログ）。
  */
 const scrollEventSchema = registry.register(
     'ScrollEvent',
@@ -33,18 +33,18 @@ const scrollEventSchema = registry.register(
             }),
         })
         .openapi({
-            description: 'Game1 のスクロールイベント（200ms 間隔のサンプリングログ）',
+            description: '利用規約ゲームのスクロールイベント（200ms 間隔のサンプリングログ）',
             example: { position: 1200, timestamp: 2500 },
         }),
 );
 
 /**
- * Game1 のチェックボックス状態。
+ * 利用規約ゲームのチェックボックス状態。
  *
  * - `checked`: 最終的なチェック状態
  * - `changed`: ユーザーが初期状態から変更したか
  *
- * 仕様書「データ構造 → Game1Data → checkboxStates」では readConfirm / mailMagazine /
+ * 仕様書「データ構造 → TermsGameData → checkboxStates」では readConfirm / mailMagazine /
  * thirdPartyShare の 3 つに同形が使われるため、共通サブスキーマとして定義する。
  */
 const checkboxStateSchema = registry.register(
@@ -60,16 +60,16 @@ const checkboxStateSchema = registry.register(
         })
         .openapi({
             description:
-                'Game1 のチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）',
+                '利用規約ゲームのチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）',
             example: { checked: true, changed: true },
         }),
 );
 
 /**
- * Game1 のポップアップ統計。
+ * 利用規約ゲームのポップアップ統計。
  *
  * ポップアップは滞在時間 timeout で出る仕様のため、高速スクロール時は
- * クライアントから送信されない（→ Game1Data 側で `optional`）。
+ * クライアントから送信されない（→ TermsGameData 側で `optional`）。
  */
 const popupStatsSchema = registry.register(
     'PopupStats',
@@ -87,19 +87,19 @@ const popupStatsSchema = registry.register(
         })
         .openapi({
             description:
-                'Game1 のポップアップ統計。高速スクロール時はポップアップ自体が出ないため Game1Data 側で optional',
+                '利用規約ゲームのポップアップ統計。高速スクロール時はポップアップ自体が出ないため TermsGameData 側で optional',
             example: { timeToClose: 850, clickCount: 1, mouseJitter: 42.3 },
         }),
 );
 
 /**
- * Game1Data（利用規約ゲーム）。
+ * TermsGameData（利用規約ゲーム）。
  *
- * 仕様書「データ構造 → Game1Data」と完全に一致させること。
+ * 仕様書「データ構造 → TermsGameData」と完全に一致させること。
  * `popupStats` のみ optional、それ以外は必須。
  */
-export const game1DataSchema = registry.register(
-    'Game1Data',
+export const termsGameDataSchema = registry.register(
+    'TermsGameData',
     z
         .object({
             totalTime: z.number().openapi({
@@ -140,8 +140,8 @@ export const game1DataSchema = registry.register(
         })
         .openapi({
             description:
-                'Game1（利用規約ゲーム）の行動データ。仕様書「データ構造 → Game1Data」準拠',
+                '利用規約ゲームの行動データ。仕様書「データ構造 → TermsGameData」準拠',
         }),
 );
 
-export type Game1Data = z.infer<typeof game1DataSchema>;
+export type TermsGameData = z.infer<typeof termsGameDataSchema>;

--- a/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
+++ b/frontend/src/features/diagnosis/components/BaselineSurvey.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { mbtiAtom } from '@/stores/diagnosis';
-import { game1DataAtom } from '@/stores/games';
+import { termsGameDataAtom } from '@/stores/games';
 import {
   QUESTIONS,
   type QuestionKey,
@@ -33,7 +33,7 @@ type ErrorVariant = 'retry' | 'restart';
 export default function BaselineSurvey() {
   const router = useRouter();
   const mbti = useAtomValue(mbtiAtom);
-  const game1Data = useAtomValue(game1DataAtom);
+  const termsGameData = useAtomValue(termsGameDataAtom);
 
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
@@ -91,12 +91,12 @@ export default function BaselineSurvey() {
 
         localStorage.setItem('user_id', result.user_id);
 
-        if (game1Data) {
+        if (termsGameData) {
           try {
             await submitGame({
               user_id: result.user_id,
               game_type: 1,
-              data: game1Data,
+              data: termsGameData,
             });
           } catch (gameErr) {
             // duplicate_submission（同一 user_id で同じゲームを再送信）は
@@ -129,7 +129,7 @@ export default function BaselineSurvey() {
         setStatus('error');
       }
     },
-    [mbti, router, game1Data]
+    [mbti, router, termsGameData]
   );
 
   const handleAnswer = (value: AnswerOption) => {

--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -137,7 +137,7 @@ export default function GroupChatGameFlow() {
       } catch (err: unknown) {
         // duplicate_submission（同一 user_id で同じゲームを再送信）は
         // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
-        // BaselineSurvey.tsx の game1 送信と同じ流儀。
+        // BaselineSurvey.tsx の terms_game 送信と同じ流儀。
         const isDuplicate =
           isApiClientError(err) && err.code === 'duplicate_submission';
         if (isDuplicate) {

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -128,7 +128,7 @@ export default function HelpdeskGameFlow() {
       } catch (err: unknown) {
         // duplicate_submission（同一 user_id で同じゲームを再送信）は
         // 既にサーバ側で受理済みなので、エラーにせず次画面へ自動進行する。
-        // BaselineSurvey.tsx の game1 送信と同じ流儀。
+        // BaselineSurvey.tsx の terms_game 送信と同じ流儀。
         const isDuplicate =
           isApiClientError(err) && err.code === 'duplicate_submission';
         if (isDuplicate) {

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -4,11 +4,11 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 import type {
-  Game1Data,
+  TermsGameData,
   PopupStats,
   ScrollEvent,
 } from '@/features/games/types';
-import { game1DataAtom } from '@/stores/games';
+import { termsGameDataAtom } from '@/stores/games';
 import PopupAd from './PopupAd';
 import PopupTerms from './PopupTerms';
 import LoadingScreen from '@/components/common/LoadingScreen';
@@ -24,7 +24,7 @@ const REACHED_BOTTOM_THRESHOLD = 0.9;
 
 export default function TermsGameFlow() {
   const router = useRouter();
-  const setGame1Data = useSetAtom(game1DataAtom);
+  const setTermsGameData = useSetAtom(termsGameDataAtom);
 
   const [checkboxStates, setCheckboxStates] = useState({
     readConfirm: false,
@@ -168,8 +168,8 @@ export default function TermsGameFlow() {
     return Date.now() - agreeHoverStartRef.current;
   }, []);
 
-  const buildGame1Data = useCallback(
-    (action: 'agree' | 'disagree'): Game1Data => {
+  const buildTermsGameData = useCallback(
+    (action: 'agree' | 'disagree'): TermsGameData => {
       const totalTime = Math.round((Date.now() - startTimeRef.current) / 1000);
 
       return {
@@ -205,8 +205,8 @@ export default function TermsGameFlow() {
       const se = new Audio('/sounds/general-button-se.mp3');
       se.play().catch(() => {});
 
-      const data = buildGame1Data(action);
-      setGame1Data(data);
+      const data = buildTermsGameData(action);
+      setTermsGameData(data);
 
       setIsCompleted(true);
 
@@ -218,7 +218,7 @@ export default function TermsGameFlow() {
         router.push('/diagnosis');
       }, 2000);
     },
-    [buildGame1Data, setGame1Data, router]
+    [buildTermsGameData, setTermsGameData, router]
   );
 
   if (isCompleted) {

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -12,12 +12,12 @@ export type SubmitGameRequest = components['schemas']['SubmitGameRequest'];
 export type SubmitGameResponse = components['schemas']['SubmitGameResponse'];
 
 // ========================================
-// Game 1: 利用規約ゲーム
+// 利用規約ゲーム（terms_game / 旧 Game 1）
 // ========================================
 export type ScrollEvent = components['schemas']['ScrollEvent'];
 export type CheckboxState = components['schemas']['CheckboxState'];
 export type PopupStats = components['schemas']['PopupStats'];
-export type Game1Data = components['schemas']['Game1Data'];
+export type TermsGameData = components['schemas']['TermsGameData'];
 
 // ========================================
 // Game 2: カスタマーサポートチャット

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -460,7 +460,7 @@ export interface components {
             status: "success";
         };
         /**
-         * @description Game1 のスクロールイベント（200ms 間隔のサンプリングログ）
+         * @description 利用規約ゲームのスクロールイベント（200ms 間隔のサンプリングログ）
          * @example {
          *       "position": 1200,
          *       "timestamp": 2500
@@ -473,7 +473,7 @@ export interface components {
             timestamp: number;
         };
         /**
-         * @description Game1 のチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）
+         * @description 利用規約ゲームのチェックボックス状態（readConfirm / mailMagazine / thirdPartyShare で共通）
          * @example {
          *       "checked": true,
          *       "changed": true
@@ -486,7 +486,7 @@ export interface components {
             changed: boolean;
         };
         /**
-         * @description Game1 のポップアップ統計。高速スクロール時はポップアップ自体が出ないため Game1Data 側で optional
+         * @description 利用規約ゲームのポップアップ統計。高速スクロール時はポップアップ自体が出ないため TermsGameData 側で optional
          * @example {
          *       "timeToClose": 850,
          *       "clickCount": 1,
@@ -501,8 +501,8 @@ export interface components {
             /** @description マウス余剰移動距離（px） */
             mouseJitter: number;
         };
-        /** @description Game1（利用規約ゲーム）の行動データ。仕様書「データ構造 → Game1Data」準拠 */
-        Game1Data: {
+        /** @description 利用規約ゲームの行動データ。仕様書「データ構造 → TermsGameData」準拠 */
+        TermsGameData: {
             /** @description 滞在時間（秒） */
             totalTime: number;
             /**
@@ -599,7 +599,7 @@ export interface components {
             user_id: string;
             /** @enum {number} */
             game_type: 1;
-            data: components["schemas"]["Game1Data"];
+            data: components["schemas"]["TermsGameData"];
         } | {
             /**
              * Format: uuid

--- a/frontend/src/stores/games.ts
+++ b/frontend/src/stores/games.ts
@@ -1,4 +1,4 @@
 import { atom } from 'jotai';
-import type { Game1Data } from '@/features/games/types';
+import type { TermsGameData } from '@/features/games/types';
 
-export const game1DataAtom = atom<Game1Data | null>(null);
+export const termsGameDataAtom = atom<TermsGameData | null>(null);


### PR DESCRIPTION
## 概要

#122（BE/FE 型名を game_id ベース命名に統一）の **PR1/3**。
`Game1Data` 等の数字ベース命名を `TermsGameData` 等の game_id ベースに揃える純粋なリネーム。機能・挙動の変更なし。

後続: PR2（helpdesk_game）、PR3（group_chat_game + 横断コメント掃除、Issue クローズ）。

## 変更内容

### BE
- `schemas/games/termsGame.ts`: \`Game1Data\` → \`TermsGameData\`、\`game1DataSchema\` → \`termsGameDataSchema\`、OpenAPI registry 名を同期
- `schemas/gameData.ts`（barrel）/ `schemas/games.ts`: re-export と discriminatedUnion の terms_game branch を新名に
- `repositories/gameRepository.ts`: `GameRawDataPayload` の terms_game branch の型を新名に
- `analysis/games/termsGame.ts`: import + ローカル型 \`Game1AnalyzeResult\` → \`TermsGameAnalyzeResult\`
- `analysis/games/{helpdeskGame,groupChatGame}.ts`: コメント中の参照リンクを新名に追従
- `openapi/examples.ts`: \`submitGameRequestExampleGame1\` → \`submitGameRequestExampleTermsGame\`

### FE
- `lib/api/generated.ts`: `npm run gen:api-types` で再生成
- `features/games/types/index.ts`: \`TermsGameData\` 再エクスポート
- `stores/games.ts`: \`game1DataAtom\` → \`termsGameDataAtom\`
- `features/games/terms/components/TermsGameFlow.tsx`: 型・atom・関数・変数名を新名に
- `features/diagnosis/components/BaselineSurvey.tsx`: atom・変数名を新名に
- `features/games/{helpdesk,group-chat}/components/*GameFlow.tsx`: コメント中の terms_game 参照（旧表現「game1 送信と同じ流儀」）を新名に統一

## やらないこと（後続 PR で対応）

- helpdesk_game（旧 Game 2）系の型名リネーム → PR2
- group_chat_game（旧 Game 3）系の型名リネーム → PR3
- 3 ゲーム並列で書かれているコメント（\`Game1Data / Game2Data / Game3Data\` 列挙形）の整理 → PR3 で一括して揃える
- 履歴コメント中の過去関数名（\`calculateGame1\` など固有名詞）はリネーム対象外
- データ構造仕様書の「命名方針」注記の更新は PR3 マージ後に実施

## 完了条件

- [x] terms_game の型・スキーマ・OpenAPI コンポーネント名・FE 参照がすべて新名に統一されている
- [x] `frontend/src/lib/api/generated.ts` が再生成・コミット済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 利用規約ゲーム関連の内部型定義を整理・統一しました。機能や動作に変更はありません。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->