### PR TITLE
fix: rename game_contributions → game_breakdown to match API naming

### DIFF
--- a/backend/src/repositories/analysisResultRepository.ts
+++ b/backend/src/repositories/analysisResultRepository.ts
@@ -26,7 +26,7 @@ export interface AnalysisResultRow {
     feedback_description: string;
     feedback_gap_point: string;
     // その他
-    game_contributions: GameBreakdown;
+    game_breakdown: GameBreakdown;
     accuracy_score: number;
     phase_summaries: PhaseSummaries;
     /** 各ゲーム詳細（GET /api/results の details と同一構造）。`analysis_results.details` JSONB。 */

--- a/backend/src/schemas/results.ts
+++ b/backend/src/schemas/results.ts
@@ -134,7 +134,7 @@ export type GameId = z.infer<typeof gameIdSchema>;
  * ゲームごとのスコア内訳（配列形式）。
  *
  * 各要素は `{ game_id, scores }` の構造で、`game_id` はゲームを識別する文字列
- * （現状は 'terms_game' / 'helpdesk_game' / 'group_chat_game'）。
+ * （現状は 'terms_game' / 'sorter_game' / 'group_chat_game'）。
  * 配列化の理由は将来のゲーム追加・差し替えに耐えるため（Phase 1 / Issue #97）。
  *
  * `scores` は当該ゲームで測定する軸のみを含む（例: terms_game は caution / logic / calmness のみ）。

--- a/backend/src/services/resultService.ts
+++ b/backend/src/services/resultService.ts
@@ -121,7 +121,7 @@ export const resultService = {
             feedback_title: analysisResult.feedback.title,
             feedback_description: analysisResult.feedback.description,
             feedback_gap_point: analysisResult.feedback.gap_point,
-            game_contributions: analysisResult.game_breakdown,
+            game_breakdown: analysisResult.game_breakdown,
             accuracy_score: analysisResult.accuracy_score,
             phase_summaries: analysisResult.phase_summaries,
             details: analysisResult.details,
@@ -170,7 +170,7 @@ export const resultService = {
                 cooperativeness: cached.gap_coop,
                 positivity: cached.gap_positive,
             },
-            game_breakdown: cached.game_contributions,
+            game_breakdown: cached.game_breakdown,
             feedback: {
                 title: cached.feedback_title,
                 description: cached.feedback_description,

--- a/backend/supabase_migration.sql
+++ b/backend/supabase_migration.sql
@@ -76,3 +76,8 @@ CREATE INDEX idx_game_logs_game_type ON game_logs(game_type);
 -- ALTER TABLE analysis_results
 -- ADD COLUMN details JSONB NOT NULL DEFAULT '[]'::jsonb;
 
+-- DB 列名を API / scoreCalculator の用語（game_breakdown）に統一する。
+-- 実行前にバックエンドの AnalysisResultRow / resultService の更新を先にデプロイすること。
+ALTER TABLE analysis_results
+  RENAME COLUMN game_contributions TO game_breakdown;
+

--- a/backend/supabase_migration.sql
+++ b/backend/supabase_migration.sql
@@ -77,7 +77,7 @@ CREATE INDEX idx_game_logs_game_type ON game_logs(game_type);
 -- ADD COLUMN details JSONB NOT NULL DEFAULT '[]'::jsonb;
 
 -- DB 列名を API / scoreCalculator の用語（game_breakdown）に統一する。
--- 実行前にバックエンドの AnalysisResultRow / resultService の更新を先にデプロイすること。
+-- 実行後にバックエンドをデプロイすること（先にデプロイすると列名不一致で一時的にキャッシュが壊れる）。
 ALTER TABLE analysis_results
   RENAME COLUMN game_contributions TO game_breakdown;
 


### PR DESCRIPTION
## 背景

BE のキャッシュ保存パスで `game_breakdown`（API / scoreCalculator の用語）と
`game_contributions`（DB 列名）が混在していた。
動作はしていたが将来のサイレントバグを防ぐため DB 列名を API 名に統一する。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `backend/src/repositories/analysisResultRepository.ts` | `AnalysisResultRow.game_contributions` → `game_breakdown` |
| `backend/src/services/resultService.ts` | キャッシュ保存・読み出しの `game_contributions` → `game_breakdown` |
| `backend/src/schemas/results.ts` | stale コメント `helpdesk_game` → `sorter_game` |
| `backend/supabase_migration.sql` | `RENAME COLUMN game_contributions TO game_breakdown` を末尾に追記 |

## 注意事項

- FE の変更なし
- Supabase マイグレーション（`ALTER TABLE RENAME COLUMN`）は **本 PR マージ後に手動実行**
- コード側を先にデプロイすると `game_contributions` 列が見つからずエラーになるため、  
  **マイグレーション → デプロイの順**で実行すること

## Test plan

- [x] `npx tsc --noEmit` 型エラーなし

Made with [Cursor](https://cursor.com)