### PR TITLE
Feat/group chat game schema

### DIFF
--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -200,30 +200,56 @@ export const submitGameRequestExampleHelpdeskGame = {
 /**
  * game_type = 3（グループチャット）の data サンプル。
  *
- * 仕様書「データ構造」→ GroupChatGameData を参照。stages は 5 ステージのうち代表 2 件を載せ、
- * `selectedOptionId: 0` でタイムアウト例も含める（仕様書準拠）。
+ * 仕様書「データ構造」→ GroupChatGameData を参照。3 ターン固定。
+ * ターン 2 でタイムアウト例を含める（仕様書準拠）。
  */
 export const submitGameRequestExampleGroupChatGame = {
     user_id: SAMPLE_USER_ID,
     game_type: 3,
     data: {
         tutorialViewTime: 8500,
-        hoveredOptions: 7,
-        typingIndicatorReactTimeMs: 1450,
-        stages: [
+        turns: [
             {
-                stageId: 1,
+                turnId: 1,
                 selectedOptionId: 2,
                 reactionTimeMs: 3200,
                 isTimeout: false,
+                firstHoverElapsedMs: 800,
+                finalChoiceHoverOrder: 2,
+                decisionConfidenceMs: 1200,
+                mouseMovementDistance: 345,
+                hoverSequence: [1, 3, 2],
+                scrolledChatHistoryCount: 0,
             },
             {
-                stageId: 2,
-                selectedOptionId: 0,
+                turnId: 2,
+                selectedOptionId: 1,
                 reactionTimeMs: 10000,
                 isTimeout: true,
+                firstHoverElapsedMs: null,
+                finalChoiceHoverOrder: null,
+                decisionConfidenceMs: null,
+                mouseMovementDistance: 0,
+                hoverSequence: [],
+                scrolledChatHistoryCount: 1,
+            },
+            {
+                turnId: 3,
+                selectedOptionId: 3,
+                reactionTimeMs: 2500,
+                isTimeout: false,
+                firstHoverElapsedMs: 600,
+                finalChoiceHoverOrder: 1,
+                decisionConfidenceMs: 900,
+                mouseMovementDistance: 210,
+                hoverSequence: [3],
+                scrolledChatHistoryCount: 0,
             },
         ],
+        turn1AnsweredBeforeColleagueA: true,
+        turn1TypingIndicatorReactTimeMs: 1450,
+        turn1HoverChangedAfterColleagueATyping: true,
+        inputDeviceType: 'mouse',
     },
 } as const;
 

--- a/backend/src/schemas/games/groupChatGame.ts
+++ b/backend/src/schemas/games/groupChatGame.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { registry } from '../../openapi/registry';
 
 /**
- * 空気読みグループチャット（group_chat_game / 旧 Game 3）の行動データ（raw_data）の zod スキーマ群。
+ * 空気読みグループチャット（group_chat_game / game_type=3）の行動データ（raw_data）の zod スキーマ群。
  *
  * 設計方針:
  * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
@@ -13,61 +13,91 @@ import { registry } from '../../openapi/registry';
  * - 本ファイルのスキーマは `submitGameRequestSchema`（schemas/games.ts）の
  *   `data` フィールド（discriminatedUnion の各 branch）として API 入出力に出るため、
  *   `.openapi()` でメタデータを付与し `registry.register()` で名前付きコンポーネント化する
- *   （Issue #58 で OpenAPI に公開し、FE の生成型に取り込まれるようにした）
  * - 内部サブスキーマも独立コンポーネント化することで、OpenAPI ドキュメント上の重複を避け
  *   FE 生成型でも再利用可能な型として扱えるようにする
  */
 
 /**
- * 空気読みグループチャットの 1 ステージ分のメトリクス。
+ * 空気読みグループチャットの 1 ターン分のメトリクス。
  *
- * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0（仕様書準拠）。
+ * `turnId` は 1-3 の固定リテラル union。
+ * `selectedOptionId`: 1-4 の内部設計上の意図 ID（表示順とは独立）。
  * 意味的に整数のフィールドには `.int()` を付けて型レベルで小数を弾く。
- * `min/max` 等の値の範囲制約は本スキーマでは表現せず、analysis 層で個別に扱う。
  */
-const groupChatGameStageSchema = registry.register(
-    'GroupChatGameStage',
+const groupChatGameTurnSchema = registry.register(
+    'GroupChatGameTurn',
     z
         .object({
-            stageId: z.number().int().openapi({
-                description: 'ステージ ID（1-5）',
+            turnId: z.union([z.literal(1), z.literal(2), z.literal(3)]).openapi({
+                description: 'ターン ID（1-3 固定）',
             }),
             selectedOptionId: z.number().int().openapi({
-                description: '選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0）',
+                description: '選択した選択肢 ID（1-4 の内部設計上の意図 ID。表示順と独立）',
             }),
             reactionTimeMs: z.number().openapi({
-                description: 'ステージ表示から選択までの反応時間（ms）',
+                description: '選択肢提示 → 選択までの反応時間（ms）',
             }),
             isTimeout: z.boolean().openapi({
                 description: 'タイムアウトしたか',
             }),
+            firstHoverElapsedMs: z.number().nullable().openapi({
+                description: '選択肢表示 → 初ホバーまでの経過時間（ms）。ホバーなしの場合は null',
+            }),
+            finalChoiceHoverOrder: z.number().int().nullable().openapi({
+                description:
+                    '最終選択した選択肢が何番目にホバーされたか（1-4）。ホバーなしの場合は null',
+            }),
+            decisionConfidenceMs: z.number().nullable().openapi({
+                description:
+                    '最終クリック直前の最後のホバー時間（ms）。ホバーなしの場合は null',
+            }),
+            mouseMovementDistance: z.number().openapi({
+                description: '選択肢表示 → 決定までのマウス総移動距離（px）',
+            }),
+            hoverSequence: z.array(z.number().int()).openapi({
+                description:
+                    'ホバーした選択肢 ID の順番（上限 10 件。超過分は切り捨て）',
+            }),
+            scrolledChatHistoryCount: z.number().int().openapi({
+                description: 'チャット履歴を遡るスクロールの回数',
+            }),
         })
         .openapi({
-            description: '空気読みグループチャットの 1 ステージ分のメトリクス',
+            description: '空気読みグループチャットの 1 ターン分のメトリクス',
         }),
 );
 
 /**
  * GroupChatGameData（空気読みグループチャット）。
  *
- * `typingIndicatorReactTimeMs` はステージ 3 / 5 のみで計測される値のため `nullable`。
+ * `turns` は要素数 3 固定の配列。
+ * `turn1AnsweredBeforeColleagueA` / `turn1TypingIndicatorReactTimeMs` /
+ * `turn1HoverChangedAfterColleagueATyping` はターン 1 固有の計測値のため `nullable`。
  */
 export const groupChatGameDataSchema = registry.register(
     'GroupChatGameData',
     z
         .object({
             tutorialViewTime: z.number().openapi({
-                description: 'チュートリアル閲覧時間（ms）',
+                description: 'オンボーディング滞在時間（スライド 1 + 2 合計、ms）',
             }),
-            hoveredOptions: z.number().int().openapi({
-                description: '全ステージ通じた選択肢ホバー回数の合計',
+            turns: z.array(groupChatGameTurnSchema).length(3).openapi({
+                description: '各ターンのメトリクス（要素数 3 固定）',
             }),
-            typingIndicatorReactTimeMs: z.number().nullable().openapi({
+            turn1AnsweredBeforeColleagueA: z.boolean().nullable().openapi({
                 description:
-                    'ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null',
+                    'ターン 1 でプレイヤーが同僚 A より先に回答したか。true=先回り / false=譲った / null=タイムアウト',
             }),
-            stages: z.array(groupChatGameStageSchema).openapi({
-                description: '各ステージのメトリクス',
+            turn1TypingIndicatorReactTimeMs: z.number().nullable().openapi({
+                description:
+                    'ターン 1 で同僚 A の「入力中」表示 → プレイヤー操作までの時間（ms）。未計測時は null',
+            }),
+            turn1HoverChangedAfterColleagueATyping: z.boolean().nullable().openapi({
+                description:
+                    'ターン 1 で同僚 A の「入力中」表示後にホバー先が変わったか。未計測時は null',
+            }),
+            inputDeviceType: z.enum(['mouse', 'touch', 'keyboard']).openapi({
+                description: '入力デバイスの種類',
             }),
         })
         .openapi({
@@ -76,4 +106,5 @@ export const groupChatGameDataSchema = registry.register(
         }),
 );
 
+export type GroupChatGameTurnData = z.infer<typeof groupChatGameTurnSchema>;
 export type GroupChatGameData = z.infer<typeof groupChatGameDataSchema>;

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -561,27 +561,46 @@ export interface components {
             turns: components["schemas"]["HelpdeskGameTurn"][];
             textInputMetrics: components["schemas"]["HelpdeskGameTextInputMetrics"] | null;
         };
-        /** @description 空気読みグループチャットの 1 ステージ分のメトリクス */
-        GroupChatGameStage: {
-            /** @description ステージ ID（1-5） */
-            stageId: number;
-            /** @description 選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0） */
+        /** @description 空気読みグループチャットの 1 ターン分のメトリクス */
+        GroupChatGameTurn: {
+            /** @description ターン ID（1-3 固定） */
+            turnId: 1 | 2 | 3;
+            /** @description 選択した選択肢 ID（1-4 の内部設計上の意図 ID。表示順と独立） */
             selectedOptionId: number;
-            /** @description ステージ表示から選択までの反応時間（ms） */
+            /** @description 選択肢提示 → 選択までの反応時間（ms） */
             reactionTimeMs: number;
             /** @description タイムアウトしたか */
             isTimeout: boolean;
+            /** @description 選択肢表示 → 初ホバーまでの経過時間（ms）。ホバーなしの場合は null */
+            firstHoverElapsedMs: number | null;
+            /** @description 最終選択した選択肢が何番目にホバーされたか（1-4）。ホバーなしの場合は null */
+            finalChoiceHoverOrder: number | null;
+            /** @description 最終クリック直前の最後のホバー時間（ms）。ホバーなしの場合は null */
+            decisionConfidenceMs: number | null;
+            /** @description 選択肢表示 → 決定までのマウス総移動距離（px） */
+            mouseMovementDistance: number;
+            /** @description ホバーした選択肢 ID の順番（上限 10 件。超過分は切り捨て） */
+            hoverSequence: number[];
+            /** @description チャット履歴を遡るスクロールの回数 */
+            scrolledChatHistoryCount: number;
         };
         /** @description 空気読みグループチャットの行動データ。仕様書「データ構造 → GroupChatGameData」準拠 */
         GroupChatGameData: {
-            /** @description チュートリアル閲覧時間（ms） */
+            /** @description オンボーディング滞在時間（スライド 1 + 2 合計、ms） */
             tutorialViewTime: number;
-            /** @description 全ステージ通じた選択肢ホバー回数の合計 */
-            hoveredOptions: number;
-            /** @description ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null */
-            typingIndicatorReactTimeMs: number | null;
-            /** @description 各ステージのメトリクス */
-            stages: components["schemas"]["GroupChatGameStage"][];
+            /** @description 各ターンのメトリクス（要素数 3 固定） */
+            turns: components["schemas"]["GroupChatGameTurn"][];
+            /** @description ターン 1 でプレイヤーが同僚 A より先に回答したか。true=先回り / false=譲った / null=タイムアウト */
+            turn1AnsweredBeforeColleagueA: boolean | null;
+            /** @description ターン 1 で同僚 A の「入力中」表示 → プレイヤー操作までの時間（ms）。未計測時は null */
+            turn1TypingIndicatorReactTimeMs: number | null;
+            /** @description ターン 1 で同僚 A の「入力中」表示後にホバー先が変わったか。未計測時は null */
+            turn1HoverChangedAfterColleagueATyping: boolean | null;
+            /**
+             * @description 入力デバイスの種類
+             * @enum {string}
+             */
+            inputDeviceType: "mouse" | "touch" | "keyboard";
         };
         /**
          * @description 荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物


### PR DESCRIPTION
## 概要
Game 3 新実装（3ターン仕様）に対応する `GroupChatGameData` 型を実装し、旧5ステージ型を置き換えた。
FE 側の `generated.ts` も再生成済み。

## 変更内容
- `backend/src/schemas/games/groupChatGame.ts`
  - 旧 `GroupChatGameStage` / 旧 `GroupChatGameData`（5ステージ）を削除
  - 新 `GroupChatGameTurn` サブスキーマを追加
  - 新 `GroupChatGameData` を再定義
  - `GroupChatGameTurnData` 型を新規 export
- `backend/src/openapi/examples.ts`
  - `submitGameRequestExampleGroupChatGame` を新スキーマに対応したサンプルデータに更新
- `frontend/src/lib/api/generated.ts`
  - `npm run gen:api-types` で再生成
  
## 関連 Issue
closes #138 

## 動作確認
- `POST /api/games/submit` (game_type: 3) で新スキーマのデータが正常に保存されることを curl で確認
- `turns` が2件の場合に `400 invalid_request: Too small: expected array to have >=3 items` が返ることを確認
- 旧スキーマ（`stages` フィールド）を送った場合に `turns: expected array, received undefined` ほか必須フィールドのバリデーションエラーが返ることを確認
- TypeScript コンパイルエラーなし（残存エラーは analysis 層のみ、Task 2 で対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **内部構造の更新**
  * グループチャットゲームのデータ構造を「ステージ単位」から「ターン単位」に変更
  * マウスホバーシーケンス、反応時間、チャット履歴などのインタラクションメトリクスを拡張
  * 入力デバイスタイプ（マウス/タッチ/キーボード）の追跡機能を実装
  * API スキーマと定義を更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->