### PR TITLE
fix: 空気読みチャットでメッセージ・入力中が表示されない不具合を修正

### DIFF
--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -182,6 +182,7 @@ export default function GroupChatGameFlow() {
     currentTurn,
     currentTurnIndex,
     totalTurns,
+    isTurnResolving,
     typingSpeaker,
     startGame: rawStartGame,
     selectOption: rawSelectOption,
@@ -235,7 +236,8 @@ export default function GroupChatGameFlow() {
             onHistoryScroll={handleHistoryScroll}
           />
 
-          {gamePhase === 'turn-active' && currentTurn ? (
+          {/* 回答確定中（早押し時の同期A挙手ビート進行中）は ChoicePad を閉じる */}
+          {gamePhase === 'turn-active' && currentTurn && !isTurnResolving ? (
             <ChoicePad
               turn={currentTurn}
               remainingTimeMs={remainingTimeMs}

--- a/frontend/src/features/games/group-chat/data/turns.ts
+++ b/frontend/src/features/games/group-chat/data/turns.ts
@@ -84,6 +84,18 @@ export const T1_TYPING_INDICATOR_DELAY_MS = 2_500;
 export const T1_PREEMPT_REVEAL_DELAY_MS = 2_500;
 
 /**
+ * ターン1: プレイヤーが同期Aの先回り発言より先に回答した（早押し）場合に、
+ * 「同期Aの挙手 → 自分の発言」の順を保つため、回答後に挙手ビートを差し込む際の遅延。
+ * 本筋シナリオ（同期Aが引き受ける）を全パターンで成立させるための演出。
+ */
+/** 早押し時: 回答クリック後「同期A 入力中」を見せてから挙手発言が出るまでの遅延 */
+export const T1_CATCHUP_TYPING_MS = 800;
+/** 早押し時: 同期A 挙手発言の後、自分の発言が表示されるまでの遅延 */
+export const T1_CATCHUP_USER_MESSAGE_MS = 500;
+/** 早押し時: 自分の発言が表示された後、ターン2へ進むまでの遅延 */
+export const T1_CATCHUP_ADVANCE_MS = 800;
+
+/**
  * 各ターンの制限時間。
  * - T1: 14s — 同期A 先回り発言（=5.0s 地点）後に約 9.0s の判断時間を確保
  * - T2: 15s — 上司+同期A+同期B 段階表示後に約 12.8s

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -420,9 +420,18 @@ export function useGroupChatGame(options: {
         }
         clearAllPendingTimeouts();
 
+        // この「入力中」は回答後に差し込む純粋な演出であり、プレイヤーの判断中に
+        // 出た同期Aのタイピングではない。反応時間・hover変化などの計測値は上の
+        // `turn.turnId === 1` ブロックでクリック時点の状態から既に確定記録済みのため、
+        // 計測用 ref（t1TypingIndicatorShownAtRef / typingShownForHoverRef /
+        // hoverChoiceAtTypingRef）はここでは意図的に更新しない。
         // 同期A「入力中」をすぐ表示（クリック→自分の発言までの「間」を埋める）
         setTypingSpeakerId('colleague-a');
         setIsTypingIndicatorVisible(true);
+
+        // 無言系の選択肢では自分の発言を出さないので、その分の待ち時間も入れない
+        const userMessageDelay = userMessage ? T1_CATCHUP_USER_MESSAGE_MS : 0;
+
         // 同期A「私やりましょうか！」
         trackTimeout(() => {
           t1PreemptShownRef.current = true;
@@ -436,14 +445,12 @@ export function useGroupChatGame(options: {
         if (userMessage) {
           trackTimeout(() => {
             setChatMessages((prev) => [...prev, userMessage]);
-          }, T1_CATCHUP_TYPING_MS + T1_CATCHUP_USER_MESSAGE_MS);
+          }, T1_CATCHUP_TYPING_MS + userMessageDelay);
         }
         // ターン確定 → ターン2へ
         trackTimeout(
           () => finalizeTurn(selectedOptionId, reactionTimeMs, false),
-          T1_CATCHUP_TYPING_MS +
-            T1_CATCHUP_USER_MESSAGE_MS +
-            T1_CATCHUP_ADVANCE_MS
+          T1_CATCHUP_TYPING_MS + userMessageDelay + T1_CATCHUP_ADVANCE_MS
         );
         return;
       }

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -402,9 +402,7 @@ export function useGroupChatGame(options: {
         (c) => c.selectedOptionId === selectedOptionId
       );
       const userMessage: ChatMessage | null =
-        choice && !choice.isSilent
-          ? { type: 'user', text: choice.text }
-          : null;
+        choice && !choice.isSilent ? { type: 'user', text: choice.text } : null;
 
       // ターン1で、同期Aの先回り発言がまだ出ていないうちに答えた（早押し）場合:
       // 「同期Aの挙手 → 自分の発言」の順を必ず保つため、自分の発言の表示とターン遷移を

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -106,6 +106,12 @@ export function useGroupChatGame(options: {
   const [remainingTimeMs, setRemainingTimeMs] = useState<number>(
     () => TURNS[0]?.timerMs ?? 0
   );
+  /**
+   * 回答確定済みだが、まだ次ターンへ進んでいない「確定中」状態。
+   * ターン1の早押し時に同期Aの挙手ビートを差し込む間 true になり、その間は
+   * ChoicePad を隠して選択肢の誤操作・SE 誤発火・固まったタイマーバー表示を防ぐ。
+   */
+  const [isTurnResolving, setIsTurnResolving] = useState(false);
   const [isTypingIndicatorVisible, setIsTypingIndicatorVisible] =
     useState(false);
   const [typingSpeakerId, setTypingSpeakerId] = useState<Exclude<
@@ -408,6 +414,8 @@ export function useGroupChatGame(options: {
         // 確定フラグだけ先に立て、タイマーと既存の時間ベース挙手予約(2.5s/5.0s)を止める。
         // 結果記録/遷移はビート終了後に finalizeTurn で行う。
         turnResolvedRef.current = true;
+        // ビート進行中は選択肢を閉じる（誤操作・SE誤発火・固まったタイマー表示の防止）
+        setIsTurnResolving(true);
         if (timerIdRef.current) {
           clearInterval(timerIdRef.current);
           timerIdRef.current = null;
@@ -490,7 +498,11 @@ export function useGroupChatGame(options: {
   // 予約したばかりの timeout まで消してしまい、メッセージ・入力中が表示されない。
   useEffect(() => {
     if (gamePhase !== 'turn-cutin') return;
-    const id = setTimeout(() => setGamePhase('turn-active'), CUTIN_DURATION_MS);
+    const id = setTimeout(() => {
+      // 次ターン開始時に「確定中」を解除して ChoicePad を再表示できるようにする
+      setIsTurnResolving(false);
+      setGamePhase('turn-active');
+    }, CUTIN_DURATION_MS);
     return () => clearTimeout(id);
   }, [gamePhase]);
 
@@ -681,6 +693,7 @@ export function useGroupChatGame(options: {
     inputDeviceDetectedRef.current = false;
     inputDeviceTypeRef.current = 'keyboard';
     resetTurnMetrics();
+    setIsTurnResolving(false);
     setChatMessages([]);
     setCurrentTurnIndex(0);
     setRemainingTimeMs(TURNS[0]?.timerMs ?? 0);
@@ -704,6 +717,7 @@ export function useGroupChatGame(options: {
     currentTurnIndex,
     totalTurns: TOTAL_TURNS,
     isTypingIndicatorVisible,
+    isTurnResolving,
     typingSpeaker,
     startGame,
     selectOption,

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -13,6 +13,9 @@ import {
   CUTIN_DURATION_MS,
   getTurn2BossLine,
   isOptionIntentId,
+  T1_CATCHUP_ADVANCE_MS,
+  T1_CATCHUP_TYPING_MS,
+  T1_CATCHUP_USER_MESSAGE_MS,
   T1_PREEMPT_MESSAGE,
   T1_PREEMPT_REVEAL_DELAY_MS,
   T1_TYPING_INDICATOR_DELAY_MS,
@@ -253,18 +256,17 @@ export function useGroupChatGame(options: {
   // =========================================================
   // ターン確定 → 次ターン or 送信へ
   // =========================================================
-  const recordTurnAndAdvance = useCallback(
+  /**
+   * ターン結果を記録して次フェーズ（次ターンのカットイン or 送信）へ進める。
+   *
+   * 二重確定ガード・タイマー停止・予約 timeout の解除は **呼び出し側の責務**とする。
+   * 通常は recordTurnAndAdvance がそれらを行ってから呼ぶが、ターン1の早押し時は
+   * 「同期Aの挙手ビートを差し込んでから確定する」ため、確定を遅延させて直接呼ぶ。
+   */
+  const finalizeTurn = useCallback(
     (selectedOptionId: number, reactionTimeMs: number, isTimeout: boolean) => {
-      if (turnResolvedRef.current) return;
       const turn = TURNS[currentTurnIndex];
       if (!turn) return;
-      turnResolvedRef.current = true;
-
-      if (timerIdRef.current) {
-        clearInterval(timerIdRef.current);
-        timerIdRef.current = null;
-      }
-      clearAllPendingTimeouts();
       setIsTypingIndicatorVisible(false);
 
       // 選択クリック由来の派生値（タイムアウト時は両方 null）。
@@ -311,7 +313,22 @@ export function useGroupChatGame(options: {
         setGamePhase('turn-cutin');
       }
     },
-    [currentTurnIndex, clearAllPendingTimeouts]
+    [currentTurnIndex]
+  );
+
+  /** 通常の確定: 二重確定ガード + タイマー停止 + 予約解除 + 結果記録/遷移 */
+  const recordTurnAndAdvance = useCallback(
+    (selectedOptionId: number, reactionTimeMs: number, isTimeout: boolean) => {
+      if (turnResolvedRef.current) return;
+      turnResolvedRef.current = true;
+      if (timerIdRef.current) {
+        clearInterval(timerIdRef.current);
+        timerIdRef.current = null;
+      }
+      clearAllPendingTimeouts();
+      finalizeTurn(selectedOptionId, reactionTimeMs, isTimeout);
+    },
+    [finalizeTurn, clearAllPendingTimeouts]
   );
 
   // =========================================================
@@ -378,19 +395,66 @@ export function useGroupChatGame(options: {
       const choice = turn.choices.find(
         (c) => c.selectedOptionId === selectedOptionId
       );
-      if (choice && !choice.isSilent) {
-        setChatMessages((prev) => [
-          ...prev,
-          { type: 'user', text: choice.text },
-        ]);
+      const userMessage: ChatMessage | null =
+        choice && !choice.isSilent
+          ? { type: 'user', text: choice.text }
+          : null;
+
+      // ターン1で、同期Aの先回り発言がまだ出ていないうちに答えた（早押し）場合:
+      // 「同期Aの挙手 → 自分の発言」の順を必ず保つため、自分の発言の表示とターン遷移を
+      // 遅延させ、先に同期Aの挙手ビート（入力中 → 私やりましょうか！）を差し込む。
+      // 本筋シナリオ（同期Aが引き受ける）を全パターンで成立させるための演出。
+      if (turn.turnId === 1 && !t1PreemptShownRef.current) {
+        // 確定フラグだけ先に立て、タイマーと既存の時間ベース挙手予約(2.5s/5.0s)を止める。
+        // 結果記録/遷移はビート終了後に finalizeTurn で行う。
+        turnResolvedRef.current = true;
+        if (timerIdRef.current) {
+          clearInterval(timerIdRef.current);
+          timerIdRef.current = null;
+        }
+        clearAllPendingTimeouts();
+
+        // 同期A「入力中」をすぐ表示（クリック→自分の発言までの「間」を埋める）
+        setTypingSpeakerId('colleague-a');
+        setIsTypingIndicatorVisible(true);
+        // 同期A「私やりましょうか！」
+        trackTimeout(() => {
+          t1PreemptShownRef.current = true;
+          setIsTypingIndicatorVisible(false);
+          setChatMessages((prev) => [
+            ...prev,
+            toChatBotMessage(T1_PREEMPT_MESSAGE),
+          ]);
+        }, T1_CATCHUP_TYPING_MS);
+        // 自分の発言（無言系の選択肢では出さない）
+        if (userMessage) {
+          trackTimeout(() => {
+            setChatMessages((prev) => [...prev, userMessage]);
+          }, T1_CATCHUP_TYPING_MS + T1_CATCHUP_USER_MESSAGE_MS);
+        }
+        // ターン確定 → ターン2へ
+        trackTimeout(
+          () => finalizeTurn(selectedOptionId, reactionTimeMs, false),
+          T1_CATCHUP_TYPING_MS +
+            T1_CATCHUP_USER_MESSAGE_MS +
+            T1_CATCHUP_ADVANCE_MS
+        );
+        return;
       }
 
+      // 通常: 同期Aの挙手が既に出ている / ターン2・3。自分の発言を即表示して確定。
+      if (userMessage) {
+        setChatMessages((prev) => [...prev, userMessage]);
+      }
       recordTurnAndAdvance(selectedOptionId, reactionTimeMs, false);
     },
     [
       gamePhase,
       currentTurnIndex,
       recordTurnAndAdvance,
+      finalizeTurn,
+      trackTimeout,
+      clearAllPendingTimeouts,
       computeTurn1HoverChanged,
     ]
   );
@@ -418,11 +482,17 @@ export function useGroupChatGame(options: {
   // =========================================================
   // カットイン演出: CUTIN_DURATION_MS 後に turn-active へ
   // =========================================================
+  // この単発 timeout は共有 timeout 群（pendingTimeoutsRef / trackTimeout）に
+  // 入れず、ローカル id で自前管理する。turn-active の useLayoutEffect は
+  // コミット時（描画前）に bot メッセージ・「入力中」表示の timeout を予約するが、
+  // この effect は useEffect（描画後）でクリーンアップが走る。共有 Set を
+  // clearAllPendingTimeouts() で一括解除すると、直前のコミットで turn-active が
+  // 予約したばかりの timeout まで消してしまい、メッセージ・入力中が表示されない。
   useEffect(() => {
     if (gamePhase !== 'turn-cutin') return;
-    trackTimeout(() => setGamePhase('turn-active'), CUTIN_DURATION_MS);
-    return () => clearAllPendingTimeouts();
-  }, [gamePhase, trackTimeout, clearAllPendingTimeouts]);
+    const id = setTimeout(() => setGamePhase('turn-active'), CUTIN_DURATION_MS);
+    return () => clearTimeout(id);
+  }, [gamePhase]);
 
   // =========================================================
   // turn-active: タイマー稼働 + メッセージ順次表示 + マウス軌跡計測


### PR DESCRIPTION
## 概要

空気読みチャット（グループチャットゲーム / game_type=3）で、他キャラのメッセージと「入力中」インジケータが表示されない不具合を修正する。あわせて、ターン1で同期Aの先回り発言が出ないまま次ターンで感謝される不整合を解消する。

## 変更内容

- **カットインのcleanupが次ターンのメッセージ用timeoutを消す問題を修正**
  カットインeffect（`useEffect`/描画後）のcleanupが共有タイマーSetを一括解除する `clearAllPendingTimeouts()` を呼んでいたため、turn-active effect（`useLayoutEffect`/コミット時）が直前に予約したbotメッセージ・入力中表示のtimeoutまで消去されていた。カットインeffectを共有Setから切り離し、自身の単発timeoutをローカルidで `clearTimeout` するよう変更。

- **ターン1の同期A先回り演出が早押しでスキップされる問題を修正**
  プレイヤーが同期Aの先回り発言より先に回答すると、同期Aの挙手（入力中→私やりましょうか！）がキャンセルされ、本筋シナリオ（同期Aが引き受ける）が成立せず「同期の返信が無いのに感謝される」状態だった。早押し時は回答後に同期Aの挙手ビートを差し込み、「同期Aの挙手 → 自分の発言」の順を全パターンで保証する。`recordTurnAndAdvance` を結果記録/遷移（`finalizeTurn`）と確定処理に分離。計測値（`turn1AnsweredBeforeColleagueA` 等）は回答クリック時点で記録するため不変。

- **早押しビート中もChoicePadが操作可能だった問題を修正**
  ビート進行中（約2.1秒）も選択肢が押せて選択音だけ鳴る・タイマーバーが固まって見えていた。確定中フラグ（`isTurnResolving`）を追加し、ビート中はChoicePadを閉じて「メッセージを表示しています...」表示に切り替える。

## 動作確認（ターン1・GIF）

「入力中」が出るターン1の挙動を4パターン録画。各見出しの下のプレースホルダー行を消し、そこに GIF をドラッグ&ドロップで貼り付けてください。

### ① 入力中の表示中に自分が送信
同期Aの「入力中」が出ている状態で、同期Aが発言し切る前に自分が送信するパターン。

<img width="800" height="520" alt="CleanShot 2026-05-28 at 21 09 43" src="https://github.com/user-attachments/assets/d8872f8c-9f85-40ac-89bd-145ea47fbcd8" />

### ② 入力中をそのまま譲る
同期Aが「私やりましょうか！」と発言し終えてから、自分が送信するパターン。

![Uploading CleanShot 2026-05-28 at 21.10.14.gif…]()


### ③ 入力中が出る前に自分が送信
同期Aの入力中が出る前に先に送信するパターン（回答後に同期Aの挙手ビートを差し込む）。

<img width="800" height="520" alt="CleanShot 2026-05-28 at 21 10 47" src="https://github.com/user-attachments/assets/98b8f64d-c6ad-4770-9e69-019c0dbd6af9" />


### ④ 入力中が出てから黙って様子を見る
入力中 → 同期Aの発言が出た後、自分は何も送らず様子を見るパターン。

<img width="800" height="520" alt="CleanShot 2026-05-28 at 21 11 12" src="https://github.com/user-attachments/assets/4b711fe7-df4e-4cf3-84f5-810356fe1ecb" />


補足: ①③のように回答後へ演出を差し込む間は ChoicePad を閉じ、誤操作・選択音の誤発火を防いでいる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 早押し演出中に選択入力パッドを自動で閉じるようにし、誤操作を防止します。

* **改善**
  * ターン1の早押し向けに演出の表示タイミングを細かく制御する遅延処理を追加し、入力→挙手→発言の表示順序をより自然にしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->