### PR TITLE
feat: グループチャットの取得データ収集ロジックを実装

### DIFF
--- a/frontend/src/features/games/group-chat/components/ChatTimeline.tsx
+++ b/frontend/src/features/games/group-chat/components/ChatTimeline.tsx
@@ -11,7 +11,14 @@ interface ChatTimelineProps {
   messages: ChatMessage[];
   /** 入力中インジケータの話者（非表示時は null） */
   typingSpeaker: Character | null;
+  /** チャット履歴を上方向にスクロールしたとき（1ジェスチャーにつき1回）。履歴遡り計測用 */
+  onHistoryScroll?: () => void;
 }
+
+/** 上方向スクロールと判定する最小移動量（px） */
+const SCROLL_UP_THRESHOLD_PX = 4;
+/** 連続スクロールを1ジェスチャーにまとめるデバウンス（ms） */
+const SCROLL_UP_DEBOUNCE_MS = 300;
 
 /** 「@あなた」を赤＋下線で強調する（T3 上司メッセージ用） */
 function renderText(text: string, hasMention?: boolean): ReactNode {
@@ -33,15 +40,36 @@ function renderText(text: string, hasMention?: boolean): ReactNode {
 export default function ChatTimeline({
   messages,
   typingSpeaker,
+  onHistoryScroll,
 }: ChatTimelineProps) {
   const endRef = useRef<HTMLDivElement>(null);
+  const prevScrollTopRef = useRef(0);
+  const lastScrollUpAtRef = useRef(0);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, typingSpeaker]);
 
+  // 上方向スクロール（履歴遡り）を1ジェスチャー単位で検知する。
+  // 自動スクロール（scrollIntoView）は下方向なので誤カウントしない。
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const scrollTop = e.currentTarget.scrollTop;
+    const prev = prevScrollTopRef.current;
+    prevScrollTopRef.current = scrollTop;
+    if (scrollTop < prev - SCROLL_UP_THRESHOLD_PX) {
+      const now = Date.now();
+      if (now - lastScrollUpAtRef.current > SCROLL_UP_DEBOUNCE_MS) {
+        lastScrollUpAtRef.current = now;
+        onHistoryScroll?.();
+      }
+    }
+  };
+
   return (
-    <div className="flex flex-1 flex-col gap-4 overflow-y-auto bg-[#dae5f3] px-9 py-[26px]">
+    <div
+      className="flex flex-1 flex-col gap-4 overflow-y-auto bg-[#dae5f3] px-9 py-[26px]"
+      onScroll={handleScroll}
+    >
       {messages.map((msg, i) => {
         if (msg.type === 'separator') {
           return (

--- a/frontend/src/features/games/group-chat/components/ChoicePad.tsx
+++ b/frontend/src/features/games/group-chat/components/ChoicePad.tsx
@@ -7,6 +7,8 @@ interface ChoicePadProps {
   remainingTimeMs: number;
   /** 選択時に意図 ID（1-4）を渡す */
   onSelect: (selectedOptionId: OptionIntentId) => void;
+  /** 選択肢にホバーしたとき（意図 ID を渡す）。迷い計測用 */
+  onHover: (selectedOptionId: OptionIntentId) => void;
 }
 
 /** 下部のタイマーバー（黄色固定）+ 2×2 選択肢グリッド。 */
@@ -14,6 +16,7 @@ export default function ChoicePad({
   turn,
   remainingTimeMs,
   onSelect,
+  onHover,
 }: ChoicePadProps) {
   const ratio = Math.max(0, Math.min(1, remainingTimeMs / turn.timerMs));
 
@@ -34,6 +37,7 @@ export default function ChoicePad({
             key={choice.selectedOptionId}
             type="button"
             onClick={() => onSelect(choice.selectedOptionId)}
+            onPointerEnter={() => onHover(choice.selectedOptionId)}
             className="min-h-[56px] rounded-2xl border-[3px] border-black bg-white px-5 py-4 text-left text-[15px] font-bold leading-snug text-black shadow-[3px_3px_0_0_#000] transition-transform hover:-translate-y-1 hover:shadow-[5px_5px_0_0_#000] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-black/40 focus-visible:ring-offset-2"
           >
             {choice.text}

--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -185,6 +185,8 @@ export default function GroupChatGameFlow() {
     typingSpeaker,
     startGame: rawStartGame,
     selectOption: rawSelectOption,
+    handleOptionHover,
+    handleHistoryScroll,
   } = useGroupChatGame({ onComplete: handleComplete });
 
   // SE を鳴らすようにラップ
@@ -227,13 +229,18 @@ export default function GroupChatGameFlow() {
             </span>
           </header>
 
-          <ChatTimeline messages={chatMessages} typingSpeaker={typingSpeaker} />
+          <ChatTimeline
+            messages={chatMessages}
+            typingSpeaker={typingSpeaker}
+            onHistoryScroll={handleHistoryScroll}
+          />
 
           {gamePhase === 'turn-active' && currentTurn ? (
             <ChoicePad
               turn={currentTurn}
               remainingTimeMs={remainingTimeMs}
               onSelect={selectOption}
+              onHover={handleOptionHover}
             />
           ) : (
             <div className="shrink-0 border-t-[6px] border-black bg-[#f1cf44] py-6 text-center text-sm font-bold text-black/60">

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { GroupChatGameData } from '@/features/games/types';
 import {
   CHARACTERS,
@@ -216,7 +222,9 @@ export function useGroupChatGame(options: {
   // 入力デバイス種別を「初回 turn-active 開始後の最初の操作」で確定する。
   // オンボーディング中の Tab / Cmd+R / Esc 等のキー操作で誤確定しないよう、
   // turn-active 中のみリスナーを有効にする（pen / 空文字は 'mouse' に丸める）。
-  useEffect(() => {
+  // 描画完了直後に同期実行する useLayoutEffect で登録し、turn-active 切替直後の
+  // 最初の操作（pointerdown / keydown）を取りこぼさないようにする。
+  useLayoutEffect(() => {
     if (gamePhase !== 'turn-active') return;
     const onPointerDown = (e: PointerEvent) => {
       if (inputDeviceDetectedRef.current) return;
@@ -402,7 +410,10 @@ export function useGroupChatGame(options: {
   // =========================================================
   // turn-active: タイマー稼働 + メッセージ順次表示 + マウス軌跡計測
   // =========================================================
-  useEffect(() => {
+  // useLayoutEffect で描画完了直後に同期実行することで、ユーザーが
+  // ChoicePad のボタンをクリック/ホバーできるようになる前に refs を
+  // 確実に初期化する（reactionTimeMs / firstHoverElapsedMs の起点ズレ防止）。
+  useLayoutEffect(() => {
     if (gamePhase !== 'turn-active') return;
     const turn = TURNS[currentTurnIndex];
     if (!turn) return;
@@ -416,8 +427,11 @@ export function useGroupChatGame(options: {
       t1TypingIndicatorShownAtRef.current = null;
     }
 
-    // マウス総移動距離の計測（turn-active 中のみ）
+    // マウス総移動距離の計測（turn-active 中のみ）。
+    // ターン確定後（recordTurnAndAdvance で turnResolvedRef=true）から
+    // effect cleanup までの pointermove は加算しない（防御的）。
     const onPointerMove = (e: PointerEvent) => {
+      if (turnResolvedRef.current) return;
       const prev = lastPointerPosRef.current;
       if (prev) {
         const dx = e.clientX - prev.x;

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -25,9 +25,12 @@ import type {
 
 /** タイマーの更新間隔（ms） */
 const TIMER_TICK_MS = 100;
+/** hoverSequence の上限件数（超過は切り捨て）。仕様書「データ構造」準拠 */
+const HOVER_SEQUENCE_CAP = 10;
 
-/** OpenAPI 生成型から 1 ターン分の型を取り出す（名前付き型の再エクスポート有無に依存しない） */
+/** OpenAPI 生成型から 1 ターン分 / 入力デバイス種別の型を取り出す */
 type GroupChatGameTurn = GroupChatGameData['turns'][number];
+type InputDeviceType = GroupChatGameData['inputDeviceType'];
 
 /**
  * ゲームの進行状態。
@@ -77,9 +80,8 @@ function toChatBotMessage(m: BotMessage): ChatMessage {
  *   コールバック内で行う（react-hooks/set-state-in-effect 対策）
  * - 一時 timeout は Set で追跡し、ターン遷移・unmount でまとめて解除する
  *
- * 取得データのうちホバー系・マウス移動距離・履歴スクロール・inputDeviceType・
- * turn1HoverChangedAfterColleagueATyping は本 PR（#140）ではデフォルト値で埋め、
- * 実計測は #141 で実装する。
+ * 取得データ（仕様書「データ構造 → GroupChatGameData」準拠）はホバー・マウス軌跡・
+ * 履歴スクロール・入力デバイスを含めすべて実計測する。
  */
 export function useGroupChatGame(options: {
   onComplete: (data: GroupChatGameData) => void;
@@ -107,7 +109,7 @@ export function useGroupChatGame(options: {
   // =========================================================
   const onboardingOpenedAtRef = useRef(0);
   const tutorialViewTimeRef = useRef(0);
-  /** turn-active 開始時刻（reactionTimeMs の起点） */
+  /** turn-active 開始時刻（reactionTimeMs / firstHoverElapsedMs の起点） */
   const optionsShownAtRef = useRef(0);
   /** ターン1「入力中」表示時刻（未表示は null） */
   const t1TypingIndicatorShownAtRef = useRef<number | null>(null);
@@ -117,6 +119,37 @@ export function useGroupChatGame(options: {
   const turn1AnsweredBeforeColleagueARef = useRef<boolean | null>(null);
   /** ターン1:「入力中」表示 → 操作までの ms（未計測は null） */
   const turn1TypingIndicatorReactTimeMsRef = useRef<number | null>(null);
+  /** ターン1:「入力中」表示の前後でホバー先が変わったか（null=ホバーなし/表示前に確定） */
+  const turn1HoverChangedAfterColleagueATypingRef = useRef<boolean | null>(
+    null
+  );
+
+  // --- 現ターンのホバー / マウス / スクロール計測（turn-active 開始時にリセット）---
+  /** 選択肢表示 → 初ホバーまでの時刻（未ホバーは null） */
+  const firstHoverAtRef = useRef<number | null>(null);
+  /** ホバーした選択肢 ID の順番（上限 HOVER_SEQUENCE_CAP） */
+  const hoverSequenceRef = useRef<number[]>([]);
+  /** distinct な初ホバー順（finalChoiceHoverOrder 算出用） */
+  const distinctHoverOrderRef = useRef<OptionIntentId[]>([]);
+  /** 直近にホバーした選択肢 ID（連続重複の除外 + 現在ホバー） */
+  const lastHoverChoiceRef = useRef<OptionIntentId | null>(null);
+  /** 直近ホバー開始時刻（decisionConfidenceMs 算出用） */
+  const lastHoverEnterAtRef = useRef<number | null>(null);
+  /** 選択肢表示 → 決定までのマウス総移動距離（px） */
+  const mouseDistanceRef = useRef(0);
+  /** 直近の pointer 座標（移動距離の差分計算用） */
+  const lastPointerPosRef = useRef<{ x: number; y: number } | null>(null);
+  /** チャット履歴を遡るスクロール回数 */
+  const scrollUpCountRef = useRef(0);
+  /** ターン1で「入力中」表示が出たか（hover変化判定の起点フラグ） */
+  const typingShownForHoverRef = useRef(false);
+  /** ターン1「入力中」表示時点でホバーしていた選択肢 ID（未ホバーは null） */
+  const hoverChoiceAtTypingRef = useRef<OptionIntentId | null>(null);
+
+  /** 入力デバイス種別（初回操作で確定） */
+  const inputDeviceTypeRef = useRef<InputDeviceType>('mouse');
+  const inputDeviceDetectedRef = useRef(false);
+
   /** 各ターンの結果ログ */
   const turnResultsRef = useRef<GroupChatGameTurn[]>([]);
   /** 現ターンが選択 or タイムアウトで確定済みか（二重確定防止） */
@@ -144,6 +177,32 @@ export function useGroupChatGame(options: {
     pendingTimeoutsRef.current.clear();
   }, []);
 
+  /** 現ターンのホバー / マウス / スクロール計測をリセット */
+  const resetTurnMetrics = useCallback(() => {
+    firstHoverAtRef.current = null;
+    hoverSequenceRef.current = [];
+    distinctHoverOrderRef.current = [];
+    lastHoverChoiceRef.current = null;
+    lastHoverEnterAtRef.current = null;
+    mouseDistanceRef.current = 0;
+    lastPointerPosRef.current = null;
+    scrollUpCountRef.current = 0;
+    typingShownForHoverRef.current = false;
+    hoverChoiceAtTypingRef.current = null;
+  }, []);
+
+  /**
+   * ターン1「入力中」表示の前後でホバー先が変わったかを判定する。
+   * - 入力中表示が出る前に確定 → null
+   * - ターン中に一度もホバーなし → null
+   * - それ以外 → 表示時点のホバー先と確定時点のホバー先が異なれば true
+   */
+  const computeTurn1HoverChanged = useCallback((): boolean | null => {
+    if (!typingShownForHoverRef.current) return null;
+    if (firstHoverAtRef.current === null) return null;
+    return lastHoverChoiceRef.current !== hoverChoiceAtTypingRef.current;
+  }, []);
+
   // onComplete の最新参照を保持（submitting effect の依存を最小化するため）
   useEffect(() => {
     onCompleteRef.current = onComplete;
@@ -153,6 +212,30 @@ export function useGroupChatGame(options: {
   useEffect(() => {
     onboardingOpenedAtRef.current = Date.now();
   }, []);
+
+  // 入力デバイス種別を「初回 turn-active 開始後の最初の操作」で確定する。
+  // オンボーディング中の Tab / Cmd+R / Esc 等のキー操作で誤確定しないよう、
+  // turn-active 中のみリスナーを有効にする（pen / 空文字は 'mouse' に丸める）。
+  useEffect(() => {
+    if (gamePhase !== 'turn-active') return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (inputDeviceDetectedRef.current) return;
+      inputDeviceDetectedRef.current = true;
+      inputDeviceTypeRef.current =
+        e.pointerType === 'touch' ? 'touch' : 'mouse';
+    };
+    const onKeyDown = () => {
+      if (inputDeviceDetectedRef.current) return;
+      inputDeviceDetectedRef.current = true;
+      inputDeviceTypeRef.current = 'keyboard';
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [gamePhase]);
 
   // =========================================================
   // ターン確定 → 次ターン or 送信へ
@@ -171,18 +254,33 @@ export function useGroupChatGame(options: {
       clearAllPendingTimeouts();
       setIsTypingIndicatorVisible(false);
 
+      // 選択クリック由来の派生値（タイムアウト時は両方 null）。
+      // ホバー refs から導出することで、selectOption 側のロジックを薄く保つ。
+      const isClickedOption = !isTimeout && isOptionIntentId(selectedOptionId);
+      const finalChoiceHoverOrder = (() => {
+        if (!isClickedOption) return null;
+        const idx = distinctHoverOrderRef.current.indexOf(selectedOptionId);
+        return idx >= 0 ? idx + 1 : null;
+      })();
+      const decisionConfidenceMs =
+        isClickedOption && lastHoverEnterAtRef.current !== null
+          ? Date.now() - lastHoverEnterAtRef.current
+          : null;
+
       const result: GroupChatGameTurn = {
         turnId: turn.turnId,
         selectedOptionId,
         reactionTimeMs,
         isTimeout,
-        // --- 以下は #141 で実計測に置き換え（本 PR はデフォルト値）---
-        firstHoverElapsedMs: null,
-        finalChoiceHoverOrder: null,
-        decisionConfidenceMs: null,
-        mouseMovementDistance: 0,
-        hoverSequence: [],
-        scrolledChatHistoryCount: 0,
+        firstHoverElapsedMs:
+          firstHoverAtRef.current !== null
+            ? firstHoverAtRef.current - optionsShownAtRef.current
+            : null,
+        finalChoiceHoverOrder,
+        decisionConfidenceMs,
+        mouseMovementDistance: Math.round(mouseDistanceRef.current),
+        hoverSequence: [...hoverSequenceRef.current],
+        scrolledChatHistoryCount: scrollUpCountRef.current,
       };
       turnResultsRef.current = [...turnResultsRef.current, result];
 
@@ -200,8 +298,36 @@ export function useGroupChatGame(options: {
   );
 
   // =========================================================
-  // ユーザー操作: 選択肢クリック
+  // ユーザー操作: 選択肢ホバー / クリック / 履歴スクロール
   // =========================================================
+
+  /** 選択肢にホバーしたとき（pointerenter）。連続して同じ選択肢に入った場合は無視する */
+  const handleOptionHover = useCallback(
+    (optionId: OptionIntentId) => {
+      if (gamePhase !== 'turn-active' || turnResolvedRef.current) return;
+      if (lastHoverChoiceRef.current === optionId) return;
+
+      const now = Date.now();
+      if (firstHoverAtRef.current === null) firstHoverAtRef.current = now;
+      if (hoverSequenceRef.current.length < HOVER_SEQUENCE_CAP) {
+        hoverSequenceRef.current.push(optionId);
+      }
+      if (!distinctHoverOrderRef.current.includes(optionId)) {
+        distinctHoverOrderRef.current.push(optionId);
+      }
+      lastHoverChoiceRef.current = optionId;
+      lastHoverEnterAtRef.current = now;
+    },
+    [gamePhase]
+  );
+
+  /** チャット履歴を上方向にスクロールしたとき（1ジェスチャーにつき1回呼ばれる想定） */
+  const handleHistoryScroll = useCallback(() => {
+    if (gamePhase !== 'turn-active' || turnResolvedRef.current) return;
+    scrollUpCountRef.current += 1;
+  }, [gamePhase]);
+
+  /** 選択肢をクリックしたとき */
   const selectOption = useCallback(
     (selectedOptionId: OptionIntentId) => {
       if (gamePhase !== 'turn-active' || turnResolvedRef.current) return;
@@ -218,6 +344,8 @@ export function useGroupChatGame(options: {
           t1TypingIndicatorShownAtRef.current !== null
             ? now - t1TypingIndicatorShownAtRef.current
             : null;
+        turn1HoverChangedAfterColleagueATypingRef.current =
+          computeTurn1HoverChanged();
       }
 
       // 無言系の選択肢（isSilent: true、例:「黙って様子を見る」）は chat に
@@ -234,7 +362,12 @@ export function useGroupChatGame(options: {
 
       recordTurnAndAdvance(selectedOptionId, reactionTimeMs, false);
     },
-    [gamePhase, currentTurnIndex, recordTurnAndAdvance]
+    [
+      gamePhase,
+      currentTurnIndex,
+      recordTurnAndAdvance,
+      computeTurn1HoverChanged,
+    ]
   );
 
   // タイムアウト時の確定処理
@@ -246,12 +379,16 @@ export function useGroupChatGame(options: {
     if (turn.turnId === 1) {
       turn1AnsweredBeforeColleagueARef.current = null;
       turn1TypingIndicatorReactTimeMsRef.current = null;
+      turn1HoverChangedAfterColleagueATypingRef.current =
+        computeTurn1HoverChanged();
     }
     // タイムアウトは「無反応」扱い: user メッセージを chat に追加しない。
     // BE には selectedOptionId=0 / isTimeout=true で送るため分析側で識別可能。
+    // クリックがないため finalChoiceHoverOrder / decisionConfidenceMs は
+    // recordTurnAndAdvance 内で自動的に null になる。
     // 仕様: タイムアウトは reactionTimeMs を実時間（≒制限時間）として記録
     recordTurnAndAdvance(0, turn.timerMs, true);
-  }, [currentTurnIndex, recordTurnAndAdvance]);
+  }, [currentTurnIndex, recordTurnAndAdvance, computeTurn1HoverChanged]);
 
   // =========================================================
   // カットイン演出: CUTIN_DURATION_MS 後に turn-active へ
@@ -263,7 +400,7 @@ export function useGroupChatGame(options: {
   }, [gamePhase, trackTimeout, clearAllPendingTimeouts]);
 
   // =========================================================
-  // turn-active: タイマー稼働 + メッセージ順次表示
+  // turn-active: タイマー稼働 + メッセージ順次表示 + マウス軌跡計測
   // =========================================================
   useEffect(() => {
     if (gamePhase !== 'turn-active') return;
@@ -273,10 +410,23 @@ export function useGroupChatGame(options: {
     // 初期化（ref 代入のみ。setState は下のコールバックで行う）
     turnResolvedRef.current = false;
     optionsShownAtRef.current = Date.now();
+    resetTurnMetrics();
     if (turn.turnId === 1) {
       t1PreemptShownRef.current = false;
       t1TypingIndicatorShownAtRef.current = null;
     }
+
+    // マウス総移動距離の計測（turn-active 中のみ）
+    const onPointerMove = (e: PointerEvent) => {
+      const prev = lastPointerPosRef.current;
+      if (prev) {
+        const dx = e.clientX - prev.x;
+        const dy = e.clientY - prev.y;
+        mouseDistanceRef.current += Math.sqrt(dx * dx + dy * dy);
+      }
+      lastPointerPosRef.current = { x: e.clientX, y: e.clientY };
+    };
+    window.addEventListener('pointermove', onPointerMove);
 
     // タイマー（interval コールバック内で setState）
     const start = Date.now();
@@ -309,6 +459,9 @@ export function useGroupChatGame(options: {
       }, 0);
       trackTimeout(() => {
         t1TypingIndicatorShownAtRef.current = Date.now();
+        // 「入力中」表示時点のホバー先を記録（hover変化判定の起点）
+        typingShownForHoverRef.current = true;
+        hoverChoiceAtTypingRef.current = lastHoverChoiceRef.current;
         setTypingSpeakerId('colleague-a');
         setIsTypingIndicatorVisible(true);
       }, T1_TYPING_INDICATOR_DELAY_MS);
@@ -357,6 +510,7 @@ export function useGroupChatGame(options: {
     }
 
     return () => {
+      window.removeEventListener('pointermove', onPointerMove);
       if (timerIdRef.current) {
         clearInterval(timerIdRef.current);
         timerIdRef.current = null;
@@ -369,6 +523,7 @@ export function useGroupChatGame(options: {
     trackTimeout,
     handleTimeout,
     clearAllPendingTimeouts,
+    resetTurnMetrics,
   ]);
 
   // =========================================================
@@ -384,9 +539,9 @@ export function useGroupChatGame(options: {
       turn1AnsweredBeforeColleagueA: turn1AnsweredBeforeColleagueARef.current,
       turn1TypingIndicatorReactTimeMs:
         turn1TypingIndicatorReactTimeMsRef.current,
-      // --- 以下は #141 で実計測に置き換え（本 PR はデフォルト値）---
-      turn1HoverChangedAfterColleagueATyping: null,
-      inputDeviceType: 'mouse',
+      turn1HoverChangedAfterColleagueATyping:
+        turn1HoverChangedAfterColleagueATypingRef.current,
+      inputDeviceType: inputDeviceTypeRef.current,
     };
     // onComplete（送信）は非同期だが、完了を待たずに completed へ進める。
     // 終了オーバーレイ内で submitStatus に応じた送信中 / 成功表示を出す設計のため。
@@ -418,13 +573,15 @@ export function useGroupChatGame(options: {
     turnResolvedRef.current = false;
     turn1AnsweredBeforeColleagueARef.current = null;
     turn1TypingIndicatorReactTimeMsRef.current = null;
+    turn1HoverChangedAfterColleagueATypingRef.current = null;
     t1PreemptShownRef.current = false;
     t1TypingIndicatorShownAtRef.current = null;
+    resetTurnMetrics();
     setChatMessages([]);
     setCurrentTurnIndex(0);
     setRemainingTimeMs(TURNS[0]?.timerMs ?? 0);
     setGamePhase('turn-cutin');
-  }, [gamePhase]);
+  }, [gamePhase, resetTurnMetrics]);
 
   // =========================================================
   // 派生値
@@ -446,5 +603,7 @@ export function useGroupChatGame(options: {
     typingSpeaker,
     startGame,
     selectOption,
+    handleOptionHover,
+    handleHistoryScroll,
   };
 }

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -270,8 +270,12 @@ export function useGroupChatGame(options: {
         const idx = distinctHoverOrderRef.current.indexOf(selectedOptionId);
         return idx >= 0 ? idx + 1 : null;
       })();
+      // 「クリックした選択肢に直近 hover していたか」を厳密に判定する。
+      // 直近 hover 先と一致しない場合（キーボード操作・別の選択肢中のクリック等）は null。
       const decisionConfidenceMs =
-        isClickedOption && lastHoverEnterAtRef.current !== null
+        isClickedOption &&
+        lastHoverEnterAtRef.current !== null &&
+        lastHoverChoiceRef.current === selectedOptionId
           ? Date.now() - lastHoverEnterAtRef.current
           : null;
 
@@ -309,15 +313,23 @@ export function useGroupChatGame(options: {
   // ユーザー操作: 選択肢ホバー / クリック / 履歴スクロール
   // =========================================================
 
-  /** 選択肢にホバーしたとき（pointerenter）。連続して同じ選択肢に入った場合は無視する */
+  /**
+   * 選択肢にホバーしたとき（pointerenter）。
+   * - `hoverSequence` への push は連続重複を抑制（同じ選択肢への連続 pointerenter を 1 件にまとめる）
+   * - `lastHoverEnterAtRef` は同一選択肢への再ホバーでも更新する（`decisionConfidenceMs` を「直近の pointerenter からクリックまで」に保つため）
+   */
   const handleOptionHover = useCallback(
     (optionId: OptionIntentId) => {
       if (gamePhase !== 'turn-active' || turnResolvedRef.current) return;
-      if (lastHoverChoiceRef.current === optionId) return;
 
       const now = Date.now();
       if (firstHoverAtRef.current === null) firstHoverAtRef.current = now;
-      if (hoverSequenceRef.current.length < HOVER_SEQUENCE_CAP) {
+
+      const isSameAsLast = lastHoverChoiceRef.current === optionId;
+      if (
+        !isSameAsLast &&
+        hoverSequenceRef.current.length < HOVER_SEQUENCE_CAP
+      ) {
         hoverSequenceRef.current.push(optionId);
       }
       if (!distinctHoverOrderRef.current.includes(optionId)) {


### PR DESCRIPTION
## 概要

Game 3「空気読みグループチャット」の取得データ収集ロジックを実装する（Issue #141）。

PR #154（`feature/group-chat-game-ui`）の仕様変更を取り込んだ新 base 起点で実装。クローズ済みの PR #155 の代替。

## 変更内容

仕様書「データ構造 → `GroupChatGameData`」準拠のデータ取得項目を実計測する:

| 項目 | 内容 |
|---|---|
| `hoverSequence` | ホバーした選択肢 ID の順番（連続重複を除外、上限 10 件） |
| `firstHoverElapsedMs` | 選択肢表示 → 初ホバーまでの ms |
| `finalChoiceHoverOrder` | 最終選択が distinct ホバー順で何番目か（1=即決 / 3-4=吟味型） |
| `decisionConfidenceMs` | クリック直前の最後の `pointerenter` からクリックまでの ms |
| `mouseMovementDistance` | turn-active 中のマウス総移動距離（px、`pointermove` ベース） |
| `scrolledChatHistoryCount` | 上方向スクロールを 1 ジェスチャー単位で集計（300ms デバウンス / 4px 閾値） |
| `inputDeviceType` | 初回 turn-active 中の最初の操作で確定（mouse / touch / keyboard） |
| `turn1HoverChangedAfterColleagueATyping` | ターン 1「入力中」表示前後でホバー先が変化したか |

### 実装

- `useGroupChatGame`: hover 計測 refs / `resetTurnMetrics` / `computeTurn1HoverChanged` / 入力デバイス検出 useEffect を追加。`recordTurnAndAdvance` 内で `finalChoiceHoverOrder` / `decisionConfidenceMs` を ref から導出し、呼び出し側の責務を薄く保つ
- `ChoicePad`: `onPointerEnter` で hover ハンドラを呼び出し
- `ChatTimeline`: `onScroll` で上方向スクロールをデバウンス検知
- `GroupChatGameFlow`: `handleOptionHover` / `handleHistoryScroll` を子コンポーネントへ配線

### PR #154 の仕様変更との整合

- 「（黙って様子を見る）」を選んでも user bubble は出ないが、**hover 経路 / 計測データは記録される**（`selectedOptionId` も BE に送信）
- タイムアウト時の `finalChoiceHoverOrder` / `decisionConfidenceMs` は `null`
- T1 タイミング変更（typing 2.5s / 先回り 5.0s / 制限 14s）に対し `turn1HoverChangedAfterColleagueATyping` の判定ロジックが正しく動作
- 入力デバイス検出は `gamePhase === 'turn-active'` 中のみ有効。オンボーディング画面の Tab / Cmd+R などのキー操作で誤確定しない

closes #141
