### PR TITLE
chore: 履歴コメントから旧関数名・変数名を削除 (2/3)

### DIFF
--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -5,8 +5,8 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
 /**
  * 空気読みグループチャット（group_chat_game）の分析モジュール。
  *
- * Issue #100 で `scoreCalculator.ts` の `calculateGame3` と
- * `phaseSummaryBuilder.ts` の Phase 3 テキスト生成ロジックを 1 ファイルに凝集。
+ * Issue #100 で `scoreCalculator.ts` 側にあった analyze ロジックと
+ * 旧 `phaseSummaryBuilder.ts` の Phase 3 テキスト生成ロジックを 1 ファイルに凝集。
  * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の group_chat_game 要素も
  * `buildDetails` として本ファイルに移管。
  */
@@ -122,9 +122,8 @@ function buildDetails(
     data: GroupChatGameData | undefined,
     result: GroupChatGameAnalyzeResult,
 ): GameDetail {
-    // 旧 scoreCalculator では `(g3.conformCount / (game3Raw?.stages?.length || 1)) * 100` で
-    // 同調率を算出していた。stages 件数は data 側、conformCount は analyze 結果側にあるため
-    // 両方を参照する（挙動は完全同一）。
+    // 同調率は「conformCount（analyze 結果側）」を「stages 件数（data 側）」で割って算出する。
+    // 旧構造から本ファイルへ移管する際もこの参照関係を維持している（挙動は完全同一）。
     return {
         game_id: groupChatGameModule.id,
         title: groupChatGameModule.title,

--- a/backend/src/analysis/games/helpdeskGame.ts
+++ b/backend/src/analysis/games/helpdeskGame.ts
@@ -5,8 +5,8 @@ import { linear, linearInv, logNorm, sigmoidInv } from '../scoreUtils';
 /**
  * AI カスタマーサポート（helpdesk_game）の分析モジュール。
  *
- * Issue #100 で `scoreCalculator.ts` の `calculateGame2` と
- * `phaseSummaryBuilder.ts` の Phase 2 テキスト生成ロジックを 1 ファイルに凝集。
+ * Issue #100 で `scoreCalculator.ts` 側にあった analyze ロジックと
+ * 旧 `phaseSummaryBuilder.ts` の Phase 2 テキスト生成ロジックを 1 ファイルに凝集。
  * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の helpdesk_game 要素も
  * `buildDetails` として本ファイルに移管。
  */

--- a/backend/src/analysis/games/termsGame.ts
+++ b/backend/src/analysis/games/termsGame.ts
@@ -5,8 +5,8 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
 /**
  * 利用規約ゲーム（terms_game）の分析モジュール。
  *
- * Issue #100 で `scoreCalculator.ts` の `calculateGame1` と
- * `phaseSummaryBuilder.ts` の Phase 1 テキスト生成ロジックを 1 ファイルに凝集した。
+ * Issue #100 で `scoreCalculator.ts` 側にあった analyze ロジックと
+ * 旧 `phaseSummaryBuilder.ts` の Phase 1 テキスト生成ロジックを 1 ファイルに凝集した。
  * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の terms_game 要素
  * （title / feature_scores / metrics）も `buildDetails` として本ファイルに移管し、
  * scoreCalculator は薄い統合層に縮小した。
@@ -39,8 +39,8 @@ export type TermsGameAnalyzeResult = {
 /**
  * scrollEvents から平均スクロール速度（px/s）と逆行スクロール回数を算出する内部 helper。
  *
- * `analyze()` と `buildSummary()` の両方から呼ばれる。旧構造では `calculateGame1`
- * の戻り値経由で `buildPhaseSummaries` に averageSpeed を引き渡していたが、
+ * `analyze()` と `buildSummary()` の両方から呼ばれる。旧構造では analyze ロジック
+ * の戻り値経由で要約生成側に averageSpeed を引き渡していたが、
  * モジュール分割後は両関数が独立呼び出しになるため、内部で再計算する。
  * O(N) で軽量、計測値も同一になる。
  */
@@ -137,7 +137,7 @@ function buildSummary(data: TermsGameData | undefined): string {
     if (!data) return 'データなし';
 
     const timeSec = (data.totalTime ?? 0).toFixed(1);
-    // scrollEvents から自前で算出（旧構造では calculateGame1 の戻り値経由で受け取っていた）。
+    // scrollEvents から自前で算出（旧構造では analyze ロジックの戻り値経由で受け取っていた）。
     // 仕様書上、FE は scrollEvents のみ送信する設計のため、raw_data には scrollMetrics は無い。
     const { averageSpeed: speed } = computeScrollMetrics(data.scrollEvents || []);
     const speedText =


### PR DESCRIPTION
## 概要

#126（Issue #122 リネームに伴うクリーンアップ）の **PR2/3**。
Issue #100 / #102 で削除された旧関数名（\`calculateGame[123]\`）と旧変数名（\`game3Raw\`）が `backend/src/analysis/games/` の履歴コメントに残っており、検索や IDE ジャンプで読み手を混乱させていたため削除する。

PR1（古い・重複ドキュメント削除）はマージ済み。後続: PR3（アセットリネーム + typo 修正）で `closes #126`。

refs #126

## 変更内容

- `termsGame.ts`: \`calculateGame1\` / \`buildPhaseSummaries\` を \`analyze ロジック\` / \`要約生成側\` に書き換え（3 箇所）
- `helpdeskGame.ts`: \`calculateGame2\` を \`analyze ロジック\` に書き換え（1 箇所）
- `groupChatGame.ts`: \`calculateGame3\` を \`analyze ロジック\` に書き換え、`buildDetails` 内の旧コード断片（\`g3.conformCount\` / \`game3Raw?.stages?.length\`）を概念的説明に書き換え（2 箇所）

## 残置（意図的）

- `phaseSummaryBuilder.ts` は削除済みのため「旧 \`phaseSummaryBuilder.ts\`」として 3 箇所残置。Issue #100 の経緯（Phase テキスト生成の責務分割）を辿るキーワードとして機能する
- Issue 番号（#100 / #102）への参照は保持

## やらないこと（後続 PR で対応）

- アセットファイル（\`game2-bgm.mp3\` 等）のリネーム → PR3
- ロジック変更 / 機能変更（コメントのみの修正）

## 完了条件

- [x] 過去関数名（\`calculateGame[123]\`）が履歴コメントから削除されている
- [x] 旧変数名（\`game3Raw\`）が削除されている
- [x] Issue 番号（#100 / #102）への参照が保持されている