### PR TITLE
fix: terms_game の measuredTraits を5軸に更新

### DIFF
--- a/frontend/src/features/result/data/gameMeta.ts
+++ b/frontend/src/features/result/data/gameMeta.ts
@@ -39,7 +39,7 @@ export const GAME_META: Record<GameId, GameMeta> = {
     color: '#ef4444',
     description:
       'サービスの利用規約に見せかけた行動計測ゲームです。長い規約をどれだけ読むか／読まずに即同意するかで、素の行動が表れます。',
-    measuredTraits: '慎重さ・論理性・冷静さ',
+    measuredTraits: '慎重さ・論理性・冷静さ・協調性・積極性',
   },
   helpdesk_game: {
     label: 'AIバトル',


### PR DESCRIPTION
## 概要

PR #151（利用規約ゲーム HCIモデル刷新）で BE が3軸→5軸に拡張されたが、
FE の `gameMeta.ts` が旧来の3軸のままだったため、説明文とグラフの軸数が一致していなかった。

## 変更内容

`frontend/src/features/result/data/gameMeta.ts`

```ts
// Before
measuredTraits: '慎重さ・論理性・冷静さ'

// After
measuredTraits: '慎重さ・論理性・冷静さ・協調性・積極性'
```

## 原因

BE（`termsGame.ts`）は `feature_scores` に5軸分を返すのでグラフは5軸で描画される。
一方 `measuredTraits`（詳細画面の説明文）は更新されておらず3軸のままだった。

## チェックリスト

- [x] TypeScript 型チェック（`tsc --noEmit`）エラーなし