### PR TITLE
Feat/sorter game schema

### DIFF
--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -1,15 +1,5 @@
-import type { ZodType } from 'zod';
 import type { GameDetail } from '../../schemas/results';
-
-// TODO: #114 で sorterGameDataSchema を作成後に正式 import に切り替える
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SorterGameData = any;
-
-const sorterGameDataSchemaStub = {
-    safeParse: (d: unknown) => ({ success: true as const, data: d }),
-};
-
-const sorterGameDataSchema = sorterGameDataSchemaStub as unknown as ZodType;
+import { SorterGameData, sorterGameDataSchema } from '../../schemas/games/sorterGame';
 
 export type SorterGameAnalyzeResult = {
     scores: { caution: number; calmness: number; logic: number; positivity: number };

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -71,7 +71,7 @@ export const apiErrorExamples = {
     [ERROR_CODES.INVALID_GAME_TYPE]: {
         status: 'error',
         error: ERROR_CODES.INVALID_GAME_TYPE,
-        message: 'game_type は 1 / 2 / 3 のいずれかで指定してください',
+        message: 'game_type は 1 / 2 / 3 / 4 のいずれかで指定してください',
     },
     [ERROR_CODES.INCOMPLETE_GAMES]: {
         status: 'error',
@@ -224,6 +224,33 @@ export const submitGameRequestExampleGroupChatGame = {
                 isTimeout: true,
             },
         ],
+    },
+} as const;
+
+/**
+ * game_type = 4（荷物仕分けゲーム）の data サンプル。
+ *
+ * 仕様書「データ構造」→ SorterGameData を参照。
+ */
+export const submitGameRequestExampleSorterGame = {
+    user_id: SAMPLE_USER_ID,
+    game_type: 4,
+    data: {
+        totalTimeMs: 50000,
+        finalScore: 120,
+        averageHesitationMs: 1200,
+        spawnedPackages: 25,
+        wrongSortCount: 3,
+        wrongPatterns: {
+            urgent: { fragile: 2, heavy: 1 },
+            fragile: {},
+            heavy: {},
+        },
+        cancelCount: 2,
+        outflowMissCount: 1,
+        panicClickCount: 4,
+        ruleChangeAdaptMs: 3500,
+        events: [],
     },
 } as const;
 

