### PR TITLE
Feat/group chat game analysis

### DIFF
--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -98,10 +98,7 @@ function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResul
 
     // --- 積極性 ---
     const sAnsweredFirst = data.turn1AnsweredBeforeColleagueA === true ? 100 : 0; // null も 0（仕様書 ※注N3）
-    const avgReactionMs = nullAvg(
-        turns.map((t) => t.reactionTimeMs),
-        THRESHOLDS.reactionMs.fallback,
-    );
+    const avgReactionMs = turns.reduce((a, t) => a + t.reactionTimeMs, 0) / turns.length;
     const sReactionMs = linearInv(avgReactionMs, THRESHOLDS.reactionMs.best, THRESHOLDS.reactionMs.worst);
     const avgFirstHoverMs = nullAvg(
         turns.map((t) => t.firstHoverElapsedMs),
@@ -134,7 +131,7 @@ function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResul
     const avgMouseDist =
         data.inputDeviceType !== 'mouse'
             ? 50
-            : turns.reduce((a, t) => a + t.mouseMovementDistance, 0) / 3;
+            : turns.reduce((a, t) => a + t.mouseMovementDistance, 0) / turns.length;
     const sMouseDist = logNorm(avgMouseDist, THRESHOLDS.mouseMovementDist.lo, THRESHOLDS.mouseMovementDist.hi);
 
     const totalHoverSeqLen = turns.reduce((a, t) => a + t.hoverSequence.length, 0);
@@ -145,9 +142,9 @@ function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResul
 
     const sTutorial = logNorm(data.tutorialViewTime ?? 0, THRESHOLDS.tutorialViewTime.lo, THRESHOLDS.tutorialViewTime.hi);
 
-    const reactionMean = turns.reduce((a, t) => a + t.reactionTimeMs, 0) / 3;
+    const reactionMean = turns.reduce((a, t) => a + t.reactionTimeMs, 0) / turns.length;
     const reactionStdDev = Math.sqrt(
-        turns.reduce((a, t) => a + (t.reactionTimeMs - reactionMean) ** 2, 0) / 3,
+        turns.reduce((a, t) => a + (t.reactionTimeMs - reactionMean) ** 2, 0) / turns.length,
     );
     const sStdDev = linearInv(reactionStdDev, THRESHOLDS.reactionStdDev.best, THRESHOLDS.reactionStdDev.worst);
 
@@ -178,10 +175,7 @@ function buildSummary(data: GroupChatGameData | undefined): string {
     const turns = data.turns;
     const conformRate =
         turns.filter((t) => t.selectedOptionId === 1 || t.selectedOptionId === 2).length / 3;
-    const avgReactionMs =
-        turns.length > 0
-            ? turns.reduce((sum, t) => sum + t.reactionTimeMs, 0) / turns.length
-            : THRESHOLDS.reactionMs.fallback;
+    const avgReactionMs = turns.reduce((sum, t) => sum + t.reactionTimeMs, 0) / turns.length;
 
     const socialText =
         conformRate >= 0.67

--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -77,8 +77,9 @@ function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResul
     };
 
     // --- 協調性 ---
+    // タイムアウトしたターンは「選択していない」ため同調にカウントしない（分母は 3 固定 = 非同調扱い）。
     const conformRate = turns.filter(
-        (t) => t.selectedOptionId === 1 || t.selectedOptionId === 2,
+        (t) => !t.isTimeout && (t.selectedOptionId === 1 || t.selectedOptionId === 2),
     ).length / 3;
     const sConformRate = linear(conformRate, 0, 1);
     const sTypingReact = logNorm(
@@ -127,12 +128,17 @@ function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResul
     );
     const sDecisionConf = logNorm(avgDecisionConf, THRESHOLDS.decisionConfidenceMs.lo, THRESHOLDS.decisionConfidenceMs.hi);
 
-    // inputDeviceType が mouse 以外のときはマウス移動距離を中立値 50 に固定（仕様書 ※注N6）
-    const avgMouseDist =
+    // inputDeviceType が mouse 以外のときはマウス移動距離が無意味なため、
+    // 正規化後スコアを中立値 50 に固定する（仕様書 ※注N6）。
+    // raw 50 を logNorm(lo=100, ...) に渡すと下限クランプで 0 点になり中立にならないため、ここで直接 50 を入れる。
+    const sMouseDist =
         data.inputDeviceType !== 'mouse'
             ? 50
-            : turns.reduce((a, t) => a + t.mouseMovementDistance, 0) / turns.length;
-    const sMouseDist = logNorm(avgMouseDist, THRESHOLDS.mouseMovementDist.lo, THRESHOLDS.mouseMovementDist.hi);
+            : logNorm(
+                  turns.reduce((a, t) => a + t.mouseMovementDistance, 0) / turns.length,
+                  THRESHOLDS.mouseMovementDist.lo,
+                  THRESHOLDS.mouseMovementDist.hi,
+              );
 
     const totalHoverSeqLen = turns.reduce((a, t) => a + t.hoverSequence.length, 0);
     const sHoverSeq = linear(totalHoverSeqLen, THRESHOLDS.hoverSeqLength.lo, THRESHOLDS.hoverSeqLength.hi);
@@ -174,7 +180,8 @@ function buildSummary(data: GroupChatGameData | undefined): string {
 
     const turns = data.turns;
     const conformRate =
-        turns.filter((t) => t.selectedOptionId === 1 || t.selectedOptionId === 2).length / 3;
+        turns.filter((t) => !t.isTimeout && (t.selectedOptionId === 1 || t.selectedOptionId === 2))
+            .length / 3;
     const avgReactionMs = turns.reduce((sum, t) => sum + t.reactionTimeMs, 0) / turns.length;
 
     const socialText =

--- a/backend/src/analysis/games/groupChatGame.ts
+++ b/backend/src/analysis/games/groupChatGame.ts
@@ -5,156 +5,235 @@ import { linear, linearInv, logNorm } from '../scoreUtils';
 /**
  * 空気読みグループチャット（group_chat_game）の分析モジュール。
  *
- * Issue #100 で `scoreCalculator.ts` 側にあった analyze ロジックと
- * 旧 `phaseSummaryBuilder.ts` の Phase 3 テキスト生成ロジックを 1 ファイルに凝集。
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` 内の group_chat_game 要素も
- * `buildDetails` として本ファイルに移管。
+ * 3 ターン実装（Task 2）として旧 5 ステージ版を全面置き換え。
+ * 評価軸: 協調性・積極性・慎重さ
  */
 
 /**
- * `analyze()` の戻り値型（Issue #102 で 2 階層構造に変更）。
- * 詳細は `termsGame.ts` の `TermsGameAnalyzeResult` コメント参照。
+ * 分析で使う閾値定数。
+ * 値は仕様書「閾値の根拠 Game 3」の初期値。
+ */
+const THRESHOLDS = {
+    typingReact:           { lo: 0,    hi: 5000  },
+    reactionMs:            { best: 1000, worst: 8000, fallback: 8000 },
+    firstHoverMs:          { best: 500,  worst: 5000, fallback: 5000 },
+    timeoutRate:           { best: 0,    worst: 1                    },
+    finalChoiceHoverOrder: { lo: 1,    hi: 4,    fallback: 2.5       },
+    decisionConfidenceMs:  { lo: 0,    hi: 2000, fallback: 0         },
+    mouseMovementDist:     { lo: 100,  hi: 3000, fallback: 50        },
+    hoverSeqLength:        { lo: 0,    hi: 15                        },
+    scrollCount:           { lo: 0,    hi: 5                         },
+    tutorialViewTime:      { lo: 2000, hi: 30000                     },
+    reactionStdDev:        { best: 500, worst: 5000                  },
+} as const;
+
+/**
+ * 各軸スコアの重み定数。
+ * 合計が 1.0 になるよう維持すること。
+ */
+const WEIGHTS = {
+    cooperativeness: { conformRate: 0.50, typingReact: 0.30, hoverChanged: 0.20 },
+    positivity:      { answeredFirst: 0.40, reactionMs: 0.30, firstHoverMs: 0.20, timeoutRate: 0.10 },
+    caution: {
+        finalChoiceHoverOrder: 0.15,
+        decisionConfidenceMs:  0.15,
+        mouseMovementDist:     0.15,
+        hoverSeqLength:        0.15,
+        scrollCount:           0.10,
+        tutorialViewTime:      0.10,
+        reactionStdDev:        0.20,
+    },
+} as const;
+
+/**
+ * `analyze()` の戻り値型。
+ * `conformRate` / `avgReactionMs` / `timeoutRate` は buildDetails / buildSummary でも参照する。
  */
 export type GroupChatGameAnalyzeResult = {
     scores: { cooperativeness: number; positivity: number; caution: number };
-    conformCount: number;
-    avgReact: number;
+    conformRate: number;
+    avgReactionMs: number;
+    timeoutRate: number;
 };
 
 /**
  * 空気読みグループチャットの行動データ → 協調性・積極性・慎重さの中間集計。
- *
- * 評価軸:
- * - 協調性(cooperativeness): 同調率・譲り待機・本音葛藤
- * - 積極性(positivity): 即応性
- * - 慎重さ(caution): チュートリアル確認・反応安定
  */
 function analyze(data: GroupChatGameData | undefined): GroupChatGameAnalyzeResult {
-    // 早期 return は通常 return と同じ shape を返す（buildDetails 側で欠損プロパティに
-    // アクセスして undefined がレスポンスに漏れるのを防ぐため）
     if (!data)
         return {
             scores: { cooperativeness: 50, positivity: 50, caution: 50 },
-            conformCount: 0,
-            avgReact: 0,
+            conformRate: 0,
+            avgReactionMs: THRESHOLDS.reactionMs.fallback,
+            timeoutRate: 0,
         };
 
-    const stages = data.stages || [];
+    const turns = data.turns;
 
-    const conformCount = stages.filter(
-        (s) => s.selectedOptionId === 1 || s.selectedOptionId === 2,
-    ).length;
+    // null を除外した平均。全 null の場合は fallback を返す。
+    const nullAvg = (vals: (number | null)[], fallback: number): number => {
+        const filtered = vals.filter((v): v is number => v !== null);
+        return filtered.length === 0 ? fallback : filtered.reduce((a, b) => a + b, 0) / filtered.length;
+    };
 
-    const conformRate = conformCount / (stages.length || 1);
+    // --- 協調性 ---
+    const conformRate = turns.filter(
+        (t) => t.selectedOptionId === 1 || t.selectedOptionId === 2,
+    ).length / 3;
+    const sConformRate = linear(conformRate, 0, 1);
+    const sTypingReact = logNorm(
+        data.turn1TypingIndicatorReactTimeMs ?? 0,
+        THRESHOLDS.typingReact.lo,
+        THRESHOLDS.typingReact.hi,
+    );
+    const sHoverChanged =
+        data.turn1HoverChangedAfterColleagueATyping === true  ? 100
+        : data.turn1HoverChangedAfterColleagueATyping === false ? 0
+        : 50; // null = 中立（仕様書 ※注N2）
+    const cooperativeness = Math.round(
+        sConformRate  * WEIGHTS.cooperativeness.conformRate
+        + sTypingReact  * WEIGHTS.cooperativeness.typingReact
+        + sHoverChanged * WEIGHTS.cooperativeness.hoverChanged,
+    );
 
-    const avgReact =
-        stages.reduce((a, s) => a + (s.reactionTimeMs ?? 0), 0) / (stages.length || 1);
+    // --- 積極性 ---
+    const sAnsweredFirst = data.turn1AnsweredBeforeColleagueA === true ? 100 : 0; // null も 0（仕様書 ※注N3）
+    const avgReactionMs = nullAvg(
+        turns.map((t) => t.reactionTimeMs),
+        THRESHOLDS.reactionMs.fallback,
+    );
+    const sReactionMs = linearInv(avgReactionMs, THRESHOLDS.reactionMs.best, THRESHOLDS.reactionMs.worst);
+    const avgFirstHoverMs = nullAvg(
+        turns.map((t) => t.firstHoverElapsedMs),
+        THRESHOLDS.firstHoverMs.fallback,
+    );
+    const sFirstHoverMs = linearInv(avgFirstHoverMs, THRESHOLDS.firstHoverMs.best, THRESHOLDS.firstHoverMs.worst);
+    const timeoutRate = turns.filter((t) => t.isTimeout).length / 3;
+    const sTimeoutRate = linearInv(timeoutRate, THRESHOLDS.timeoutRate.best, THRESHOLDS.timeoutRate.worst);
+    const positivity = Math.round(
+        sAnsweredFirst * WEIGHTS.positivity.answeredFirst
+        + sReactionMs   * WEIGHTS.positivity.reactionMs
+        + sFirstHoverMs * WEIGHTS.positivity.firstHoverMs
+        + sTimeoutRate  * WEIGHTS.positivity.timeoutRate,
+    );
 
-    const reactionVariance =
-        stages.reduce((a, s) => a + Math.pow((s.reactionTimeMs ?? 0) - avgReact, 2), 0) /
-        (stages.length || 1);
+    // --- 慎重さ ---
+    const avgFinalChoice = nullAvg(
+        turns.map((t) => t.finalChoiceHoverOrder),
+        THRESHOLDS.finalChoiceHoverOrder.fallback,
+    );
+    const sFinalChoice = linear(avgFinalChoice, THRESHOLDS.finalChoiceHoverOrder.lo, THRESHOLDS.finalChoiceHoverOrder.hi);
 
-    //協調性: 同調率・譲り待機・本音葛藤
-    const sConform = linear(conformRate, 0, 1);
-    const sWait = logNorm(data.typingIndicatorReactTimeMs ?? 0, 0, 5000);
+    const avgDecisionConf = nullAvg(
+        turns.map((t) => t.decisionConfidenceMs),
+        THRESHOLDS.decisionConfidenceMs.fallback,
+    );
+    const sDecisionConf = logNorm(avgDecisionConf, THRESHOLDS.decisionConfidenceMs.lo, THRESHOLDS.decisionConfidenceMs.hi);
 
-    const hoverCount = data.hoveredOptions ?? 0;
+    // inputDeviceType が mouse 以外のときはマウス移動距離を中立値 50 に固定（仕様書 ※注N6）
+    const avgMouseDist =
+        data.inputDeviceType !== 'mouse'
+            ? 50
+            : turns.reduce((a, t) => a + t.mouseMovementDistance, 0) / 3;
+    const sMouseDist = logNorm(avgMouseDist, THRESHOLDS.mouseMovementDist.lo, THRESHOLDS.mouseMovementDist.hi);
 
-    const sHover = linear(hoverCount, 0, 5);
+    const totalHoverSeqLen = turns.reduce((a, t) => a + t.hoverSequence.length, 0);
+    const sHoverSeq = linear(totalHoverSeqLen, THRESHOLDS.hoverSeqLength.lo, THRESHOLDS.hoverSeqLength.hi);
 
-    const cooperativeness = Math.round(sConform * 0.5 + sWait * 0.3 + sHover * 0.2);
+    const totalScrollCount = turns.reduce((a, t) => a + t.scrolledChatHistoryCount, 0);
+    const sScrollCount = linear(totalScrollCount, THRESHOLDS.scrollCount.lo, THRESHOLDS.scrollCount.hi);
 
-    //積極性: 即応性
-    const positivity = Math.round(linearInv(avgReact, 1000, 8000));
+    const sTutorial = logNorm(data.tutorialViewTime ?? 0, THRESHOLDS.tutorialViewTime.lo, THRESHOLDS.tutorialViewTime.hi);
 
-    //慎重さ: チュートリアル確認・反応安定
-    const sTutorial = logNorm(data.tutorialViewTime ?? 0, 1000, 15000);
-    const sVariance = linearInv(reactionVariance, 500, 5000);
+    const reactionMean = turns.reduce((a, t) => a + t.reactionTimeMs, 0) / 3;
+    const reactionStdDev = Math.sqrt(
+        turns.reduce((a, t) => a + (t.reactionTimeMs - reactionMean) ** 2, 0) / 3,
+    );
+    const sStdDev = linearInv(reactionStdDev, THRESHOLDS.reactionStdDev.best, THRESHOLDS.reactionStdDev.worst);
 
-    const caution = Math.round(sTutorial * 0.5 + sVariance * 0.5);
+    const caution = Math.round(
+        sFinalChoice   * WEIGHTS.caution.finalChoiceHoverOrder
+        + sDecisionConf  * WEIGHTS.caution.decisionConfidenceMs
+        + sMouseDist     * WEIGHTS.caution.mouseMovementDist
+        + sHoverSeq      * WEIGHTS.caution.hoverSeqLength
+        + sScrollCount   * WEIGHTS.caution.scrollCount
+        + sTutorial      * WEIGHTS.caution.tutorialViewTime
+        + sStdDev        * WEIGHTS.caution.reactionStdDev,
+    );
 
     return {
         scores: { cooperativeness, positivity, caution },
-        conformCount,
-        avgReact,
+        conformRate,
+        avgReactionMs,
+        timeoutRate,
     };
 }
 
 /**
  * 空気読みグループチャットの行動データ → 結果画面に表示するサマリーテキスト。
- *
- * 例: 「グループの空気を敏感に察知して周りに合わせ、即決でアクションを起こしました。」
  */
 function buildSummary(data: GroupChatGameData | undefined): string {
     if (!data) return 'データなし';
 
-    const stages = data.stages || [];
-
-    // 多数派（仮に選択肢1と2を多数派とする）を選んだ回数で同調率を算出
-    const conformCount = stages.filter(
-        (s) => s.selectedOptionId === 1 || s.selectedOptionId === 2,
-    ).length;
-    const conformRate = (conformCount / (stages.length || 1)) * 100;
+    const turns = data.turns;
+    const conformRate =
+        turns.filter((t) => t.selectedOptionId === 1 || t.selectedOptionId === 2).length / 3;
+    const avgReactionMs =
+        turns.length > 0
+            ? turns.reduce((sum, t) => sum + t.reactionTimeMs, 0) / turns.length
+            : THRESHOLDS.reactionMs.fallback;
 
     const socialText =
-        conformRate >= 60
-            ? 'グループの空気を敏感に察知して周りに合わせ'
-            : '周りに流されず我が道をゆく選択肢を取り';
-
-    // 平均反応速度から速度感を表現する。
-    // Phase 3 の reactionTimeMs は仕様上 null が来ない（タイムアウト時も実時間 ≈ 10000ms で記録される）。
-    // 防御的に `?? 2000`（中立値）でフォールバックし、stages 0 件のときも 2000ms を使う。
-    const avgReaction =
-        stages.length > 0
-            ? stages.reduce((sum, s) => sum + (s.reactionTimeMs ?? 2000), 0) / stages.length
-            : 2000;
+        conformRate >= 0.67
+            ? '周りの空気を読んで行動し'
+            : '自分の判断を優先し';
     const speedText =
-        avgReaction < 2000 ? '即決でアクションを起こしました。' : '慎重にタイミングを伺いました。';
+        avgReactionMs < 3000
+            ? '素早く決断しました。'
+            : '慎重に考えてから選択しました。';
 
     return `${socialText}、${speedText}`;
 }
 
 /**
  * 空気読みグループチャットの行動データ + analyze 結果 → 結果画面 details 用の構造体。
- * Issue #102 で旧 `scoreCalculator.ts` の `details: [...]` の group_chat_game 要素を移管。挙動は完全同一。
  */
 function buildDetails(
     data: GroupChatGameData | undefined,
     result: GroupChatGameAnalyzeResult,
 ): GameDetail {
-    // 同調率は「conformCount（analyze 結果側）」を「stages 件数（data 側）」で割って算出する。
-    // 旧構造から本ファイルへ移管する際もこの参照関係を維持している（挙動は完全同一）。
     return {
         game_id: groupChatGameModule.id,
         title: groupChatGameModule.title,
         feature_scores: [
             { axis: 'cooperativeness', name: '協調性', score: result.scores.cooperativeness },
-            { axis: 'positivity', name: '積極性', score: result.scores.positivity },
+            { axis: 'positivity',      name: '積極性', score: result.scores.positivity },
+            { axis: 'caution',         name: '慎重さ', score: result.scores.caution },
         ],
         metrics: [
             {
                 label: '同調率(%)',
-                user: Math.round(((result.conformCount ?? 0) / (data?.stages?.length || 1)) * 100),
-                average: 75,
+                user: Math.round(result.conformRate * 100),
+                average: 67,
                 category: 'social',
             },
             {
-                label: '反応潜時(ms)',
-                user: Math.round(result.avgReact ?? 0),
+                label: '反応時間平均(ms)',
+                user: Math.round(result.avgReactionMs),
                 average: 3500,
                 category: 'time',
             },
             {
-                label: '本音ホバー(回)',
-                user: data?.hoveredOptions ?? 0,
-                average: 2.4,
-                category: 'mouse',
+                label: 'タイムアウト率(%)',
+                user: Math.round(result.timeoutRate * 100),
+                average: 10,
+                category: 'input',
             },
             {
-                label: '譲り合い待機(ms)',
-                user: data?.typingIndicatorReactTimeMs ?? 0,
-                average: 2000,
-                category: 'time',
+                label: '先回り回答',
+                user: data?.turn1AnsweredBeforeColleagueA === true ? 1 : 0,
+                average: 0.5,
+                category: 'social',
             },
         ],
     };

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -200,30 +200,56 @@ export const submitGameRequestExampleHelpdeskGame = {
 /**
  * game_type = 3（グループチャット）の data サンプル。
  *
- * 仕様書「データ構造」→ GroupChatGameData を参照。stages は 5 ステージのうち代表 2 件を載せ、
- * `selectedOptionId: 0` でタイムアウト例も含める（仕様書準拠）。
+ * 仕様書「データ構造」→ GroupChatGameData を参照。3 ターン固定。
+ * ターン 2 でタイムアウト例を含める（仕様書準拠）。
  */
 export const submitGameRequestExampleGroupChatGame = {
     user_id: SAMPLE_USER_ID,
     game_type: 3,
     data: {
         tutorialViewTime: 8500,
-        hoveredOptions: 7,
-        typingIndicatorReactTimeMs: 1450,
-        stages: [
+        turns: [
             {
-                stageId: 1,
+                turnId: 1,
                 selectedOptionId: 2,
                 reactionTimeMs: 3200,
                 isTimeout: false,
+                firstHoverElapsedMs: 800,
+                finalChoiceHoverOrder: 2,
+                decisionConfidenceMs: 1200,
+                mouseMovementDistance: 345,
+                hoverSequence: [1, 3, 2],
+                scrolledChatHistoryCount: 0,
             },
             {
-                stageId: 2,
-                selectedOptionId: 0,
+                turnId: 2,
+                selectedOptionId: 1,
                 reactionTimeMs: 10000,
                 isTimeout: true,
+                firstHoverElapsedMs: null,
+                finalChoiceHoverOrder: null,
+                decisionConfidenceMs: null,
+                mouseMovementDistance: 0,
+                hoverSequence: [],
+                scrolledChatHistoryCount: 1,
+            },
+            {
+                turnId: 3,
+                selectedOptionId: 3,
+                reactionTimeMs: 2500,
+                isTimeout: false,
+                firstHoverElapsedMs: 600,
+                finalChoiceHoverOrder: 1,
+                decisionConfidenceMs: 900,
+                mouseMovementDistance: 210,
+                hoverSequence: [3],
+                scrolledChatHistoryCount: 0,
             },
         ],
+        turn1AnsweredBeforeColleagueA: true,
+        turn1TypingIndicatorReactTimeMs: 1450,
+        turn1HoverChangedAfterColleagueATyping: true,
+        inputDeviceType: 'mouse',
     },
 } as const;
 

--- a/backend/src/openapi/examples.ts
+++ b/backend/src/openapi/examples.ts
@@ -223,7 +223,7 @@ export const submitGameRequestExampleGroupChatGame = {
             },
             {
                 turnId: 2,
-                selectedOptionId: 1,
+                selectedOptionId: 0,
                 reactionTimeMs: 10000,
                 isTimeout: true,
                 firstHoverElapsedMs: null,

--- a/backend/src/schemas/games/groupChatGame.ts
+++ b/backend/src/schemas/games/groupChatGame.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { registry } from '../../openapi/registry';
 
 /**
- * 空気読みグループチャット（group_chat_game / 旧 Game 3）の行動データ（raw_data）の zod スキーマ群。
+ * 空気読みグループチャット（group_chat_game / game_type=3）の行動データ（raw_data）の zod スキーマ群。
  *
  * 設計方針:
  * - 仕様書「データ構造」を一次情報として、TS と zod の二重管理を避けるため
@@ -13,61 +13,91 @@ import { registry } from '../../openapi/registry';
  * - 本ファイルのスキーマは `submitGameRequestSchema`（schemas/games.ts）の
  *   `data` フィールド（discriminatedUnion の各 branch）として API 入出力に出るため、
  *   `.openapi()` でメタデータを付与し `registry.register()` で名前付きコンポーネント化する
- *   （Issue #58 で OpenAPI に公開し、FE の生成型に取り込まれるようにした）
  * - 内部サブスキーマも独立コンポーネント化することで、OpenAPI ドキュメント上の重複を避け
  *   FE 生成型でも再利用可能な型として扱えるようにする
  */
 
 /**
- * 空気読みグループチャットの 1 ステージ分のメトリクス。
+ * 空気読みグループチャットの 1 ターン分のメトリクス。
  *
- * `selectedOptionId`: 1-4 が通常選択、タイムアウト時は 0（仕様書準拠）。
+ * `turnId` は 1-3 の固定リテラル union。
+ * `selectedOptionId`: 1-4 の内部設計上の意図 ID（表示順とは独立）。
  * 意味的に整数のフィールドには `.int()` を付けて型レベルで小数を弾く。
- * `min/max` 等の値の範囲制約は本スキーマでは表現せず、analysis 層で個別に扱う。
  */
-const groupChatGameStageSchema = registry.register(
-    'GroupChatGameStage',
+const groupChatGameTurnSchema = registry.register(
+    'GroupChatGameTurn',
     z
         .object({
-            stageId: z.number().int().openapi({
-                description: 'ステージ ID（1-5）',
+            turnId: z.union([z.literal(1), z.literal(2), z.literal(3)]).openapi({
+                description: 'ターン ID（1-3 固定）',
             }),
             selectedOptionId: z.number().int().openapi({
-                description: '選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0）',
+                description: '選択した選択肢 ID（1-4 の内部設計上の意図 ID。表示順と独立）',
             }),
             reactionTimeMs: z.number().openapi({
-                description: 'ステージ表示から選択までの反応時間（ms）',
+                description: '選択肢提示 → 選択までの反応時間（ms）',
             }),
             isTimeout: z.boolean().openapi({
                 description: 'タイムアウトしたか',
             }),
+            firstHoverElapsedMs: z.number().nullable().openapi({
+                description: '選択肢表示 → 初ホバーまでの経過時間（ms）。ホバーなしの場合は null',
+            }),
+            finalChoiceHoverOrder: z.number().int().nullable().openapi({
+                description:
+                    '最終選択した選択肢が何番目にホバーされたか（1-4）。ホバーなしの場合は null',
+            }),
+            decisionConfidenceMs: z.number().nullable().openapi({
+                description:
+                    '最終クリック直前の最後のホバー時間（ms）。ホバーなしの場合は null',
+            }),
+            mouseMovementDistance: z.number().openapi({
+                description: '選択肢表示 → 決定までのマウス総移動距離（px）',
+            }),
+            hoverSequence: z.array(z.number().int()).openapi({
+                description:
+                    'ホバーした選択肢 ID の順番（上限 10 件。超過分は切り捨て）',
+            }),
+            scrolledChatHistoryCount: z.number().int().openapi({
+                description: 'チャット履歴を遡るスクロールの回数',
+            }),
         })
         .openapi({
-            description: '空気読みグループチャットの 1 ステージ分のメトリクス',
+            description: '空気読みグループチャットの 1 ターン分のメトリクス',
         }),
 );
 
 /**
  * GroupChatGameData（空気読みグループチャット）。
  *
- * `typingIndicatorReactTimeMs` はステージ 3 / 5 のみで計測される値のため `nullable`。
+ * `turns` は要素数 3 固定の配列。
+ * `turn1AnsweredBeforeColleagueA` / `turn1TypingIndicatorReactTimeMs` /
+ * `turn1HoverChangedAfterColleagueATyping` はターン 1 固有の計測値のため `nullable`。
  */
 export const groupChatGameDataSchema = registry.register(
     'GroupChatGameData',
     z
         .object({
             tutorialViewTime: z.number().openapi({
-                description: 'チュートリアル閲覧時間（ms）',
+                description: 'オンボーディング滞在時間（スライド 1 + 2 合計、ms）',
             }),
-            hoveredOptions: z.number().int().openapi({
-                description: '全ステージ通じた選択肢ホバー回数の合計',
+            turns: z.array(groupChatGameTurnSchema).length(3).openapi({
+                description: '各ターンのメトリクス（要素数 3 固定）',
             }),
-            typingIndicatorReactTimeMs: z.number().nullable().openapi({
+            turn1AnsweredBeforeColleagueA: z.boolean().nullable().openapi({
                 description:
-                    'ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null',
+                    'ターン 1 でプレイヤーが同僚 A より先に回答したか。true=先回り / false=譲った / null=タイムアウト',
             }),
-            stages: z.array(groupChatGameStageSchema).openapi({
-                description: '各ステージのメトリクス',
+            turn1TypingIndicatorReactTimeMs: z.number().nullable().openapi({
+                description:
+                    'ターン 1 で同僚 A の「入力中」表示 → プレイヤー操作までの時間（ms）。未計測時は null',
+            }),
+            turn1HoverChangedAfterColleagueATyping: z.boolean().nullable().openapi({
+                description:
+                    'ターン 1 で同僚 A の「入力中」表示後にホバー先が変わったか。未計測時は null',
+            }),
+            inputDeviceType: z.enum(['mouse', 'touch', 'keyboard']).openapi({
+                description: '入力デバイスの種類',
             }),
         })
         .openapi({
@@ -76,4 +106,5 @@ export const groupChatGameDataSchema = registry.register(
         }),
 );
 
+export type GroupChatGameTurnData = z.infer<typeof groupChatGameTurnSchema>;
 export type GroupChatGameData = z.infer<typeof groupChatGameDataSchema>;

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -1,10 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type {
-  GroupChatGameData,
-  GroupChatGameStage,
-} from '@/features/games/types';
+import type { GroupChatGameData } from '@/features/games/types';
 import {
   BOTS,
   STAGES,
@@ -64,6 +61,19 @@ export type ChatMessage =
   | SeparatorTimelineMessage;
 
 /**
+ * 旧5ステージ仕様の1ステージ分の操作ログ。
+ * 以前は generated.ts の GroupChatGameStage を参照していたが、新3ターン仕様で
+ * 同型が廃止されたためローカルに退避している。
+ * TODO(#140 / #141): 新3ターン仕様の収集ロジックに作り直す際に削除する。
+ */
+interface LegacyStageResult {
+  stageId: number;
+  selectedOptionId: number;
+  reactionTimeMs: number;
+  isTimeout: boolean;
+}
+
+/**
  * 空気読みグループチャット（group_chat_game）全体のステート管理フック。
  *
  * 以下のフローを制御する:
@@ -103,7 +113,7 @@ export function useGroupChatGame(options: {
   /** ステージ3の「○○が返信中」表示〜ユーザー操作までの時間(ms) */
   const stage3TypingReactRef = useRef<number | null>(null);
   /** 各ステージの操作ログを蓄積 */
-  const stageResultsRef = useRef<GroupChatGameStage[]>([]);
+  const stageResultsRef = useRef<LegacyStageResult[]>([]);
   const tutorialViewTimeRef = useRef(0);
   const timerIdRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -139,7 +149,7 @@ export function useGroupChatGame(options: {
       typingIndicatorReactTimeMs?: number | null
     ) => {
       const stage = STAGES[currentStageIndex];
-      const log: GroupChatGameStage = {
+      const log: LegacyStageResult = {
         stageId: stage.stageId,
         selectedOptionId,
         reactionTimeMs,
@@ -382,11 +392,30 @@ export function useGroupChatGame(options: {
     if (gamePhase !== 'submitting' || submittedRef.current) return;
     submittedRef.current = true;
 
+    // TODO(#140 / #141): 新3ターン仕様の収集ロジックに置き換える。
+    // 現状は旧5ステージ仕様で集めたデータを新型 GroupChatGameData の形に
+    // 暫定マッピングして型を満たしているだけ（収集値の意味的な正しさは未対応）。
     const groupChatGameData: GroupChatGameData = {
       tutorialViewTime: tutorialViewTimeRef.current,
-      stages: [...stageResultsRef.current],
-      hoveredOptions: totalHoveredOptionsRef.current,
-      typingIndicatorReactTimeMs: stage3TypingReactRef.current,
+      turns: ([1, 2, 3] as const).map((turnId) => {
+        const stage = stageResultsRef.current[turnId - 1];
+        return {
+          turnId,
+          selectedOptionId: stage?.selectedOptionId ?? 0,
+          reactionTimeMs: stage?.reactionTimeMs ?? 0,
+          isTimeout: stage?.isTimeout ?? false,
+          firstHoverElapsedMs: null,
+          finalChoiceHoverOrder: null,
+          decisionConfidenceMs: null,
+          mouseMovementDistance: 0,
+          hoverSequence: [],
+          scrolledChatHistoryCount: 0,
+        };
+      }),
+      turn1AnsweredBeforeColleagueA: null,
+      turn1TypingIndicatorReactTimeMs: stage3TypingReactRef.current,
+      turn1HoverChangedAfterColleagueATyping: null,
+      inputDeviceType: 'mouse',
     };
     onComplete(groupChatGameData);
     const id = setTimeout(() => setGamePhase('completed'), 0);

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -33,5 +33,4 @@ export type VoiceRespondResponse =
 // ========================================
 // 空気読みグループチャット（group_chat_game / 旧 Game 3）
 // ========================================
-export type GroupChatGameStage = components['schemas']['GroupChatGameStage'];
 export type GroupChatGameData = components['schemas']['GroupChatGameData'];

--- a/frontend/src/lib/api/generated.ts
+++ b/frontend/src/lib/api/generated.ts
@@ -561,27 +561,46 @@ export interface components {
             turns: components["schemas"]["HelpdeskGameTurn"][];
             textInputMetrics: components["schemas"]["HelpdeskGameTextInputMetrics"] | null;
         };
-        /** @description 空気読みグループチャットの 1 ステージ分のメトリクス */
-        GroupChatGameStage: {
-            /** @description ステージ ID（1-5） */
-            stageId: number;
-            /** @description 選択した選択肢 ID（1-4 が通常選択、タイムアウト時は 0） */
+        /** @description 空気読みグループチャットの 1 ターン分のメトリクス */
+        GroupChatGameTurn: {
+            /** @description ターン ID（1-3 固定） */
+            turnId: 1 | 2 | 3;
+            /** @description 選択した選択肢 ID（1-4 の内部設計上の意図 ID。表示順と独立） */
             selectedOptionId: number;
-            /** @description ステージ表示から選択までの反応時間（ms） */
+            /** @description 選択肢提示 → 選択までの反応時間（ms） */
             reactionTimeMs: number;
             /** @description タイムアウトしたか */
             isTimeout: boolean;
+            /** @description 選択肢表示 → 初ホバーまでの経過時間（ms）。ホバーなしの場合は null */
+            firstHoverElapsedMs: number | null;
+            /** @description 最終選択した選択肢が何番目にホバーされたか（1-4）。ホバーなしの場合は null */
+            finalChoiceHoverOrder: number | null;
+            /** @description 最終クリック直前の最後のホバー時間（ms）。ホバーなしの場合は null */
+            decisionConfidenceMs: number | null;
+            /** @description 選択肢表示 → 決定までのマウス総移動距離（px） */
+            mouseMovementDistance: number;
+            /** @description ホバーした選択肢 ID の順番（上限 10 件。超過分は切り捨て） */
+            hoverSequence: number[];
+            /** @description チャット履歴を遡るスクロールの回数 */
+            scrolledChatHistoryCount: number;
         };
         /** @description 空気読みグループチャットの行動データ。仕様書「データ構造 → GroupChatGameData」準拠 */
         GroupChatGameData: {
-            /** @description チュートリアル閲覧時間（ms） */
+            /** @description オンボーディング滞在時間（スライド 1 + 2 合計、ms） */
             tutorialViewTime: number;
-            /** @description 全ステージ通じた選択肢ホバー回数の合計 */
-            hoveredOptions: number;
-            /** @description ステージ 3 / 5 で「入力中...」表示後の操作時間（ms）。未計測時は null */
-            typingIndicatorReactTimeMs: number | null;
-            /** @description 各ステージのメトリクス */
-            stages: components["schemas"]["GroupChatGameStage"][];
+            /** @description 各ターンのメトリクス（要素数 3 固定） */
+            turns: components["schemas"]["GroupChatGameTurn"][];
+            /** @description ターン 1 でプレイヤーが同僚 A より先に回答したか。true=先回り / false=譲った / null=タイムアウト */
+            turn1AnsweredBeforeColleagueA: boolean | null;
+            /** @description ターン 1 で同僚 A の「入力中」表示 → プレイヤー操作までの時間（ms）。未計測時は null */
+            turn1TypingIndicatorReactTimeMs: number | null;
+            /** @description ターン 1 で同僚 A の「入力中」表示後にホバー先が変わったか。未計測時は null */
+            turn1HoverChangedAfterColleagueATyping: boolean | null;
+            /**
+             * @description 入力デバイスの種類
+             * @enum {string}
+             */
+            inputDeviceType: "mouse" | "touch" | "keyboard";
         };
         /**
          * @description 荷物の種類。urgent=特急 / fragile=取扱注意 / heavy=重量物


### PR DESCRIPTION
## 概要
Game 3 の新実装（3ターン仕様）に向けて、GroupChatGameData 型の定義（スキーマ層）と
分析モジュール（analysis 層）を旧5ステージ版から新3ターン版に置き換えた。

## 変更内容
**スキーマ層**
- `backend/src/schemas/games/groupChatGame.ts`
  - 旧 `GroupChatGameStage` / 旧 `GroupChatGameData`（5ステージ）を削除
  - 新 `GroupChatGameTurn` サブスキーマを追加（10フィールド）
  - 新 `GroupChatGameData` を再定義（turns 3件固定 / turn1系3フィールド / inputDeviceType）
  - `GroupChatGameTurnData` 型を新規 export
- `backend/src/openapi/examples.ts`
  - `submitGameRequestExampleGroupChatGame` を新スキーマに対応（タイムアウトターン例を含む）
- `frontend/src/lib/api/generated.ts`
  - `npm run gen:api-types` で再生成

**分析層**
- `backend/src/analysis/games/groupChatGame.ts`
  - 旧 `GroupChatGameAnalyzeResult` / 旧 `analyze` / `buildSummary` / `buildDetails` を削除
  - `THRESHOLDS` / `WEIGHTS` 定数を仕様書「閾値の根拠 Game 3」の初期値で定義
  - 協調性: 同調率(0.50) + 譲り合い待機(0.30) + 同調圧力での意思変化(0.20)
  - 積極性: 先回り判定(0.40) + 即断即決(0.30) + 初動の速さ(0.20) + タイムアウト率(0.10)
  - 慎重さ: 7指標の加重和（reactionStdDev を BE 側で派生計算）
  - `inputDeviceType !== 'mouse'` のときマウス移動距離を中立値 50 に固定（仕様書 ※注N6）

## 関連 Issue
closes #138, closes #139

## 動作確認
curl で3ゲーム全送信後に `GET /api/results/:user_id` を実行し確認。
- `POST /api/games/submit` (game_type: 3) で正常保存されることを確認
- turns 2件送信 → `400: Too small: expected array to have >=3 items` を確認
- 旧スキーマ（stages フィールド）送信 → `400: turns: expected array, received undefined` を確認
- スコアを手計算で検証（cooperativeness: 79 / positivity: 91 / caution: 57 が一致）
- `phase_summaries` の文言・`metrics` の値が仕様書の閾値と一致することを確認

## 備考
当初 スキーマ（Task 1）/ 分析（Task 2）の 2 PR に分割する予定でしたが、
スキーマ変更が分析ファイルのコンパイルを壊す依存関係のため CI を通せず、1 PR にまとめました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * グループチャットゲームを3ターン固定のターンベース仕様に移行しました（送信データ・計測項目の更新を含む）。

* **リファクタリング**
  * 分析ロジックを刷新し、複数の観測指標から協調性・積極性・慎重さを算出するように変更しました。
  * データ構造をステージ中心からターン中心へ再構成しました。

* **ドキュメント**
  * サンプル送信例と公開スキーマを新仕様に合わせて更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
