### PR TITLE
Feat/sorter game normal flow

### DIFF
--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -1,15 +1,5 @@
-import type { ZodType } from 'zod';
 import type { GameDetail } from '../../schemas/results';
-
-// TODO: #114 で sorterGameDataSchema を作成後に正式 import に切り替える
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SorterGameData = any;
-
-const sorterGameDataSchemaStub = {
-    safeParse: (d: unknown) => ({ success: true as const, data: d }),
-};
-
-const sorterGameDataSchema = sorterGameDataSchemaStub as unknown as ZodType;
+import { SorterGameData, sorterGameDataSchema } from '../../schemas/games/sorterGame';
 
 export type SorterGameAnalyzeResult = {
     scores: { caution: number; calmness: number; logic: number; positivity: number };

--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -51,7 +51,7 @@ function analyze(data: SorterGameData | undefined): SorterGameAnalyzeResult {
 
     // --- 誤仕分け率 ---
     const sortEventCount = data.events.filter((e) => e.eventType === 'sort').length;
-    const wrongSortRate = data.wrongSortCount / Math.max(1, sortEventCount);
+    const wrongSortRate = Math.min(1, data.wrongSortCount / Math.max(1, sortEventCount));
 
     // --- 誤仕分け集中度（concentration）---
     // wrongPatterns の全エントリ数値を1配列にまとめ max/sum で算出

--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -2,6 +2,37 @@ import { SorterGameData, sorterGameDataSchema } from '../../schemas/games/sorter
 import type { GameDetail } from '../../schemas/results';
 import { linear, linearInv } from '../scoreUtils';
 
+/**
+ * sorter_game の分析で使う閾値定数。
+ * チームで合意後にここだけ変更すれば全スコア式に反映される。
+ * 値は分析ロジック仕様書「閾値の根拠 Game 2」の初期値。
+ */
+const THRESHOLDS = {
+    hesitation: { best: 200, worst: 4000 },
+    cancelCount: { best: 0, worst: 5 },
+    wrongSortRate: { best: 0, worst: 0.3 },
+    panicClick: { best: 0, worst: 10 },
+    adaptMs: { best: 0, worst: 20000 },
+    concentration: { lo: 0, hi: 1 },
+} as const;
+
+/**
+ * 各軸スコアの重み定数。
+ * 合計が 1.0 になるよう維持すること。
+ */
+const WEIGHTS = {
+    caution: { hesitation: 0.7, cancel: 0.3 },
+    calmness: { wrongRate: 0.5, panic: 0.3, concentration: 0.2 },
+    logic: { adapt: 0.7, concentration: 0.3 },
+} as const;
+
+/**
+ * concentration の最低サンプル数閾値。
+ * 誤仕分けが少なすぎる場合に中立値 0.5 を使う。
+ * 仕様書「※注9」参照。実装段階で決定後に本書を更新する（暗定 3）。
+ */
+const MIN_SAMPLE_FOR_CONCENTRATION = 3;
+
 export type SorterGameAnalyzeResult = {
     scores: { caution: number; calmness: number; logic: number; positivity: number };
     avgHesitationMs: number;
@@ -31,36 +62,46 @@ function analyze(data: SorterGameData | undefined): SorterGameAnalyzeResult {
     ].filter((v): v is number => typeof v === 'number');
 
     const sumCounts = allCounts.reduce((a, b) => a + b, 0);
-    const MIN_SAMPLE = 3;
     const concentration =
-        data.wrongSortCount < MIN_SAMPLE || sumCounts === 0
+        data.wrongSortCount < MIN_SAMPLE_FOR_CONCENTRATION || sumCounts === 0
             ? 0.5
             : Math.max(...allCounts) / sumCounts;
 
     // --- 慎重さ ---
     // 平均判断時間(0.70) + やり直し・取り消し回数(0.30)
     const sCaution =
-        linearInv(data.averageHesitationMs, 200, 4000) * 0.7 +
-        linearInv(data.cancelCount, 0, 5) * 0.3;
+        linearInv(
+            data.averageHesitationMs,
+            THRESHOLDS.hesitation.best,
+            THRESHOLDS.hesitation.worst,
+        ) *
+            WEIGHTS.caution.hesitation +
+        linearInv(data.cancelCount, THRESHOLDS.cancelCount.best, THRESHOLDS.cancelCount.worst) *
+            WEIGHTS.caution.cancel;
 
     // --- 冷静さ ---
     // 誤仕分け率(0.50) + 凍結中パニッククリック(0.30) + 誤仕分け集中度(冷静さ向け)(0.20)
     // 冷静さ向け集中度は linear（散発=パニック=低得点 / 一貫=落ち着き=高得点）
     const sCalmness =
-        linearInv(wrongSortRate, 0, 0.3) * 0.5 +
-        linearInv(data.panicClickCount, 0, 10) * 0.3 +
-        linear(concentration, 0, 1) * 0.2;
+        linearInv(wrongSortRate, THRESHOLDS.wrongSortRate.best, THRESHOLDS.wrongSortRate.worst) *
+            WEIGHTS.calmness.wrongRate +
+        linearInv(data.panicClickCount, THRESHOLDS.panicClick.best, THRESHOLDS.panicClick.worst) *
+            WEIGHTS.calmness.panic +
+        linear(concentration, THRESHOLDS.concentration.lo, THRESHOLDS.concentration.hi) *
+            WEIGHTS.calmness.concentration;
 
     // --- 論理性 ---
     // ルール変更適応速度(0.70) + 誤仕分け集中度(論理性向け)(0.30)
     // 論理性向け集中度は linearInv（散らばり=高得点 / 一貫した誤認知=低得点）
-    const adaptMs = data.ruleChangeAdaptMs ?? 20000;
+    const adaptMs = data.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.worst;
     const sLogic =
-        linearInv(adaptMs, 0, 20000) * 0.7 + linearInv(concentration, 0, 1) * 0.3;
+        linearInv(adaptMs, THRESHOLDS.adaptMs.best, THRESHOLDS.adaptMs.worst) * WEIGHTS.logic.adapt +
+        linearInv(concentration, THRESHOLDS.concentration.lo, THRESHOLDS.concentration.hi) *
+            WEIGHTS.logic.concentration;
 
     // --- 積極性 ---
     // ルール変更適応速度(1.00)
-    const sPositivity = linearInv(adaptMs, 0, 20000);
+    const sPositivity = linearInv(adaptMs, THRESHOLDS.adaptMs.best, THRESHOLDS.adaptMs.worst);
 
     return {
         scores: {
@@ -122,7 +163,7 @@ function buildDetails(data: SorterGameData | undefined, result: SorterGameAnalyz
             },
             {
                 label: 'ルール適応速度(ms)',
-                user: data?.ruleChangeAdaptMs ?? 20000,
+                user: data?.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.worst,
                 average: 5000,
                 category: 'time',
             },

--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -9,10 +9,10 @@ import { linear, linearInv } from '../scoreUtils';
  */
 const THRESHOLDS = {
     hesitation: { best: 200, worst: 4000 },
-    cancelCount: { best: 0, worst: 5 },
+    cancelCount: { best: 0, worst: 5, fallback: 0 },
     wrongSortRate: { best: 0, worst: 0.3 },
-    panicClick: { best: 0, worst: 10 },
-    adaptMs: { best: 0, worst: 20000 },
+    panicClick: { best: 0, worst: 10, fallback: 0 },
+    adaptMs: { best: 0, worst: 20000, fallback: 20000 },
     concentration: { lo: 0, hi: 1 },
 } as const;
 
@@ -93,7 +93,7 @@ function analyze(data: SorterGameData | undefined): SorterGameAnalyzeResult {
     // --- 論理性 ---
     // ルール変更適応速度(0.70) + 誤仕分け集中度(論理性向け)(0.30)
     // 論理性向け集中度は linearInv（散らばり=高得点 / 一貫した誤認知=低得点）
-    const adaptMs = data.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.worst;
+    const adaptMs = data.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.fallback;
     const sLogic =
         linearInv(adaptMs, THRESHOLDS.adaptMs.best, THRESHOLDS.adaptMs.worst) * WEIGHTS.logic.adapt +
         linearInv(concentration, THRESHOLDS.concentration.lo, THRESHOLDS.concentration.hi) *
@@ -156,14 +156,20 @@ function buildDetails(data: SorterGameData | undefined, result: SorterGameAnalyz
                 category: 'sort',
             },
             {
+                label: '流出ミス(回)',
+                user: data?.outflowMissCount ?? 0,
+                average: 2,
+                category: 'sort',
+            },
+            {
                 label: 'パニッククリック(回)',
-                user: data?.panicClickCount ?? 0,
+                user: data?.panicClickCount ?? THRESHOLDS.panicClick.fallback,
                 average: 3,
                 category: 'input',
             },
             {
                 label: 'ルール適応速度(ms)',
-                user: data?.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.worst,
+                user: data?.ruleChangeAdaptMs ?? THRESHOLDS.adaptMs.fallback,
                 average: 5000,
                 category: 'time',
             },

--- a/backend/src/analysis/games/sorterGame.ts
+++ b/backend/src/analysis/games/sorterGame.ts
@@ -1,22 +1,97 @@
-import type { GameDetail } from '../../schemas/results';
 import { SorterGameData, sorterGameDataSchema } from '../../schemas/games/sorterGame';
+import type { GameDetail } from '../../schemas/results';
+import { linear, linearInv } from '../scoreUtils';
 
 export type SorterGameAnalyzeResult = {
     scores: { caution: number; calmness: number; logic: number; positivity: number };
+    avgHesitationMs: number;
+    wrongSortRate: number;
+    concentration: number;
 };
 
 function analyze(data: SorterGameData | undefined): SorterGameAnalyzeResult {
-    if (!data) return { scores: { caution: 50, calmness: 50, logic: 50, positivity: 50 } };
-    // TODO: #115 で本実装
-    return { scores: { caution: 50, calmness: 50, logic: 50, positivity: 50 } };
+    if (!data)
+        return {
+            scores: { caution: 50, calmness: 50, logic: 50, positivity: 50 },
+            avgHesitationMs: 0,
+            wrongSortRate: 0,
+            concentration: 0.5,
+        };
+
+    // --- 誤仕分け率 ---
+    const sortEventCount = data.events.filter((e) => e.eventType === 'sort').length;
+    const wrongSortRate = data.wrongSortCount / Math.max(1, sortEventCount);
+
+    // --- 誤仕分け集中度（concentration）---
+    // wrongPatterns の全エントリ数値を1配列にまとめ max/sum で算出
+    const allCounts: number[] = [
+        ...Object.values(data.wrongPatterns.urgent ?? {}),
+        ...Object.values(data.wrongPatterns.fragile ?? {}),
+        ...Object.values(data.wrongPatterns.heavy ?? {}),
+    ].filter((v): v is number => typeof v === 'number');
+
+    const sumCounts = allCounts.reduce((a, b) => a + b, 0);
+    const MIN_SAMPLE = 3;
+    const concentration =
+        data.wrongSortCount < MIN_SAMPLE || sumCounts === 0
+            ? 0.5
+            : Math.max(...allCounts) / sumCounts;
+
+    // --- 慎重さ ---
+    // 平均判断時間(0.70) + やり直し・取り消し回数(0.30)
+    const sCaution =
+        linearInv(data.averageHesitationMs, 200, 4000) * 0.7 +
+        linearInv(data.cancelCount, 0, 5) * 0.3;
+
+    // --- 冷静さ ---
+    // 誤仕分け率(0.50) + 凍結中パニッククリック(0.30) + 誤仕分け集中度(冷静さ向け)(0.20)
+    // 冷静さ向け集中度は linear（散発=パニック=低得点 / 一貫=落ち着き=高得点）
+    const sCalmness =
+        linearInv(wrongSortRate, 0, 0.3) * 0.5 +
+        linearInv(data.panicClickCount, 0, 10) * 0.3 +
+        linear(concentration, 0, 1) * 0.2;
+
+    // --- 論理性 ---
+    // ルール変更適応速度(0.70) + 誤仕分け集中度(論理性向け)(0.30)
+    // 論理性向け集中度は linearInv（散らばり=高得点 / 一貫した誤認知=低得点）
+    const adaptMs = data.ruleChangeAdaptMs ?? 20000;
+    const sLogic =
+        linearInv(adaptMs, 0, 20000) * 0.7 + linearInv(concentration, 0, 1) * 0.3;
+
+    // --- 積極性 ---
+    // ルール変更適応速度(1.00)
+    const sPositivity = linearInv(adaptMs, 0, 20000);
+
+    return {
+        scores: {
+            caution: Math.round(sCaution),
+            calmness: Math.round(sCalmness),
+            logic: Math.round(sLogic),
+            positivity: Math.round(sPositivity),
+        },
+        avgHesitationMs: data.averageHesitationMs,
+        wrongSortRate,
+        concentration,
+    };
 }
 
-function buildSummary(_data: SorterGameData | undefined): string {
-    // TODO: #115 で本実装
-    return '荷物仕分けゲームをプレイしました。';
+function buildSummary(data: SorterGameData | undefined): string {
+    if (!data) return 'データなし';
+
+    const adaptText =
+        data.ruleChangeAdaptMs != null
+            ? `ルール変更には ${(data.ruleChangeAdaptMs / 1000).toFixed(1)} 秒で適応しました。`
+            : 'ルール変更には適応できませんでした。';
+
+    const panicText =
+        data.panicClickCount > 5
+            ? 'システム障害中に焦りが見られました。'
+            : 'システム障害中も落ち着いて待てました。';
+
+    return `${adaptText}${panicText}`;
 }
 
-function buildDetails(_data: SorterGameData | undefined, result: SorterGameAnalyzeResult): GameDetail {
+function buildDetails(data: SorterGameData | undefined, result: SorterGameAnalyzeResult): GameDetail {
     return {
         game_id: sorterGameModule.id,
         title: sorterGameModule.title,
@@ -26,7 +101,32 @@ function buildDetails(_data: SorterGameData | undefined, result: SorterGameAnaly
             { axis: 'logic', name: '論理性', score: result.scores.logic },
             { axis: 'positivity', name: '積極性', score: result.scores.positivity },
         ],
-        metrics: [],
+        metrics: [
+            {
+                label: '平均判断時間(ms)',
+                user: Math.round(result.avgHesitationMs),
+                average: 1500,
+                category: 'time',
+            },
+            {
+                label: '誤仕分け率(%)',
+                user: Math.round(result.wrongSortRate * 100),
+                average: 15,
+                category: 'sort',
+            },
+            {
+                label: 'パニッククリック(回)',
+                user: data?.panicClickCount ?? 0,
+                average: 3,
+                category: 'input',
+            },
+            {
+                label: 'ルール適応速度(ms)',
+                user: data?.ruleChangeAdaptMs ?? 20000,
+                average: 5000,
+                category: 'time',
+            },
+        ],
     };
 }
 

--- a/backend/src/analysis/registry.ts
+++ b/backend/src/analysis/registry.ts
@@ -148,4 +148,4 @@ export const GAME_TYPE_TO_ID = Object.fromEntries(
  * 将来的なゲームフロー制御のソースとして利用する。
  * ロング版や別フローを実装する際は別の FLOW 定数を追加する想定（本リファクタ範囲外）。
  */
-export const NORMAL_FLOW: readonly GameId[] = ['terms_game', 'helpdesk_game', 'group_chat_game'];
+export const NORMAL_FLOW: readonly GameId[] = ['terms_game', 'sorter_game', 'group_chat_game'];

--- a/backend/src/analysis/scoreCalculator.ts
+++ b/backend/src/analysis/scoreCalculator.ts
@@ -42,7 +42,7 @@ import { safeScore } from './scoreUtils';
  * 未送信ゲームの値は undefined（`incomplete_games` ガード後は実質起こらないが、
  * モジュール側の早期 return で安全に扱える）。
  *
- * NORMAL_FLOW に含まれない GameId（例: sorter_game）は欠落してよいため Partial。
+ * NORMAL_FLOW に含まれない GameId（例: helpdesk_game）は欠落してよいため Partial。
  * resultService が NORMAL_FLOW をループして詰めるため、NORMAL_FLOW 外のキーは存在しない。
  */
 export type GameDataByGameId = Readonly<Partial<Record<GameId, unknown>>>;
@@ -78,7 +78,7 @@ function computeAccuracyScore(gaps: BaselineScores): number {
  * 3 ゲームの行動データから 5 軸スコア・gaps・feedback・details 等の結果レスポンス
  * オブジェクトを組み立てる。
  *
- * 配列順は `NORMAL_FLOW`（terms_game → helpdesk_game → group_chat_game の通常フロー）に
+ * 配列順は `NORMAL_FLOW`（terms_game → sorter_game → group_chat_game の通常フロー）に
  * 合わせる。FE は配列内を `find(game_id === '...')` で参照する設計のため、配列順は
  * セマンティクスに影響しないが、API レスポンスの安定化のため固定順で出力する。
  */

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -71,7 +71,7 @@ export const apiErrorExamples = {
     [ERROR_CODES.INVALID_GAME_TYPE]: {
         status: 'error',
         error: ERROR_CODES.INVALID_GAME_TYPE,
-        message: 'game_type は 1 / 2 / 3 のいずれかで指定してください',
+        message: 'game_type は 1 / 2 / 3 / 4 のいずれかで指定してください',
     },
     [ERROR_CODES.INCOMPLETE_GAMES]: {
         status: 'error',
@@ -224,6 +224,33 @@ export const submitGameRequestExampleGroupChatGame = {
                 isTimeout: true,
             },
         ],
+    },
+} as const;
+
+/**
+ * game_type = 4（荷物仕分けゲーム）の data サンプル。
+ *
+ * 仕様書「データ構造」→ SorterGameData を参照。
+ */
+export const submitGameRequestExampleSorterGame = {
+    user_id: SAMPLE_USER_ID,
+    game_type: 4,
+    data: {
+        totalTimeMs: 50000,
+        finalScore: 120,
+        averageHesitationMs: 1200,
+        spawnedPackages: 25,
+        wrongSortCount: 3,
+        wrongPatterns: {
+            urgent: { fragile: 2, heavy: 1 },
+            fragile: {},
+            heavy: {},
+        },
+        cancelCount: 2,
+        outflowMissCount: 1,
+        panicClickCount: 4,
+        ruleChangeAdaptMs: 3500,
+        events: [],
     },
 } as const;
 

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -302,12 +302,12 @@ export const voiceRespondResponseExample = {
  * （Swagger UI の閲覧者が実際のレスポンスと突合しても齟齬が出ないようにするため）。
  * 値自体は「形を示すための代表値」で、特定ユーザーの実測値ではない。
  *
- * `details[*].feature_scores` は実装側では複数軸（terms_game: 3 軸 / helpdesk_game: 3 軸 /
- * group_chat_game: 2 軸）を返す。本 example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、
+ * `details[*].feature_scores` は実装側では複数軸（terms_game: 3 軸 / sorter_game: 4 軸 /
+ * helpdesk_game: 3 軸 / group_chat_game: 2 軸）を返す。本 example は肥大化を避けて各ゲーム 1 軸のみ掲載しているが、
  * 実際のレスポンスでは複数要素の配列になる点に注意。
  *
  * game_id は Phase 3（registry 導入）で正式定義予定の文字列 ID を先取りで使用している。
- * 配列順は terms_game → helpdesk_game → group_chat_game の通常フロー順
+ * 配列順は terms_game → sorter_game → group_chat_game の通常フロー順
  * （Phase 3 で `analysis/registry.ts` の `NORMAL_FLOW` 定数として正式定義予定）。
  */
 export const resultsResponseExample = {
@@ -343,7 +343,10 @@ export const resultsResponseExample = {
     },
     game_breakdown: [
         { game_id: 'terms_game', scores: { caution: 45, logic: 75, calmness: 55 } },
-        { game_id: 'helpdesk_game', scores: { positivity: 70, calmness: 55, logic: 75 } },
+        {
+            game_id: 'sorter_game',
+            scores: { caution: 50, calmness: 55, positivity: 70, logic: 65 },
+        },
         { game_id: 'group_chat_game', scores: { cooperativeness: 60, positivity: 70, caution: 45 } },
     ],
     feedback: {
@@ -354,11 +357,15 @@ export const resultsResponseExample = {
     accuracy_score: 78,
     phase_summaries: [
         { game_id: 'terms_game', summary: '規約を爆速でスクロールし、最後まで読まずに同意しました。' },
-        { game_id: 'helpdesk_game', summary: 'AI の理不尽な対応に感情的に反応する場面が見られました。' },
+        {
+            game_id: 'sorter_game',
+            summary:
+                'ルール変更には3.5秒で適応しました。システム障害中も落ち着いて待てました。',
+        },
         { game_id: 'group_chat_game', summary: 'グループの空気を読みつつ、自分の意見も主張していました。' },
     ],
     // タイトル文字列は analysis/scoreCalculator.ts の実装値に合わせる
-    // （helpdesk_game: 'AIカスタマーサポート' / group_chat_game: '空気読みグループチャット'）
+    // （sorter_game: '荷物仕分けゲーム' / group_chat_game: '空気読みグループチャット'）
     details: [
         {
             game_id: 'terms_game',
@@ -371,14 +378,10 @@ export const resultsResponseExample = {
             ],
         },
         {
-            game_id: 'helpdesk_game',
-            title: 'AIカスタマーサポート',
-            feature_scores: [
-                { axis: 'positivity', name: '積極性', score: 70 },
-            ],
-            metrics: [
-                { label: '発話数', user: 8, average: 5, category: 'message' },
-            ],
+            game_id: 'sorter_game',
+            title: '荷物仕分けゲーム',
+            feature_scores: [{ axis: 'caution', name: '慎重さ', score: 50 }],
+            metrics: [{ label: '平均判断時間(ms)', user: 1200, average: 1500, category: 'time' }],
         },
         {
             game_id: 'group_chat_game',

--- a/backend/src/openapi/paths/games.ts
+++ b/backend/src/openapi/paths/games.ts
@@ -22,7 +22,7 @@ registry.registerPath({
     tags: ['Games'],
     summary: 'ゲームプレイデータ送信',
     description:
-        '各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。' +
+        '各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）の終了時に行動データを送信する。' +
         '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。',
     request: {
         body: {
@@ -48,7 +48,7 @@ registry.registerPath({
                 'リクエスト不正。主な業務エラーコード: ' +
                 'invalid_request（必須フィールド欠落 / data が空）/ ' +
                 'invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ ' +
-                'invalid_game_type（game_type が 1-3 の範囲外）',
+                'invalid_game_type（game_type が 1-4 の範囲外）',
             content: {
                 'application/json': {
                     schema: apiErrorSchema,

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -50,9 +50,10 @@ export const gameRepository = {
      * 戻り値の `raw_data` は `unknown`（GameLog.raw_data の定義どおり）。
      * 構造の検証は呼び出し元（resultService）が zod スキーマで parse して行う。
      *
-     * `order` は DB カラム名（game_type）で行う。出力上の並び順は
-     * `terms_game` (1) → `helpdesk_game` (2) → `group_chat_game` (3) になり、
-     * `analysis/registry.ts` の `NORMAL_FLOW` と一致する。
+     * `order` は DB カラム名（game_type）で行う。返却配列は数値昇順（1→4 =
+     * terms → helpdesk → group_chat → sorter）。
+     * 診断結果の game_breakdown / details の並びは `NORMAL_FLOW` であり、
+     * 本配列の並びとは一致しない（`resultService` が game_id で引き当てる）。
      * 未知の game_type が DB に紛れていた場合（DB 整合性破壊）はその行をスキップしつつ
      * `console.error` で報告する（呼び出し元の `gameLogs.length < 3` 判定で
      * 400 incomplete_games に倒れる流れになり、レスポンスに不整合行が漏れない）。

--- a/backend/src/repositories/gameRepository.ts
+++ b/backend/src/repositories/gameRepository.ts
@@ -1,6 +1,6 @@
 import { GAME_TYPE_TO_ID, ID_TO_GAME_TYPE } from '../analysis/registry';
 import { supabase } from '../db/client';
-import { TermsGameData, HelpdeskGameData, GroupChatGameData } from '../schemas/gameData';
+import { TermsGameData, HelpdeskGameData, GroupChatGameData, SorterGameData } from '../schemas/gameData';
 import { GameId, GameLog } from '../types';
 
 /**
@@ -18,7 +18,8 @@ import { GameId, GameLog } from '../types';
 export type GameRawDataPayload =
     | { gameId: 'terms_game'; rawData: TermsGameData }
     | { gameId: 'helpdesk_game'; rawData: HelpdeskGameData }
-    | { gameId: 'group_chat_game'; rawData: GroupChatGameData };
+    | { gameId: 'group_chat_game'; rawData: GroupChatGameData }
+    | { gameId: 'sorter_game'; rawData: SorterGameData };
 
 /**
  * DB 行（game_logs）の生レコード型。

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -20,7 +20,7 @@ router.post(
             // HTTP 境界（Anti-Corruption Layer / Issue #101）。
             // 仕様維持のため API の wire format は数値 game_type のままとし、
             // service 層へ渡す前にドメインの文字列 GameId に変換する。
-            // game_type は zod スキーマで 1/2/3 のいずれかに narrow 済みのため、
+            // game_type は zod スキーマで 1/2/3/4 のいずれかに narrow 済みのため、
             // GAME_TYPE_TO_ID のキー網羅性が保証される（ID_TO_GAME_TYPE と
             // 対称な定数を `analysis/registry.ts` に集約してある）。
             const gameId = GAME_TYPE_TO_ID[game_type];

--- a/backend/src/schemas/gameData.ts
+++ b/backend/src/schemas/gameData.ts
@@ -8,8 +8,10 @@
  * - 利用規約ゲーム（terms_game / 旧 Game 1）: `./games/termsGame`
  * - AI カスタマーサポート（helpdesk_game / 旧 Game 2）: `./games/helpdeskGame`
  * - 空気読みグループチャット（group_chat_game / 旧 Game 3）: `./games/groupChatGame`
+ * - 荷物仕分けゲーム（sorter_game / game_type=4）: `./games/sorterGame`
  */
 
 export { termsGameDataSchema, type TermsGameData } from './games/termsGame';
 export { helpdeskGameDataSchema, type HelpdeskGameData } from './games/helpdeskGame';
 export { groupChatGameDataSchema, type GroupChatGameData } from './games/groupChatGame';
+export { sorterGameDataSchema, type SorterGameData } from './games/sorterGame';

--- a/backend/src/schemas/games.ts
+++ b/backend/src/schemas/games.ts
@@ -9,11 +9,13 @@ import {
     termsGameDataSchema,
     helpdeskGameDataSchema,
     groupChatGameDataSchema,
+    sorterGameDataSchema,
 } from './gameData';
 import {
     submitGameRequestExampleTermsGame,
     submitGameRequestExampleHelpdeskGame,
     submitGameRequestExampleGroupChatGame,
+    submitGameRequestExampleSorterGame,
     submitGameResponseExample,
 } from '../openapi/examples';
 
@@ -36,15 +38,15 @@ import {
  * 値の追加時に `types/index.ts` の `GAME_TYPES` のみを更新すれば
  * 型と OpenAPI enum が自動で追随する（二重管理を解消）。
  *
- * `Object.values(GAME_TYPES)` の戻り値型は `(1 | 2 | 3)[]` で、
+ * `Object.values(GAME_TYPES)` の戻り値型は `(1 | 2 | 3 | 4)[]` で、
  * `z.literal<const T extends ReadonlyArray<Literal>>(value: T)` の T[number] 推論により
- * 内部型は `1 | 2 | 3` のユニオンが維持される（`gameService.parseGameData` の
+ * 内部型は `1 | 2 | 3 | 4` のユニオンが維持される（`gameService.parseGameData` の
  * 網羅性チェック `const _exh: never = gameType` が機能するために必須）。
  */
 const GAME_TYPE_VALUES = Object.values(GAME_TYPES);
 
 /**
- * ゲーム種別（1: 利用規約 / 2: AI チャット / 3: グループチャット）。
+ * ゲーム種別（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）。
  *
  * `types/index.ts` の `GAME_TYPES` 定数を唯一の真実とし、
  * `GAME_TYPE_VALUES` 経由で zod スキーマと OpenAPI enum の両方に展開する。
@@ -54,7 +56,7 @@ const GAME_TYPE_VALUES = Object.values(GAME_TYPES);
  * は OpenAPI 公開用の独立コンポーネント（GameType）として残し、他エンドポイントや
  * FE 生成型から再利用可能にする。
  *
- * NOTE: zod v4 の `z.literal(array)` は内部的に `1 | 2 | 3` の literal union として
+ * NOTE: zod v4 の `z.literal(array)` は内部的に `1 | 2 | 3 | 4` の literal union として
  * 振る舞うが、`@asteasolutions/zod-to-openapi` v8.5 の `LiteralTransformer` は
  * multi-value literal を `enum: [values[0]]`（先頭 1 要素のみ）にしか展開しない。
  * よって OpenAPI で正しい enum を出すには `.openapi({ enum: [...] })` で全値を
@@ -64,7 +66,7 @@ export const gameTypeSchema = registry.register(
     'GameType',
     z.literal(GAME_TYPE_VALUES).openapi({
         description:
-            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット',
+            'ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット / 4: 荷物仕分け',
         enum: GAME_TYPE_VALUES,
         example: GAME_TYPES.TERMS_GAME,
     }),
@@ -78,6 +80,7 @@ export const gameTypeSchema = registry.register(
  * - game_type === 1 のとき data は TermsGameData
  * - game_type === 2 のとき data は HelpdeskGameData
  * - game_type === 3 のとき data は GroupChatGameData
+ * - game_type === 4 のとき data は SorterGameData
  *
  * OpenAPI 上は `oneOf` で表現され、各 branch の
  * `game_type: { type: 'number', enum: [N] }` リテラル enum で判別する形になる。
@@ -86,8 +89,8 @@ export const gameTypeSchema = registry.register(
  *   `discriminator: { mapping: { '1': ..., '2': ..., '3': ... } }` を出力する
  * - OpenAPI 仕様上 `mapping` のキーは Map<string, string> のため数値リテラルでも
  *   文字列化される。openapi-typescript v7 はこのキーをそのまま tsLiteral に渡すため、
- *   FE 生成型の game_type が文字列リテラル "1" / "2" / "3" になり、BE の
- *   z.literal(1|2|3) と矛盾する（PR #64 のレビュー経緯参照）。
+ *   FE 生成型の game_type が文字列リテラル "1" / "2" / "3" / "4" になり、BE の
+ *   z.literal(1|2|3|4) と矛盾する（PR #64 のレビュー経緯参照）。
  *
  * Swagger UI / 生成型からも各 branch の game_type literal で構造が見えるため、
  * discriminator 等価の機能は維持される。
@@ -133,11 +136,22 @@ export const submitGameRequestSchema = registry.register(
                         '空気読みグループチャット（game_type=3）の終了時に送るリクエスト',
                     example: submitGameRequestExampleGroupChatGame,
                 }),
+            z
+                .object({
+                    user_id: userIdSchema,
+                    game_type: z.literal(GAME_TYPES.SORTER),
+                    data: sorterGameDataSchema,
+                })
+                .openapi({
+                    description:
+                        '荷物仕分けゲーム（game_type=4）の終了時に送るリクエスト',
+                    example: submitGameRequestExampleSorterGame,
+                }),
         ])
         .openapi({
             description:
                 '各ゲーム終了時に行動データを送信するリクエスト。' +
-                'game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。' +
+                'game_type の値（1 / 2 / 3 / 4）で data 構造が決まる（oneOf）。' +
                 '同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す',
         }),
 );
@@ -164,7 +178,7 @@ export const submitGameResponseSchema = registry.register(
 );
 
 /**
- * ゲーム種別（1/2/3）の TS 型。
+ * ゲーム種別（1/2/3/4）の TS 型。
  * `gameTypeSchema` から `z.infer` で導出するため、値の追加時は
  * `types/index.ts` の `GAME_TYPES` のみを更新すれば本型・zod スキーマ・
  * OpenAPI enum の全てが `GAME_TYPE_VALUES` 経由で自動的に追随する。

--- a/backend/src/schemas/games/sorterGame.ts
+++ b/backend/src/schemas/games/sorterGame.ts
@@ -1,0 +1,141 @@
+// zod プロトタイプに `.openapi()` を生やすため、z 本体の import より前に
+// 拡張モジュールを副作用 import する（openapi/registry.ts 参照）。
+import '../../openapi/registry';
+import { z } from 'zod';
+import { registry } from '../../openapi/registry';
+
+/**
+ * 荷物仕分けゲーム（sorter_game / game_type=4）の行動データ（raw_data）の zod スキーマ群。
+ *
+ * 設計方針:
+ * - 仕様書「データ構造 → SorterGameData」を一次情報とし、TS 型は `z.infer` で導出する
+ * - `submitGameRequestSchema`（schemas/games.ts）の `data` discriminated branch として
+ *   API に公開されるため `.openapi()` と `registry.register()` でコンポーネント化する
+ * - `wrongPatterns` は
+ *   `Record<'urgent'|'fragile'|'heavy', Partial<Record<'urgent'|'fragile'|'heavy', number>>>`
+ *   に相当するオブジェクト形で表現する
+ */
+
+const packageTypeSchema = registry.register(
+    'PackageType',
+    z.enum(['urgent', 'fragile', 'heavy']).openapi({
+        description: '荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物',
+    }),
+);
+
+const binChosenSchema = z.union([packageTypeSchema, z.null()]).openapi({
+    description: '仕分け先。流出・取り消し時は null',
+});
+
+const sortEventTypeSchema = registry.register(
+    'SortEventType',
+    z.enum(['sort', 'cancel', 'outflow']).openapi({
+        description: 'sort=仕分け / cancel=取り消し / outflow=流出',
+    }),
+);
+
+const wrongPatternCountsRowSchema = registry.register(
+    'SorterWrongPatternCountsRow',
+    z
+        .object({
+            urgent: z.number().optional(),
+            fragile: z.number().optional(),
+            heavy: z.number().optional(),
+        })
+        .openapi({
+            description:
+                '正解ラベル別に、どのビンへ誤仕分けしたかの回数（省略キーは未定義＝0 回扱い）',
+        }),
+);
+
+const wrongPatternsSchema = registry.register(
+    'WrongPatterns',
+    z
+        .object({
+            urgent: wrongPatternCountsRowSchema.openapi({
+                description: 'urgent を誤仕分けしたパターン別カウント',
+            }),
+            fragile: wrongPatternCountsRowSchema.openapi({
+                description: 'fragile を誤仕分けしたパターン別カウント',
+            }),
+            heavy: wrongPatternCountsRowSchema.openapi({
+                description: 'heavy を誤仕分けしたパターン別カウント',
+            }),
+        })
+        .openapi({
+            description:
+                '誤仕分けパターン。例: { urgent: { fragile: 2 } } = urgent を fragile に 2 回誤仕分け',
+        }),
+);
+
+const sortEventSchema = registry.register(
+    'SortEvent',
+    z
+        .object({
+            timestamp: z.number().openapi({
+                description: 'ゲーム開始からの経過時間（ms）',
+            }),
+            eventType: sortEventTypeSchema,
+            packageType: packageTypeSchema,
+            binChosen: binChosenSchema,
+            hesitationMs: z.number().nullable().openapi({
+                description: '選択→仕分けの ms。流出・取り消し時は null',
+            }),
+            correct: z.boolean().openapi({
+                description: '正解判定（ルール変更後の判定込み）。流出・取り消し時は false',
+            }),
+            duringRuleChange: z.boolean().openapi({
+                description: 'ルール変更後のイベントか',
+            }),
+            duringFreeze: z.boolean().openapi({
+                description: '凍結中のクリックか（記録のみ、処理しない）',
+            }),
+        })
+        .openapi({
+            description: '荷物仕分けゲームの1イベント分のログ',
+        }),
+);
+
+export const sorterGameDataSchema = registry.register(
+    'SorterGameData',
+    z
+        .object({
+            totalTimeMs: z.number().openapi({
+                description: '実プレイ時間（ms）。設計値 50000ms',
+            }),
+            finalScore: z.number().int().openapi({
+                description: 'プレイ画面の表示用スコア。5 軸スコア算出には使わない',
+            }),
+            averageHesitationMs: z.number().openapi({
+                description: '平均判断時間（選択→仕分けまでの ms 平均）',
+            }),
+            spawnedPackages: z.number().int().openapi({
+                description: 'ゲーム中に出現した荷物の総数',
+            }),
+            wrongSortCount: z.number().int().openapi({
+                description: '誤仕分けの回数',
+            }),
+            wrongPatterns: wrongPatternsSchema,
+            cancelCount: z.number().int().openapi({
+                description: '選択取り消し回数',
+            }),
+            outflowMissCount: z.number().int().openapi({
+                description: '流出ミスの回数（仕分けされず画面外へ流れた荷物）',
+            }),
+            panicClickCount: z.number().int().openapi({
+                description: '凍結中（システム障害 5 秒間）のクリック数',
+            }),
+            ruleChangeAdaptMs: z.number().nullable().openapi({
+                description: 'ルール変更後、新ルールで初正解までの ms。未適応なら null',
+            }),
+            events: z.array(sortEventSchema).openapi({
+                description: 'ゲーム中のイベントログ',
+            }),
+        })
+        .openapi({
+            description:
+                '荷物仕分けゲームの行動データ。仕様書「データ構造 → SorterGameData」準拠',
+        }),
+);
+
+export type SorterGameData = z.infer<typeof sorterGameDataSchema>;

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -67,7 +67,7 @@ export interface paths {
         put?: never;
         /**
          * ゲームプレイデータ送信
-         * @description 各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット）の終了時に行動データを送信する。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。
+         * @description 各ゲーム（1: 利用規約 / 2: AI チャット / 3: グループチャット / 4: 荷物仕分け）の終了時に行動データを送信する。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す。
          */
         post: {
             parameters: {
@@ -91,7 +91,7 @@ export interface paths {
                         "application/json": components["schemas"]["SubmitGameResponse"];
                     };
                 };
-                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / data が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ invalid_game_type（game_type が 1-3 の範囲外） */
+                /** @description リクエスト不正。主な業務エラーコード: invalid_request（必須フィールド欠落 / data が空）/ invalid_user_id（user_id が不正 = 形式違反 / 欠落 / 存在しない）/ invalid_game_type（game_type が 1-4 の範囲外） */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -584,12 +584,75 @@ export interface components {
             stages: components["schemas"]["GroupChatGameStage"][];
         };
         /**
-         * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット
+         * @description 荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物
+         * @enum {string}
+         */
+        PackageType: "urgent" | "fragile" | "heavy";
+        /**
+         * @description sort=仕分け / cancel=取り消し / outflow=流出
+         * @enum {string}
+         */
+        SortEventType: "sort" | "cancel" | "outflow";
+        /** @description 正解ラベル別に、どのビンへ誤仕分けしたかの回数（省略キーは未定義＝0 回扱い） */
+        SorterWrongPatternCountsRow: {
+            urgent?: number;
+            fragile?: number;
+            heavy?: number;
+        };
+        /** @description 誤仕分けパターン。例: { urgent: { fragile: 2 } } = urgent を fragile に 2 回誤仕分け */
+        WrongPatterns: {
+            urgent: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+            fragile: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+            heavy: components["schemas"]["SorterWrongPatternCountsRow"] & unknown;
+        };
+        /** @description 荷物仕分けゲームの1イベント分のログ */
+        SortEvent: {
+            /** @description ゲーム開始からの経過時間（ms） */
+            timestamp: number;
+            eventType: components["schemas"]["SortEventType"];
+            packageType: components["schemas"]["PackageType"];
+            /** @description 仕分け先。流出・取り消し時は null */
+            binChosen: components["schemas"]["PackageType"] | null;
+            /** @description 選択→仕分けの ms。流出・取り消し時は null */
+            hesitationMs: number | null;
+            /** @description 正解判定（ルール変更後の判定込み）。流出・取り消し時は false */
+            correct: boolean;
+            /** @description ルール変更後のイベントか */
+            duringRuleChange: boolean;
+            /** @description 凍結中のクリックか（記録のみ、処理しない） */
+            duringFreeze: boolean;
+        };
+        /** @description 荷物仕分けゲームの行動データ。仕様書「データ構造 → SorterGameData」準拠 */
+        SorterGameData: {
+            /** @description 実プレイ時間（ms）。設計値 50000ms */
+            totalTimeMs: number;
+            /** @description プレイ画面の表示用スコア。5 軸スコア算出には使わない */
+            finalScore: number;
+            /** @description 平均判断時間（選択→仕分けまでの ms 平均） */
+            averageHesitationMs: number;
+            /** @description ゲーム中に出現した荷物の総数 */
+            spawnedPackages: number;
+            /** @description 誤仕分けの回数 */
+            wrongSortCount: number;
+            wrongPatterns: components["schemas"]["WrongPatterns"];
+            /** @description 選択取り消し回数 */
+            cancelCount: number;
+            /** @description 流出ミスの回数（仕分けされず画面外へ流れた荷物） */
+            outflowMissCount: number;
+            /** @description 凍結中（システム障害 5 秒間）のクリック数 */
+            panicClickCount: number;
+            /** @description ルール変更後、新ルールで初正解までの ms。未適応なら null */
+            ruleChangeAdaptMs: number | null;
+            /** @description ゲーム中のイベントログ */
+            events: components["schemas"]["SortEvent"][];
+        };
+        /**
+         * @description ゲーム種別。1: 利用規約ゲーム / 2: AI カスタマーサポート / 3: グループチャット / 4: 荷物仕分け
          * @example 1
          * @enum {number}
          */
         GameType: 1 | 2 | 3 | 4;
-        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type の値（1 / 2 / 3）で data 構造が決まる（oneOf）。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
+        /** @description 各ゲーム終了時に行動データを送信するリクエスト。game_type の値（1 / 2 / 3 / 4）で data 構造が決まる（oneOf）。同一ユーザー × 同一 game_type の重複送信は 409 `duplicate_submission` を返す */
         SubmitGameRequest: {
             /**
              * Format: uuid
@@ -620,6 +683,16 @@ export interface components {
             /** @enum {number} */
             game_type: 3;
             data: components["schemas"]["GroupChatGameData"];
+        } | {
+            /**
+             * Format: uuid
+             * @description ユーザー識別子（UUID v4）
+             * @example 550e8400-e29b-41d4-a716-446655440000
+             */
+            user_id: string;
+            /** @enum {number} */
+            game_type: 4;
+            data: components["schemas"]["SorterGameData"];
         };
         /**
          * @description ゲームデータ保存成功レスポンス（200 OK）

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -801,11 +801,12 @@ export interface components {
          *         }
          *       },
          *       {
-         *         "game_id": "helpdesk_game",
+         *         "game_id": "sorter_game",
          *         "scores": {
-         *           "positivity": 70,
+         *           "caution": 50,
          *           "calmness": 55,
-         *           "logic": 75
+         *           "positivity": 70,
+         *           "logic": 65
          *         }
          *       },
          *       {
@@ -867,8 +868,8 @@ export interface components {
          *         "summary": "規約を爆速でスクロールし、最後まで読まずに同意しました。"
          *       },
          *       {
-         *         "game_id": "helpdesk_game",
-         *         "summary": "AI の理不尽な対応に感情的に反応する場面が見られました。"
+         *         "game_id": "sorter_game",
+         *         "summary": "ルール変更には3.5秒で適応しました。システム障害中も落ち着いて待てました。"
          *       },
          *       {
          *         "game_id": "group_chat_game",
@@ -951,21 +952,21 @@ export interface components {
          *         ]
          *       },
          *       {
-         *         "game_id": "helpdesk_game",
-         *         "title": "AIカスタマーサポート",
+         *         "game_id": "sorter_game",
+         *         "title": "荷物仕分けゲーム",
          *         "feature_scores": [
          *           {
-         *             "axis": "positivity",
-         *             "name": "積極性",
-         *             "score": 70
+         *             "axis": "caution",
+         *             "name": "慎重さ",
+         *             "score": 50
          *           }
          *         ],
          *         "metrics": [
          *           {
-         *             "label": "発話数",
-         *             "user": 8,
-         *             "average": 5,
-         *             "category": "message"
+         *             "label": "平均判断時間(ms)",
+         *             "user": 1200,
+         *             "average": 1500,
+         *             "category": "time"
          *           }
          *         ]
          *       },
@@ -1034,11 +1035,12 @@ export interface components {
          *           }
          *         },
          *         {
-         *           "game_id": "helpdesk_game",
+         *           "game_id": "sorter_game",
          *           "scores": {
-         *             "positivity": 70,
+         *             "caution": 50,
          *             "calmness": 55,
-         *             "logic": 75
+         *             "positivity": 70,
+         *             "logic": 65
          *           }
          *         },
          *         {
@@ -1062,8 +1064,8 @@ export interface components {
          *           "summary": "規約を爆速でスクロールし、最後まで読まずに同意しました。"
          *         },
          *         {
-         *           "game_id": "helpdesk_game",
-         *           "summary": "AI の理不尽な対応に感情的に反応する場面が見られました。"
+         *           "game_id": "sorter_game",
+         *           "summary": "ルール変更には3.5秒で適応しました。システム障害中も落ち着いて待てました。"
          *         },
          *         {
          *           "game_id": "group_chat_game",
@@ -1091,21 +1093,21 @@ export interface components {
          *           ]
          *         },
          *         {
-         *           "game_id": "helpdesk_game",
-         *           "title": "AIカスタマーサポート",
+         *           "game_id": "sorter_game",
+         *           "title": "荷物仕分けゲーム",
          *           "feature_scores": [
          *             {
-         *               "axis": "positivity",
-         *               "name": "積極性",
-         *               "score": 70
+         *               "axis": "caution",
+         *               "name": "慎重さ",
+         *               "score": 50
          *             }
          *           ],
          *           "metrics": [
          *             {
-         *               "label": "発話数",
-         *               "user": 8,
-         *               "average": 5,
-         *               "category": "message"
+         *               "label": "平均判断時間(ms)",
+         *               "user": 1200,
+         *               "average": 1500,
+         *               "category": "time"
          *             }
          *           ]
          *         },


### PR DESCRIPTION
## 概要
`NORMAL_FLOW` を `[terms_game, sorter_game, group_chat_game]` に切り替え、
通常フローから `helpdesk_game` を外す。
`helpdesk_game` のコード・schemas・voice/respond エンドポイントはロング版用に残置。

## 変更内容
- `analysis/registry.ts`: `NORMAL_FLOW` を sorter_game に切り替え
- `analysis/scoreCalculator.ts`: コメントのフロー順を更新、`GameDataByGameId` のコメントを `helpdesk_game` に修正
- `openapi/examples.ts`: `resultsResponseExample` の `game_breakdown` / `phase_summaries` / `details` を `sorter_game` に更新
- `repositories/gameRepository.ts`: `findLogsByUserId` のコメントを実態に合わせて更新
- `frontend/src/lib/api/generated.ts`: 再生成

## 注意点
- `helpdesk_game` は `GAME_MODULES` / `ID_TO_GAME_TYPE` に残置
- `voice/respond` エンドポイントは削除していない
- #115 のissue(PR)がマージされるまで待機

## 動作確認
- `cd backend && npx tsc --noEmit` が通ることを確認
- `cd frontend && npm run gen:api-types` が正常終了することを確認
- `cd frontend && npx tsc --noEmit` が通ることを確認
- `POST /api/register` → 201 ✅
- `POST /api/games/submit` game_type=1 → 200 ✅
- `POST /api/games/submit` game_type=4 → 200 ✅（#119 DB マイグレーション適用後[supabaseのみ]）
- `POST /api/games/submit` game_type=3 → 200 ✅
- `GET /api/results/:user_id` → 200 ✅
  - `game_breakdown` が `terms_game / sorter_game / group_chat_game` の順で返ること確認
  - `phase_summaries` に `sorter_game` のサマリーが含まれること確認
  - `details` に `sorter_game` の `feature_scores` / `metrics` が含まれること確認

## 関連 Issue
closes #116
parent: #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 新しいゲーム「荷物仕分けゲーム」を追加しました。ゲーム実行フローに組み込まれ、スコア分析と詳細指標の生成に対応しています。
  * 仕分け精度、判断時間、パニック状態の検出など、ゲームの行動分析メトリクスが新たに実装されました。

* **Documentation**
  * API 仕様を更新し、新しいゲームタイプに対応しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->