--- a/backend/src/openapi/paths/games.ts
+++ b/backend/src/openapi/paths/games.ts
@@ -22,7 +22,7 @@ registry.registerPath({
     tags: ['Games'],
     summary: 'ゲームプレイデータ送信',
     description:
-        '各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。' +
+        '各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）の終了時に行動データを送信する。' +
         '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。',
     request: {
         body: {
@@ -48,7 +48,7 @@ registry.registerPath({
                 'リクエスト不正。主な業務エラーコード: ' +
                 'invalid_request（必須フィールド欠落 / data が空）/ ' +
                 'invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ ' +
-                'invalid_game_type（game_type が 1-3 の範囲外）',
+                'invalid_game_type（game_type が 1-4 の範囲外）',
             content: {
                 'application/json': {
                     schema: apiErrorSchema,

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,6 +1,6 @@
 import { GAME_TYPE_TO_ID, ID_TO_GAME_TYPE } from '../analysis/registry';
 import { supabase } from '../db/client';
-import { TermsGameData, HelpdeskGameData, GroupChatGameData } from '../schemas/gameData';
+import { TermsGameData, HelpdeskGameData, GroupChatGameData, SorterGameData } from '../schemas/gameData';
 import { GameId, GameLog } from '../types';
 
 /**
@@ -18,7 +18,8 @@ import { GameId, GameLog } from '../types';
 export type GameRawDataPayload =
     | { gameId: 'terms_game'; rawData: TermsGameData }
     | { gameId: 'helpdesk_game'; rawData: HelpdeskGameData }
-    | { gameId: 'group_chat_game'; rawData: GroupChatGameData };
+    | { gameId: 'group_chat_game'; rawData: GroupChatGameData }
+    | { gameId: 'sorter_game'; rawData: SorterGameData };
 
 /**
  * DB 行（game_logs）の生レコード型。

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -20,7 +20,7 @@ router.post(
             // HTTP 境界（Anti-Corruption Layer / Issue #101）。
             // 仕様維持のため API の wire format は数値 game_type のままとし、
             // service 層へ渡す前にドメインの文字列 GameId に変換する。
-            // game_type は zod スキーマで 1/2/3 のいずれかに narrow 済みのため、
+            // game_type は zod スキーマで 1/2/3/4 のいずれかに narrow 済みのため、
             // GAME_TYPE_TO_ID のキー網羅性が保証される（ID_TO_GAME_TYPE と
             // 対称な定数を `analysis/registry.ts` に集約してある）。
             const gameId = GAME_TYPE_TO_ID[game_type];

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -8,8 +8,10 @@
  * - 利用規約ゲーム（terms_game / 旧 Game 1）: `./games/termsGame`
  * - AI カスタマーサポート（helpdesk_game / 旧 Game 2）: `./games/helpdeskGame`
  * - 空気読みグループチャット（group_chat_game / 旧 Game 3）: `./games/groupChatGame`
+ * - 荷物仕分けゲーム（sorter_game / game_type=4）: `./games/sorterGame`
  */
 
 export { termsGameDataSchema, type TermsGameData } from './games/termsGame';
 export { helpdeskGameDataSchema, type HelpdeskGameData } from './games/helpdeskGame';
 export { groupChatGameDataSchema, type GroupChatGameData } from './games/groupChatGame';
+export { sorterGameDataSchema, type SorterGameData } from './games/sorterGame';

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -9,11 +9,13 @@ import {
     termsGameDataSchema,
     helpdeskGameDataSchema,
     groupChatGameDataSchema,
+    sorterGameDataSchema,
 } from './gameData';
 import {
     submitGameRequestExampleTermsGame,
     submitGameRequestExampleHelpdeskGame,
     submitGameRequestExampleGroupChatGame,
+    submitGameRequestExampleSorterGame,
     submitGameResponseExample,
 } from '../openapi/examples';
 
@@ -36,15 +38,15 @@ import {
  * 値の追加時に `types/index.ts` の `GAME_TYPES` のみを更新すれば
  * 型と OpenAPI enum が自動で追随する（二重管理を解消）。
  *
- * `Object.values(GAME_TYPES)` の戻り値型は `(1 | 2 | 3)[]` で、
+ * `Object.values(GAME_TYPES)` の戻り値型は `(1 | 2 | 3 | 4)[]` で、
  * `z.literal<const T extends ReadonlyArray<Literal>>(value: T)` の T[number] 推論により
- * 内部型は `1 | 2 | 3` のユニオンが維持される（`gameService.parseGameData` の
+ * 内部型は `1 | 2 | 3 | 4` のユニオンが維持される（`gameService.parseGameData` の
  * 網羅性チェック `const _exh: never = gameType` が機能するために必須）。
  */
 const GAME_TYPE_VALUES = Object.values(GAME_TYPES);
 
 /**
- * ゲーム種別（1: 利用規約 / 2: AI チャット / 3: グループチャット）。
+ * ゲーム種別（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）。
  *
  * `types/index.ts` の `GAME_TYPES` 定数を唯一の真実とし、
  * `GAME_TYPE_VALUES` 経由で zod スキーマと OpenAPI enum の両方に展開する。
@@ -54,7 +56,7 @@ const GAME_TYPE_VALUES = Object.values(GAME_TYPES);
  * は OpenAPI 公開用の独立コンポーネント（GameType）として残し、他エンドポイントや
  * FE 生成型から再利用可能にする。
  *
- * NOTE: zod v4 の `z.literal(array)` は内部的に `1 | 2 | 3` の literal union として
+ * NOTE: zod v4 の `z.literal(array)` は内部的に `1 | 2 | 3 | 4` の literal union として
  * 振る舞うが、`@asteasolutions/zod-to-openapi` v8.5 の `LiteralTransformer` は
  * multi-value literal を `enum: [values[0]]`（先頭 1 要素のみ）にしか展開しない。
  * よって OpenAPI で正しい enum を出すには `.openapi({ enum: [...] })` で全値を
@@ -64,7 +66,7 @@ export const gameTypeSchema = registry.register(
     'GameType',
     z.literal(GAME_TYPE_VALUES).openapi({
         description:
-            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット',
+            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット / 4: 荷物仕分け',
         enum: GAME_TYPE_VALUES,
         example: GAME_TYPES.TERMS_GAME,
     }),
@@ -78,6 +80,7 @@ export const gameTypeSchema = registry.register(
  * - game_type === 1 のとき data は TermsGameData
  * - game_type === 2 のとき data は HelpdeskGameData
  * - game_type === 3 のとき data は GroupChatGameData
+ * - game_type === 4 のとき data は SorterGameData
  *
  * OpenAPI 上は `oneOf` で表現され、各 branch の
  * `game_type: { type: 'number', enum: [N] }` リテラル enum で判別する形になる。
@@ -86,8 +89,8 @@ export const gameTypeSchema = registry.register(
  *   `discriminator: { mapping: { '1': ..., '2': ..., '3': ... } }` を出力する
  * - OpenAPI 仕様上 `mapping` のキーは Map<string, string> のため数値リテラルでも
  *   文字列化される。openapi-typescript v7 はこのキーをそのまま tsLiteral に渡すため、
- *   FE 生成型の game_type が文字列リテラル "1" / "2" / "3" になり、BE の
- *   z.literal(1|2|3) と矛盾する（PR #64 のレビュー経緯参照）。
+ *   FE 生成型の game_type が文字列リテラル "1" / "2" / "3" / "4" になり、BE の
+ *   z.literal(1|2|3|4) と矛盾する（PR #64 のレビュー経緯参照）。
  *
  * Swagger UI / 生成型からも各 branch の game_type literal で構造が見えるため、
  * discriminator 等価の機能は維持される。
@@ -133,11 +136,22 @@ export const submitGameRequestSchema = registry.register(
                         '空気読みグループチャット（game_type=3）の終了時に送るリクエスト',
                     example: submitGameRequestExampleGroupChatGame,
                 }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.SORTER),
+                    data: sorterGameDataSchema,
+                })
+                .openapi({
+                    description:
+                        '荷物仕分けゲーム（game_type=4）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleSorterGame,
+                }),
         ])
         .openapi({
             description:
                 '各ゲーム終了時に行動データを送信するリクエスト。' +
-                'game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。' +
+                'game_type の値（1 / 2 / 3 / 4）で data 構造が決まる（oneOf）。' +
                 '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
         }),
 );
@@ -164,7 +178,7 @@ export const submitGameResponseSchema = registry.register(
 );
 
 /**
- * ゲーム種別（1/2/3）の TS 型。
+ * ゲーム種別（1/2/3/4）の TS 型。
  * `gameTypeSchema` から `z.infer` で導出するため、値の追加時は
  * `types/index.ts` の `GAME_TYPES` のみを更新すれば本型・zod スキーマ・
  * OpenAPI enum の全てが `GAME_TYPE_VALUES` 経由で自動的に追随する。

--- a/backend/src/schemas/games/sorterGame.ts
+++ b/backend/src/schemas/games/sorterGame.ts
@@ -1,0 +1,141 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../../openapi/registry';
+import { z } from 'zod';
+import { registry } from '../../openapi/registry';
+
+/**
+ * 荷物仕分けゲーム（sorter_game / game_type=4）の行動データ（raw_data）の zod スキーマ群。
+ *
+ * 設計方針:
+ * - 仕様書「データ構造 → SorterGameData」を一次情報とし、TS 型は `z.infer` で導出する
+ * - `submitGameRequestSchema`（schemas/games.ts）の `data` discriminated branch として
+ *   API に公開されるため `.openapi()` と `registry.register()` でコンポーネント化する
+ * - `wrongPatterns` は
+ *   `Record<'urgent'|'fragile'|'heavy', Partial<Record<'urgent'|'fragile'|'heavy', number>>>`
+ *   に相当するオブジェクト形で表現する
+ */
+
+const packageTypeSchema = registry.register(
+    'PackageType',
+    z.enum(['urgent', 'fragile', 'heavy']).openapi({
+        description: '荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物',
+    }),
+);
+
+const binChosenSchema = z.union([packageTypeSchema, z.null()]).openapi({
+    description: '仕分け先。流出・取り消し時は null',
+});
+
+const sortEventTypeSchema = registry.register(
+    'SortEventType',
+    z.enum(['sort', 'cancel', 'outflow']).openapi({
+        description: 'sort=仕分け / cancel=取り消し / outflow=流出',
+    }),
+);
+
+const wrongPatternCountsRowSchema = registry.register(
+    'SorterWrongPatternCountsRow',
+    z
+        .object({
+            urgent: z.number().optional(),
+            fragile: z.number().optional(),
+            heavy: z.number().optional(),
+        })
+        .openapi({
+            description:
+                '正解ラベル別に、どのビンへ誤仕分けしたかの回数（省略キーは未定義＝0 回扱い）',
+        }),
+);
+
+const wrongPatternsSchema = registry.register(
+    'WrongPatterns',
+    z
+        .object({
+            urgent: wrongPatternCountsRowSchema.openapi({
+                description: 'urgent を誤仕分けしたパターン別カウント',
+            }),
+            fragile: wrongPatternCountsRowSchema.openapi({
+                description: 'fragile を誤仕分けしたパターン別カウント',
+            }),
+            heavy: wrongPatternCountsRowSchema.openapi({
+                description: 'heavy を誤仕分けしたパターン別カウント',
+            }),
+        })
+        .openapi({
+            description:
+                '誤仕分けパターン。例: { urgent: { fragile: 2 } } = urgent を fragile に 2 回誤仕分け',
+        }),
+);
+
+const sortEventSchema = registry.register(
+    'SortEvent',
+    z
+        .object({
+            timestamp: z.number().openapi({
+                description: 'ゲーム開始からの経過時間（ms）',
+            }),
+            eventType: sortEventTypeSchema,
+            packageType: packageTypeSchema,
+            binChosen: binChosenSchema,
+            hesitationMs: z.number().nullable().openapi({
+                description: '選択→仕分けの ms。流出・取り消し時は null',
+            }),
+            correct: z.boolean().openapi({
+                description: '正解判定（ルール変更後の判定込み）。流出・取り消し時は false',
+            }),
+            duringRuleChange: z.boolean().openapi({
+                description: 'ルール変更後のイベントか',
+            }),
+            duringFreeze: z.boolean().openapi({
+                description: '凍結中のクリックか（記録のみ、処理しない）',
+            }),
+        })
+        .openapi({
+            description: '荷物仕分けゲームの1イベント分のログ',
+        }),
+);
+
+export const sorterGameDataSchema = registry.register(
+    'SorterGameData',
+    z
+        .object({
+            totalTimeMs: z.number().openapi({
+                description: '実プレイ時間（ms）。設計値 50000ms',
+            }),
+            finalScore: z.number().int().openapi({
+                description: 'プレイ画面の表示用スコア。5 軸スコア算出には使わない',
+            }),
+            averageHesitationMs: z.number().openapi({
+                description: '平均判断時間（選択→仕分けまでの ms 平均）',
+            }),
+            spawnedPackages: z.number().int().openapi({
+                description: 'ゲーム中に出現した荷物の総数',
+            }),
+            wrongSortCount: z.number().int().openapi({
+                description: '誤仕分けの回数',
+            }),
+            wrongPatterns: wrongPatternsSchema,
+            cancelCount: z.number().int().openapi({
+                description: '選択取り消し回数',
+            }),
+            outflowMissCount: z.number().int().openapi({
+                description: '流出ミスの回数（仕分けされず画面外へ流れた荷物）',
+            }),
+            panicClickCount: z.number().int().openapi({
+                description: '凍結中（システム障害 5 秒間）のクリック数',
+            }),
+            ruleChangeAdaptMs: z.number().nullable().openapi({
+                description: 'ルール変更後、新ルールで初正解までの ms。未適応なら null',
+            }),
+            events: z.array(sortEventSchema).openapi({
+                description: 'ゲーム中のイベントログ',
+            }),
+        })
+        .openapi({
+            description:
+                '荷物仕分けゲームの行動データ。仕様書「データ構造 → SorterGameData」準拠',
+        }),
+);
+
+export type SorterGameData = z.infer<typeof sorterGameDataSchema>;

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -67,7 +67,7 @@ export interface paths {
         put?: never;
         /**
          * ゲームプレイデータ送信
-         * @description 各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。
+         * @description 各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）の終了時に行動データを送信する。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。
          */
         post: {
             parameters: {
@@ -91,7 +91,7 @@ export interface paths {
                         "application/json": components["schemas"]["SubmitGameResponse"];
                     };
                 };
-                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / data が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ invalid_game_type（game_type が 1-3 の範囲外） */
+                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / data が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ invalid_game_type（game_type が 1-4 の範囲外） */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -584,12 +584,75 @@ export interface components {
             stages: components["schemas"]["GroupChatGameStage"][];
         };
         /**
-         * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット
+         * @description 荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物
+         * @enum {string}
+         */
+        PackageType: "urgent" | "fragile" | "heavy";
+        /**
+         * @description sort=仕分け / cancel=取り消し / outflow=流出
+         * @enum {string}
+         */
+        SortEventType: "sort" | "cancel" | "outflow";
+        /** @description 正解ラベル別に、どのビンへ誤仕分けしたかの回数（省略キーは未定義＝0 回扱い） */
+        SorterWrongPatternCountsRow: {
+            urgent?: number;
+            fragile?: number;
+            heavy?: number;
+        };
+        /** @description 誤仕分けパターン。例: { urgent: { fragile: 2 } } = urgent を fragile に 2 回誤仕分け */
+        WrongPatterns: {
+            urgent: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+            fragile: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+            heavy: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+        };
+        /** @description 荷物仕分けゲームの1イベント分のログ */
+        SortEvent: {
+            /** @description ゲーム開始からの経過時間（ms） */
+            timestamp: number;
+            eventType: components["schemas"]["SortEventType"];
+            packageType: components["schemas"]["PackageType"];
+            /** @description 仕分け先。流出・取り消し時は null */
+            binChosen: components["schemas"]["PackageType"] | null;
+            /** @description 選択→仕分けの ms。流出・取り消し時は null */
+            hesitationMs: number | null;
+            /** @description 正解判定（ルール変更後の判定込み）。流出・取り消し時は false */
+            correct: boolean;
+            /** @description ルール変更後のイベントか */
+            duringRuleChange: boolean;
+            /** @description 凍結中のクリックか（記録のみ、処理しない） */
+            duringFreeze: boolean;
+        };
+        /** @description 荷物仕分けゲームの行動データ。仕様書「データ構造 → SorterGameData」準拠 */
+        SorterGameData: {
+            /** @description 実プレイ時間（ms）。設計値 50000ms */
+            totalTimeMs: number;
+            /** @description プレイ画面の表示用スコア。5 軸スコア算出には使わない */
+            finalScore: number;
+            /** @description 平均判断時間（選択→仕分けまでの ms 平均） */
+            averageHesitationMs: number;
+            /** @description ゲーム中に出現した荷物の総数 */
+            spawnedPackages: number;
+            /** @description 誤仕分けの回数 */
+            wrongSortCount: number;
+            wrongPatterns: components["schemas"]["WrongPatterns"];
+            /** @description 選択取り消し回数 */
+            cancelCount: number;
+            /** @description 流出ミスの回数（仕分けされず画面外へ流れた荷物） */
+            outflowMissCount: number;
+            /** @description 凍結中（システム障害 5 秒間）のクリック数 */
+            panicClickCount: number;
+            /** @description ルール変更後、新ルールで初正解までの ms。未適応なら null */
+            ruleChangeAdaptMs: number | null;
+            /** @description ゲーム中のイベントログ */
+            events: components["schemas"]["SortEvent"][];
+        };
+        /**
+         * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット / 4: 荷物仕分け
          * @example 1
          * @enum {number}
          */
         GameType: 1 | 2 | 3 | 4;
-        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type の値（1 / 2 / 3 / 4）で data 構造が決まる（oneOf）。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
         SubmitGameRequest: {
             /**
              * Format: uuid
@@ -620,6 +683,16 @@ export interface components {
             /** @enum {number} */
             game_type: 3;
             data: components["schemas"]["GroupChatGameData"];
+        } | {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /** @enum {number} */
+            game_type: 4;
+            data: components["schemas"]["SorterGameData"];
         };
         /**
          * @description ゲームデータ保存成功レスポンス（200 OK）


### PR DESCRIPTION
## 概要
`sorter_game`（荷物仕分けゲーム）の zod スキーマを追加し、
`POST /api/games/submit` の discriminatedUnion に game_type=4 branch を追加する。

## 変更内容
- `schemas/games/sorterGame.ts`: `SorterGameData` / `WrongPatterns` / `SortEvent` 等の zod スキーマを新規作成
- `schemas/gameData.ts`: `sorterGame` の再エクスポートを追加
- `schemas/games.ts`: discriminatedUnion に game_type=4 branch を追加
- `analysis/games/sorterGame.ts`: 仮置きスキーマを正式 import に切り替え
- `repositories/gameRepository.ts`: `GameRawDataPayload` に `sorter_game` を追加
- `openapi/examples.ts`: game_type=4 の example を追加
- `openapi/paths/games.ts`: description を 1-4 に更新
- `frontend/src/lib/api/generated.ts`: 再生成

## 注意点
- `resultsResponseExample` の `game_breakdown` はまだ `helpdesk_game` のまま（#116 で更新）
- 分析ロジックの本実装は #115 で行う

## 関連 Issue
closes #114
parent: #121

## 動作確認
- `cd backend && npx tsc --noEmit` が通ることを確認
- `cd frontend && npm run gen:api-types` が正常終了し `generated.ts` が更新されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 荷物仕分けゲーム（game_type=4）に対応しました。APIスキーマ、バックエンド、フロントエンドで統合され、計測時間、スコア、仕分けイベント、誤仕分け内訳などの行動データ検証が実装されました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/131)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->