### PR TITLE
refactor: helpdesk_game の型名を game_id ベースに統一 (2/3)

### DIFF
--- a/backend/src/analysis/games/helpdeskGame.ts
+++ b/backend/src/analysis/games/helpdeskGame.ts
@@ -142,7 +142,7 @@ function buildSummary(data: HelpdeskGameData | undefined): string {
     const allVoice = turns.length > 0 && reactValues.length === turns.length;
 
     if (allTextOrEmpty) {
-        // 全ターンテキスト: 反応速度に言及しない(仕様書例文に準拠)
+        // 全ターンテキスト: 反応速度に言及しない（仕様書例文に準拠）
         return 'テキストで冷静に反論を展開しました。';
     }
 

--- a/backend/src/analysis/games/helpdeskGame.ts
+++ b/backend/src/analysis/games/helpdeskGame.ts
@@ -1,13 +1,13 @@
-import { Game2Data, game2DataSchema } from '../../schemas/games/helpdeskGame';
+import { HelpdeskGameData, helpdeskGameDataSchema } from '../../schemas/games/helpdeskGame';
 import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
 
 /**
- * Game2（AI カスタマーサポート）の分析モジュール。
+ * AI カスタマーサポート（helpdesk_game）の分析モジュール。
  *
  * Issue #100 で `scoreCalculator.ts` の `calculateGame2` と
  * `phaseSummaryBuilder.ts` の Phase 2 テキスト生成ロジックを 1 ファイルに凝集。
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の Game2 要素も
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の helpdesk_game 要素も
  * `buildDetails` として本ファイルに移管。
  */
 
@@ -15,7 +15,7 @@ import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
  * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
  * 詳細は `termsGame.ts` の `TermsGameAnalyzeResult` コメント参照。
  */
-export type Game2AnalyzeResult = {
+export type HelpdeskGameAnalyzeResult = {
     scores: { positivity: number; calmness: number; logic: number };
     avgReact: number;
     totalSpeech: number;
@@ -24,14 +24,14 @@ export type Game2AnalyzeResult = {
 };
 
 /**
- * Game2 行動データ → 積極性・冷静さ・論理性の中間集計。
+ * AI カスタマーサポートの行動データ → 積極性・冷静さ・論理性の中間集計。
  *
  * 評価軸:
  * - 積極性(positivity): 反応速度・発話量・音声使用
  * - 冷静さ(calmness): 音量安定・沈黙率・打鍵安定
  * - 論理性(logic): 論理接続詞・不要語
  */
-function analyze(data: Game2Data | undefined): Game2AnalyzeResult {
+function analyze(data: HelpdeskGameData | undefined): HelpdeskGameAnalyzeResult {
     // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
     // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
@@ -114,11 +114,11 @@ function analyze(data: Game2Data | undefined): Game2AnalyzeResult {
 }
 
 /**
- * Game2 行動データ → 結果画面に表示するサマリーテキスト。
+ * AI カスタマーサポートの行動データ → 結果画面に表示するサマリーテキスト。
  *
  * 例: 「AIの理不尽な対応に即座に反応し、音声で堂々と反論を展開しました。」
  */
-function buildSummary(data: Game2Data | undefined): string {
+function buildSummary(data: HelpdeskGameData | undefined): string {
     if (!data) return 'データなし';
 
     const turns = data.turns || [];
@@ -130,7 +130,7 @@ function buildSummary(data: Game2Data | undefined): string {
     //
     // 判定軸として `turns[i].inputMethod === 'text'` は使わず `reactionTimeMs === null`
     // のみで判定する。これは仕様書「Game 2 Null 値の扱い → 注: ターン単位の
-    // `Game2Turn.inputMethod` について」で「現状の集計ロジックは "null 判定" で同等の効果が
+    // `HelpdeskGameTurn.inputMethod` について」で「現状の集計ロジックは "null 判定" で同等の効果が
     // 得られるため、スコア計算では inputMethod を直接参照しない」と明記された方針に揃えた
     // ためで、analyze と同じ判定基準になる。
     const reactValues = turns.map((t) => t.reactionTimeMs).filter((v): v is number => v !== null);
@@ -142,7 +142,7 @@ function buildSummary(data: Game2Data | undefined): string {
     const allVoice = turns.length > 0 && reactValues.length === turns.length;
 
     if (allTextOrEmpty) {
-        // 全ターンテキスト: 反応速度に言及しない（仕様書例文に準拠）
+        // 全ターンテキスト: 反応速度に言及しない(仕様書例文に準拠)
         return 'テキストで冷静に反論を展開しました。';
     }
 
@@ -154,9 +154,9 @@ function buildSummary(data: Game2Data | undefined): string {
         return `${reactionText}、音声で堂々と反論を展開しました。`;
     }
 
-    // 混在: null 除外平均で反応速度を判定し、method は Game2Data 直下の inputMethod を採用。
+    // 混在: null 除外平均で反応速度を判定し、method は HelpdeskGameData 直下の inputMethod を採用。
     // 直下フィールドを使う根拠は analyze の sVoice 算出と同じ方針（音声選択を 0/100
-    // で評価する積極性スコアが Game2Data.inputMethod を参照しているため、サマリー側もそろえる）。
+    // で評価する積極性スコアが HelpdeskGameData.inputMethod を参照しているため、サマリー側もそろえる）。
     // 「主に音声/テキストどちらだったか」をターン多数決で決める方が正確という議論はあるが、
     // 仕様書未定義のためスコアと同じ判定軸に揃える。
     const method = data.inputMethod === 'voice' ? '音声で堂々と' : 'テキストで冷静に';
@@ -164,10 +164,13 @@ function buildSummary(data: Game2Data | undefined): string {
 }
 
 /**
- * Game2 行動データ + analyze 結果 → 結果画面 details 用の構造体。
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の Game2 要素を移管。挙動は完全同一。
+ * AI カスタマーサポートの行動データ + analyze 結果 → 結果画面 details 用の構造体。
+ * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の helpdesk_game 要素を移管。挙動は完全同一。
  */
-function buildDetails(_data: Game2Data | undefined, result: Game2AnalyzeResult): GameDetail {
+function buildDetails(
+    _data: HelpdeskGameData | undefined,
+    result: HelpdeskGameAnalyzeResult,
+): GameDetail {
     return {
         game_id: helpdeskGameModule.id,
         title: helpdeskGameModule.title,
@@ -206,16 +209,16 @@ function buildDetails(_data: Game2Data | undefined, result: Game2AnalyzeResult):
 }
 
 /**
- * Game2（AI カスタマーサポート）モジュール。
+ * AI カスタマーサポート（helpdesk_game）モジュール。
  * registry の `GameModuleEntry` 型に合わせて `unknown` 入力のアダプタを薄く挟む
  * （詳細は `termsGame.ts` の export コメント参照）。
  */
 export const helpdeskGameModule = {
     id: 'helpdesk_game' as const,
     title: 'AIカスタマーサポート',
-    schema: game2DataSchema,
-    analyze: (data: unknown) => analyze(data as Game2Data | undefined),
-    buildSummary: (data: unknown) => buildSummary(data as Game2Data | undefined),
+    schema: helpdeskGameDataSchema,
+    analyze: (data: unknown) => analyze(data as HelpdeskGameData | undefined),
+    buildSummary: (data: unknown) => buildSummary(data as HelpdeskGameData | undefined),
     buildDetails: (data: unknown, result: unknown) =>
-        buildDetails(data as Game2Data | undefined, result as Game2AnalyzeResult),
+        buildDetails(data as HelpdeskGameData | undefined, result as HelpdeskGameAnalyzeResult),
 };

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -162,10 +162,10 @@ export const submitGameRequestExampleTermsGame = {
 /**
  * game_type = 2（AI カスタマーサポート）の data サンプル。
  *
- * 仕様書「データ構造」→ Game2Data を参照。turns は最小 2 件（音声 1 件 + テキスト 1 件）で
+ * 仕様書「データ構造」→ HelpdeskGameData を参照。turns は最小 2 件（音声 1 件 + テキスト 1 件）で
  * 構造を示し、テキスト入力時は音声系メトリクスが null になる例を載せる。
  */
-export const submitGameRequestExampleGame2 = {
+export const submitGameRequestExampleHelpdeskGame = {
     user_id: SAMPLE_USER_ID,
     game_type: 2,
     data: {

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,13 +1,13 @@
 import { GAME_TYPE_TO_ID, ID_TO_GAME_TYPE } from '../analysis/registry';
 import { supabase } from '../db/client';
-import { TermsGameData, Game2Data, Game3Data } from '../schemas/gameData';
+import { TermsGameData, HelpdeskGameData, Game3Data } from '../schemas/gameData';
 import { GameId, GameLog } from '../types';
 
 /**
  * 各 GameId に対応する raw_data の組（判別可能 union）。
  *
  * saveLog の引数として `gameId` と `rawData` を一緒に受け取ることで、
- * 「terms_game の gameId に Game2Data の rawData が渡る」といったミスマッチを
+ * 「terms_game の gameId に HelpdeskGameData の rawData が渡る」といったミスマッチを
  * コンパイル時に弾ける。呼び出し元（service 層）が zod スキーマで parse して
  * narrow 済みであることを型レベルで担保する想定で、repositories 層では構造検証しない。
  *
@@ -17,7 +17,7 @@ import { GameId, GameLog } from '../types';
  */
 export type GameRawDataPayload =
     | { gameId: 'terms_game'; rawData: TermsGameData }
-    | { gameId: 'helpdesk_game'; rawData: Game2Data }
+    | { gameId: 'helpdesk_game'; rawData: HelpdeskGameData }
     | { gameId: 'group_chat_game'; rawData: Game3Data };
 
 /**

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -6,10 +6,10 @@
  * 本 barrel 経由でも構わない（既存 import パスを壊さない方針）。
  *
  * - 利用規約ゲーム（terms_game / 旧 Game 1）: `./games/termsGame`
- * - Game2（AI カスタマーサポート）: `./games/helpdeskGame`
+ * - AI カスタマーサポート（helpdesk_game / 旧 Game 2）: `./games/helpdeskGame`
  * - Game3（空気読みグループチャット）: `./games/groupChatGame`
  */
 
 export { termsGameDataSchema, type TermsGameData } from './games/termsGame';
-export { game2DataSchema, type Game2Data } from './games/helpdeskGame';
+export { helpdeskGameDataSchema, type HelpdeskGameData } from './games/helpdeskGame';
 export { game3DataSchema, type Game3Data } from './games/groupChatGame';

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -7,12 +7,12 @@ import { userIdSchema } from './common';
 import { GAME_TYPES } from '../types';
 import {
     termsGameDataSchema,
-    game2DataSchema,
+    helpdeskGameDataSchema,
     game3DataSchema,
 } from './gameData';
 import {
     submitGameRequestExampleTermsGame,
-    submitGameRequestExampleGame2,
+    submitGameRequestExampleHelpdeskGame,
     submitGameRequestExampleGame3,
     submitGameResponseExample,
 } from '../openapi/examples';
@@ -76,7 +76,7 @@ export const gameTypeSchema = registry.register(
  * `z.discriminatedUnion('game_type', [...])` で `game_type` × `data` の対応を
  * 型レベルで強制する（Issue #58）:
  * - game_type === 1 のとき data は TermsGameData
- * - game_type === 2 のとき data は Game2Data
+ * - game_type === 2 のとき data は HelpdeskGameData
  * - game_type === 3 のとき data は Game3Data
  *
  * OpenAPI 上は `oneOf` で表現され、各 branch の
@@ -115,12 +115,12 @@ export const submitGameRequestSchema = registry.register(
                 .object({
                     user_id: userIdSchema,
                     game_type: z.literal(GAME_TYPES.AI_CHAT),
-                    data: game2DataSchema,
+                    data: helpdeskGameDataSchema,
                 })
                 .openapi({
                     description:
-                        'Game2（AI カスタマーサポート）の終了時に送るリクエスト',
-                    example: submitGameRequestExampleGame2,
+                        'AI カスタマーサポート（game_type=2）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleHelpdeskGame,
                 }),
             z
                 .object({

--- a/backend/src/schemas/games/helpdeskGame.ts
+++ b/backend/src/schemas/games/helpdeskGame.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { registry } from '../../openapi/registry';
 
 /**
- * Game2（AI カスタマーサポート）の行動データ（raw_data）の zod スキーマ群。
+ * AI カスタマーサポート（helpdesk_game / 旧 Game 2）の行動データ（raw_data）の zod スキーマ群。
  *
  * 設計方針:
  * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
@@ -19,36 +19,36 @@ import { registry } from '../../openapi/registry';
  */
 
 /**
- * Game2 の入力方式（音声 / テキスト）。
+ * AI カスタマーサポートの入力方式（音声 / テキスト）。
  *
- * Game2Data 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
+ * HelpdeskGameData 直下の `inputMethod` と各ターン（`turns[].inputMethod`）の両方で
  * 使うため、共通サブスキーマとして定義する。
  *
  * 文字列リテラルかつエラーコードの個別マッピング（invalid_xxx 等）が不要なため
  * z.enum で簡潔に書く（voice.ts の voiceEmotionSchema と同方針）。OpenAPI 出力は
  * `{ type: 'string', enum: [...] }` のクリーンな形になる。
  */
-const game2InputMethodSchema = registry.register(
-    'Game2InputMethod',
+const helpdeskGameInputMethodSchema = registry.register(
+    'HelpdeskGameInputMethod',
     z.enum(['voice', 'text']).openapi({
-        description: 'Game2 の入力方式（voice: 音声 / text: テキスト）',
+        description: 'AI カスタマーサポートの入力方式（voice: 音声 / text: テキスト）',
     }),
 );
 
 /**
- * Game2 の 1 ターン分のメトリクス。
+ * AI カスタマーサポートの 1 ターン分のメトリクス。
  *
  * テキスト入力時は音声系メトリクス（reactionTimeMs / speechDurationMs /
  * silenceDurationMs / volumeDb）が取得できないため `nullable`。
  */
-const game2TurnSchema = registry.register(
-    'Game2Turn',
+const helpdeskGameTurnSchema = registry.register(
+    'HelpdeskGameTurn',
     z
         .object({
             turnIndex: z.number().int().openapi({
                 description: 'ターン番号（1 始まり）',
             }),
-            inputMethod: game2InputMethodSchema,
+            inputMethod: helpdeskGameInputMethodSchema,
             reactionTimeMs: z.number().nullable().openapi({
                 description: '喋り出しまでの反応速度（ms）。テキスト入力時は null',
             }),
@@ -67,17 +67,17 @@ const game2TurnSchema = registry.register(
         })
         .openapi({
             description:
-                'Game2 の 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null',
+                'AI カスタマーサポートの 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null',
         }),
 );
 
 /**
- * Game2 のテキスト入力メトリクス。
+ * AI カスタマーサポートのテキスト入力メトリクス。
  *
  * テキスト入力が一度も発生しなかった場合（全ターン音声）は null。
  */
-const game2TextInputMetricsSchema = registry.register(
-    'Game2TextInputMetrics',
+const helpdeskGameTextInputMetricsSchema = registry.register(
+    'HelpdeskGameTextInputMetrics',
     z
         .object({
             typingIntervalVariance: z.number().openapi({
@@ -86,36 +86,36 @@ const game2TextInputMetricsSchema = registry.register(
         })
         .openapi({
             description:
-                'Game2 のテキスト入力メトリクス。全ターン音声入力の場合は Game2Data 側で null',
+                'AI カスタマーサポートのテキスト入力メトリクス。全ターン音声入力の場合は HelpdeskGameData 側で null',
         }),
 );
 
 /**
- * Game2Data（AI カスタマーサポート）。
+ * HelpdeskGameData（AI カスタマーサポート）。
  */
-export const game2DataSchema = registry.register(
-    'Game2Data',
+export const helpdeskGameDataSchema = registry.register(
+    'HelpdeskGameData',
     z
         .object({
-            inputMethod: game2InputMethodSchema,
+            inputMethod: helpdeskGameInputMethodSchema,
             turnCount: z.number().int().openapi({
                 description: '実施ターン数',
             }),
-            turns: z.array(game2TurnSchema).openapi({
+            turns: z.array(helpdeskGameTurnSchema).openapi({
                 description: '各ターンのメトリクス（turnCount 件）',
             }),
             // textInputMetrics は `z.union([..., z.null()])` で nullable にする。
             // `.nullable()` を使うと OpenAPI 3.1 上で `allOf: [$ref, type: ['object','null']]`
-            // という形になり、openapi-typescript が `Game2TextInputMetrics & (Record<string, never> | null)`
+            // という形になり、openapi-typescript が `HelpdeskGameTextInputMetrics & (Record<string, never> | null)`
             // という壊れた交差型を生成する（null も具体値も代入できなくなる）。
             // `z.union([schema, z.null()])` だと `oneOf: [$ref, type: 'null']` 形式になり、
-            // 生成型が `Game2TextInputMetrics | null` で正しく表現される。
-            textInputMetrics: z.union([game2TextInputMetricsSchema, z.null()]),
+            // 生成型が `HelpdeskGameTextInputMetrics | null` で正しく表現される。
+            textInputMetrics: z.union([helpdeskGameTextInputMetricsSchema, z.null()]),
         })
         .openapi({
             description:
-                'Game2（AI カスタマーサポート）の行動データ。仕様書「データ構造 → Game2Data」準拠',
+                'AI カスタマーサポートの行動データ。仕様書「データ構造 → HelpdeskGameData」準拠',
         }),
 );
 
-export type Game2Data = z.infer<typeof game2DataSchema>;
+export type HelpdeskGameData = z.infer<typeof helpdeskGameDataSchema>;

--- a/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
+++ b/frontend/src/features/games/helpdesk/components/HelpdeskGameFlow.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { Game2Data } from '@/features/games/types';
+import type { HelpdeskGameData } from '@/features/games/types';
 import { submitGame } from '@/lib/api';
 import {
   MAX_RETRY_COUNT,
@@ -29,7 +29,7 @@ export default function HelpdeskGameFlow() {
   const [textInput, setTextInput] = useState('');
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('loading');
   const [errorVariant, setErrorVariant] = useState<ErrorVariant>('retry');
-  const pendingDataRef = useRef<Game2Data | null>(null);
+  const pendingDataRef = useRef<HelpdeskGameData | null>(null);
 
   // リトライ回数は描画ロジックに直接影響しない（catch 内で variant を決める材料
   // としてのみ使う）ため、useState ではなく useRef で扱う。
@@ -107,8 +107,8 @@ export default function HelpdeskGameFlow() {
    * 成功時は `retryCountRef.current = 0` でリセットして次画面へ遷移する。
    * user_id 欠損は localStorage が空のままで回復不能なので即 `restart`。
    */
-  const submitGame2 = useCallback(
-    async (data: Game2Data) => {
+  const submitHelpdeskGame = useCallback(
+    async (data: HelpdeskGameData) => {
       const userId = localStorage.getItem('user_id');
       if (!userId) {
         setErrorVariant('restart');
@@ -155,7 +155,7 @@ export default function HelpdeskGameFlow() {
   );
 
   const handleComplete = useCallback(
-    async (data: Game2Data) => {
+    async (data: HelpdeskGameData) => {
       pendingDataRef.current = data;
       setSubmitStatus('loading');
 
@@ -164,9 +164,9 @@ export default function HelpdeskGameFlow() {
         bgmRef.current.pause();
       }
 
-      await submitGame2(data);
+      await submitHelpdeskGame(data);
     },
-    [submitGame2]
+    [submitHelpdeskGame]
   );
 
   const {
@@ -238,8 +238,8 @@ export default function HelpdeskGameFlow() {
     if (!data) return;
     retryCountRef.current += 1;
     setSubmitStatus('loading');
-    await submitGame2(data);
-  }, [submitGame2, playSE]);
+    await submitHelpdeskGame(data);
+  }, [submitHelpdeskGame, playSE]);
 
   const handleGoTop = useCallback(() => {
     playSE('/sounds/general-button-se.mp3');

--- a/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
+++ b/frontend/src/features/games/helpdesk/hooks/useHelpdeskGame.ts
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
-  Game2Data,
-  Game2Turn,
-  Game2TextInputMetrics,
+  HelpdeskGameData,
+  HelpdeskGameTurn,
+  HelpdeskGameTextInputMetrics,
 } from '@/features/games/types';
 import { postVoiceRespond } from '@/lib/api';
 import {
@@ -35,7 +35,7 @@ import { useTypingMetrics } from './useTypingMetrics';
  * support-speaking  → サポート担当の発言をチャットに追加中
  * user-input        → ユーザーの音声/テキスト入力待ち（20秒タイマー稼働）
  * voice-api-error   → AI応答API失敗、リトライ待ち
- * submitting        → 全ラリー完了、Game2Data を組み立てて onComplete に渡す
+ * submitting        → 全ラリー完了、HelpdeskGameData を組み立てて onComplete に渡す
  * completed         → 送信完了、次の画面への遷移待ち
  * error             → その他エラー
  */
@@ -66,7 +66,7 @@ export interface ChatMessage {
 export type VoiceApiErrorVariant = 'retry' | 'restart';
 
 /**
- * Game 2（カスタマーサポートチャット）全体のステート管理フック。
+ * AI カスタマーサポート（helpdesk_game）全体のステート管理フック。
  *
  * useSpeechRecognition / useAudioMetrics / useTypingMetrics を統合し、
  * 以下のフローを制御する:
@@ -76,7 +76,7 @@ export type VoiceApiErrorVariant = 'retry' | 'restart';
  * 音声入力時は 20 秒で自動終了、テキスト入力時は送信ボタンで終了。
  */
 export function useHelpdeskGame(options: {
-  onComplete: (data: Game2Data) => void;
+  onComplete: (data: HelpdeskGameData) => void;
 }) {
   const { onComplete } = options;
 
@@ -84,7 +84,7 @@ export function useHelpdeskGame(options: {
   const [inputMethod, setInputMethod] = useState<'voice' | 'text'>('voice');
   const [currentTurn, setCurrentTurn] = useState(0); // 0〜2（3ラリー）
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]); // 表示用メッセージ履歴
-  const [turns, setTurns] = useState<Game2Turn[]>([]); // 収集データ用ターンログ
+  const [turns, setTurns] = useState<HelpdeskGameTurn[]>([]); // 収集データ用ターンログ
   const [gamePhase, setGamePhase] = useState<GamePhase>('tutorial');
   const [remainingTimeMs, setRemainingTimeMs] = useState(TURN_TIME_LIMIT_MS);
   const [voiceApiRetrying, setVoiceApiRetrying] = useState(false);
@@ -224,7 +224,7 @@ export function useHelpdeskGame(options: {
   const speechAbort = speech.abort;
 
   // =========================================================
-  // ゲーム終了 → Game2Data 組み立て
+  // ゲーム終了 → HelpdeskGameData 組み立て
   // =========================================================
 
   // ステートの最新値をエフェクト外から参照するための ref
@@ -240,14 +240,14 @@ export function useHelpdeskGame(options: {
   }, [inputMethod]);
 
   /**
-   * 全ターンのデータを Game2Data にまとめて onComplete へ渡す。
+   * 全ターンのデータを HelpdeskGameData にまとめて onComplete へ渡す。
    * onComplete は副作用なのでアップデータ関数の外で呼ぶ
    * （Strict Mode でアップデータが2回呼ばれても副作用は1回だけにする）。
    */
   const buildAndSubmit = useCallback(() => {
     const currentTurns = turnsRef.current;
     const hasTextTurn = currentTurns.some((t) => t.inputMethod === 'text');
-    const textInputMetrics: Game2TextInputMetrics | null = hasTextTurn
+    const textInputMetrics: HelpdeskGameTextInputMetrics | null = hasTextTurn
       ? {
           typingIntervalVariance:
             typingVariancesRef.current.length > 0
@@ -256,13 +256,13 @@ export function useHelpdeskGame(options: {
               : 0,
         }
       : null;
-    const game2Data: Game2Data = {
+    const helpdeskGameData: HelpdeskGameData = {
       inputMethod: inputMethodRef.current,
       turnCount: currentTurns.length,
       turns: currentTurns,
       textInputMetrics,
     };
-    onComplete(game2Data);
+    onComplete(helpdeskGameData);
     setGamePhase('completed');
 
     // 電話終了音

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -20,12 +20,12 @@ export type PopupStats = components['schemas']['PopupStats'];
 export type TermsGameData = components['schemas']['TermsGameData'];
 
 // ========================================
-// Game 2: カスタマーサポートチャット
+// AI カスタマーサポート（helpdesk_game / 旧 Game 2）
 // ========================================
-export type Game2Turn = components['schemas']['Game2Turn'];
-export type Game2TextInputMetrics =
-  components['schemas']['Game2TextInputMetrics'];
-export type Game2Data = components['schemas']['Game2Data'];
+export type HelpdeskGameTurn = components['schemas']['HelpdeskGameTurn'];
+export type HelpdeskGameTextInputMetrics =
+  components['schemas']['HelpdeskGameTextInputMetrics'];
+export type HelpdeskGameData = components['schemas']['HelpdeskGameData'];
 export type VoiceRespondRequest = components['schemas']['VoiceRespondRequest'];
 export type VoiceRespondResponse =
   components['schemas']['VoiceRespondResponse'];

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -527,15 +527,15 @@ export interface components {
             agreeButtonHoverTimeMs: number;
         };
         /**
-         * @description Game2 の入力方式（voice: 音声 / text: テキスト）
+         * @description AI カスタマーサポートの入力方式（voice: 音声 / text: テキスト）
          * @enum {string}
          */
-        Game2InputMethod: "voice" | "text";
-        /** @description Game2 の 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null */
-        Game2Turn: {
+        HelpdeskGameInputMethod: "voice" | "text";
+        /** @description AI カスタマーサポートの 1 ターン分のメトリクス。テキスト入力時は音声系フィールドが null */
+        HelpdeskGameTurn: {
             /** @description ターン番号（1 始まり） */
             turnIndex: number;
-            inputMethod: components["schemas"]["Game2InputMethod"];
+            inputMethod: components["schemas"]["HelpdeskGameInputMethod"];
             /** @description 喋り出しまでの反応速度（ms）。テキスト入力時は null */
             reactionTimeMs: number | null;
             /** @description 発話時間（ms）。テキスト入力時は null */
@@ -547,19 +547,19 @@ export interface components {
             /** @description 文字起こし結果 or テキスト入力内容 */
             transcribedText: string;
         };
-        /** @description Game2 のテキスト入力メトリクス。全ターン音声入力の場合は Game2Data 側で null */
-        Game2TextInputMetrics: {
+        /** @description AI カスタマーサポートのテキスト入力メトリクス。全ターン音声入力の場合は HelpdeskGameData 側で null */
+        HelpdeskGameTextInputMetrics: {
             /** @description タイピング間隔の分散 */
             typingIntervalVariance: number;
         };
-        /** @description Game2（AI カスタマーサポート）の行動データ。仕様書「データ構造 → Game2Data」準拠 */
-        Game2Data: {
-            inputMethod: components["schemas"]["Game2InputMethod"];
+        /** @description AI カスタマーサポートの行動データ。仕様書「データ構造 → HelpdeskGameData」準拠 */
+        HelpdeskGameData: {
+            inputMethod: components["schemas"]["HelpdeskGameInputMethod"];
             /** @description 実施ターン数 */
             turnCount: number;
             /** @description 各ターンのメトリクス（turnCount 件） */
-            turns: components["schemas"]["Game2Turn"][];
-            textInputMetrics: components["schemas"]["Game2TextInputMetrics"] | null;
+            turns: components["schemas"]["HelpdeskGameTurn"][];
+            textInputMetrics: components["schemas"]["HelpdeskGameTextInputMetrics"] | null;
         };
         /** @description Game3 の 1 ステージ分のメトリクス */
         Game3Stage: {
@@ -609,7 +609,7 @@ export interface components {
             user_id: string;
             /** @enum {number} */
             game_type: 2;
-            data: components["schemas"]["Game2Data"];
+            data: components["schemas"]["HelpdeskGameData"];
         } | {
             /**
              * Format: uuid


### PR DESCRIPTION
## 概要

#122（BE/FE 型名を game_id ベース命名に統一）の **PR2/3**。
`Game2Data` 等の数字ベース命名を `HelpdeskGameData` 等の game_id ベースに揃える純粋なリネーム。機能・挙動の変更なし。

PR1（terms_game）はマージ済み。後続: PR3（group_chat_game + 横断コメント掃除、Issue クローズ）。

## 変更内容

### BE
- `schemas/games/helpdeskGame.ts`: \`Game2Data\` → \`HelpdeskGameData\`、\`game2DataSchema\` → \`helpdeskGameDataSchema\`、サブ型 \`Game2InputMethod\` / \`Game2Turn\` / \`Game2TextInputMetrics\` も \`HelpdeskGame*\` にリネーム、OpenAPI registry 名を同期
- `schemas/gameData.ts`（barrel）/ `schemas/games.ts`: re-export と discriminatedUnion の helpdesk_game branch を新名に
- `repositories/gameRepository.ts`: `GameRawDataPayload` の helpdesk_game branch の型を新名に
- `analysis/games/helpdeskGame.ts`: import + ローカル型 \`Game2AnalyzeResult\` → \`HelpdeskGameAnalyzeResult\`
- `openapi/examples.ts`: \`submitGameRequestExampleGame2\` → \`submitGameRequestExampleHelpdeskGame\`

### FE
- `lib/api/generated.ts`: `npm run gen:api-types` で再生成
- `features/games/types/index.ts`: \`HelpdeskGameData\` / \`HelpdeskGameTurn\` / \`HelpdeskGameTextInputMetrics\` を再エクスポート
- `features/games/helpdesk/components/HelpdeskGameFlow.tsx`: 型と関数名 \`submitGame2\` → \`submitHelpdeskGame\`
- `features/games/helpdesk/hooks/useHelpdeskGame.ts`: 型と局所変数 \`game2Data\` → \`helpdeskGameData\`

## やらないこと（後続 PR で対応）

- group_chat_game（旧 Game 3）系の型名リネーム → PR3
- 3 ゲーム並列で書かれているコメント（\`Game1Data / Game2Data / Game3Data\` 列挙形）の整理 → PR3 で一括して揃える
- 履歴コメント中の過去関数名（\`calculateGame2\` など固有名詞）はリネーム対象外
- データ構造仕様書の「命名方針」注記の更新は PR3 マージ後に実施

## 完了条件

- [x] helpdesk_game の型・スキーマ・OpenAPI コンポーネント名・FE 参照がすべて新名に統一されている
- [x] `frontend/src/lib/api/generated.ts` が再生成・コミット済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ヘルプデスクゲーム機能の内部構造を整理・統一しました。バックエンド・フロントエンド間の命名を統一し、システムの一貫性を向上させました。ユーザー向けの機能や動作に変更はありません。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->