### PR TITLE
feat: 利用規約ゲームの二段構え同意プロセスと行動計測

### DIFF
--- a/frontend/src/features/games/terms/components/ErrorDialog.tsx
+++ b/frontend/src/features/games/terms/components/ErrorDialog.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import type { FC } from 'react';
+
+interface ErrorDialogProps {
+  message: string;
+  /** OK ボタン押下（ダイアログを閉じる）。'errorDialog' クリックとして計測される */
+  onConfirm: () => void;
+  /** ダイアログ本体（OK ボタン以外）のクリック。'errorDialog' として計測される */
+  onDialogClick: () => void;
+  /** オーバーレイ背景のクリック。'other'（焦って画面外を触る行動）として計測される */
+  onOverlayClick: () => void;
+}
+
+/**
+ * 二段構え同意プロセスの 2 段目で表示するエラー差し戻しダイアログ。
+ *
+ * 第5条「読みました」未チェックのまま同意ボタンを押下した際に表示する。
+ * エラー後のクリック行動（連打・無関係操作）を計測するため、
+ * オーバーレイ背景／ダイアログ本体／OK ボタンのクリックを別経路で親に通知する。
+ */
+const ErrorDialog: FC<ErrorDialogProps> = ({
+  message,
+  onConfirm,
+  onDialogClick,
+  onOverlayClick,
+}) => {
+  return (
+    <div
+      // PopupTerms(z-50) / PopupAd(z-60) より前面に出す
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40"
+      onClick={onOverlayClick}
+    >
+      <div
+        className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+        role="alertdialog"
+        aria-modal="true"
+        onClick={(e) => {
+          // オーバーレイ背景の 'other' 計測に伝播させない
+          e.stopPropagation();
+          onDialogClick();
+        }}
+      >
+        <p className="text-center text-base font-bold text-gray-800">
+          {message}
+        </p>
+        <div className="mt-5 flex justify-center">
+          <button
+            onClick={(e) => {
+              // ダイアログ本体の 'errorDialog' 計測と二重計上しないよう伝播を止める
+              e.stopPropagation();
+              onConfirm();
+            }}
+            className="rounded bg-red-600 px-6 py-2 text-sm font-bold text-white hover:bg-red-700"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorDialog;

--- a/frontend/src/features/games/terms/components/ErrorDialog.tsx
+++ b/frontend/src/features/games/terms/components/ErrorDialog.tsx
@@ -4,20 +4,21 @@ import type { FC } from 'react';
 
 interface ErrorDialogProps {
   message: string;
-  /** OK ボタン押下（ダイアログを閉じる）。'errorDialog' クリックとして計測される */
+  /** OK ボタン押下（ダイアログを閉じる） */
   onConfirm: () => void;
-  /** ダイアログ本体（OK ボタン以外）のクリック。'errorDialog' として計測される */
-  onDialogClick: () => void;
-  /** オーバーレイ背景のクリック。'other'（焦って画面外を触る行動）として計測される */
-  onOverlayClick: () => void;
+  /** ダイアログ本体（OK ボタン以外）のクリック。エラー差し戻し時の 'errorDialog' 計測に使う（任意） */
+  onDialogClick?: () => void;
+  /** オーバーレイ背景のクリック。エラー差し戻し時の 'other' 計測に使う（任意） */
+  onOverlayClick?: () => void;
 }
 
 /**
- * 二段構え同意プロセスの 2 段目で表示するエラー差し戻しダイアログ。
+ * 規約同意フローの差し戻し / 案内ダイアログ。2 つの用途で再利用する。
  *
- * 第5条「読みました」未チェックのまま同意ボタンを押下した際に表示する。
- * エラー後のクリック行動（連打・無関係操作）を計測するため、
- * オーバーレイ背景／ダイアログ本体／OK ボタンのクリックを別経路で親に通知する。
+ * - エラー差し戻し: 第5条「読みました」未チェックのまま同意ボタンを押下した際に表示。
+ *   エラー後のクリック行動（連打・無関係操作）を計測するため、オーバーレイ背景／
+ *   ダイアログ本体／OK ボタンのクリックを別経路（onOverlayClick / onDialogClick）で通知する。
+ * - 同意要求: 「同意しない」押下時に同意を促す案内。計測は不要なので onConfirm のみ渡す。
  */
 const ErrorDialog: FC<ErrorDialogProps> = ({
   message,
@@ -38,7 +39,7 @@ const ErrorDialog: FC<ErrorDialogProps> = ({
         onClick={(e) => {
           // オーバーレイ背景の 'other' 計測に伝播させない
           e.stopPropagation();
-          onDialogClick();
+          onDialogClick?.();
         }}
       >
         <p className="text-center text-base font-bold text-gray-800">

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -20,7 +20,7 @@ import LoadingScreen from '@/components/common/LoadingScreen';
 // import { submitGame } from '@/lib/api';
 
 // ポップアップ広告が表示されるまでの遅延時間（ms）
-const POPUP_DELAY_MS = 8_000;
+const POPUP_DELAY_MS = 5_000;
 // スクロールイベントの記録間隔（ms）。パフォーマンスのため間引く
 const SCROLL_THROTTLE_MS = 200;
 // 「最下部まで到達した」と判定するスクロール割合（90%）

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -7,10 +7,14 @@ import type {
   TermsGameData,
   PopupStats,
   ScrollEvent,
+  TermsErrorEvent,
+  TermsPostErrorClick,
+  TermsCheckboxEvent,
 } from '@/features/games/types';
 import { termsGameDataAtom } from '@/stores/games';
 import PopupAd from './PopupAd';
 import PopupTerms from './PopupTerms';
+import ErrorDialog from './ErrorDialog';
 import LoadingScreen from '@/components/common/LoadingScreen';
 // TODO: バックエンド接続時にコメントアウトを解除する
 // import { submitGame } from '@/lib/api';
@@ -21,6 +25,11 @@ const POPUP_DELAY_MS = 15_000;
 const SCROLL_THROTTLE_MS = 200;
 // 「最下部まで到達した」と判定するスクロール割合（90%）
 const REACHED_BOTTOM_THRESHOLD = 0.9;
+// 第5条「読みました」未チェックで同意を試みた際のエラー理由。
+// BE 分析（termsGame.ts）が完全一致で判定するため固定値（仕様書「データ構造」準拠）。
+const ERROR_REASON_MISSING_READ_CONFIRM = 'missing_read_confirm';
+// エラー差し戻しダイアログの表示メッセージ
+const ERROR_DIALOG_MESSAGE = '未確認の必須項目があります';
 
 export default function TermsGameFlow() {
   const router = useRouter();
@@ -37,6 +46,8 @@ export default function TermsGameFlow() {
   const [showPopup, setShowPopup] = useState(false);
   // 利用規約モーダル表示状態（初期で表示）
   const [showTermsModal] = useState(true);
+  // エラー差し戻しダイアログの表示状態（二段構え同意プロセスの2段目）
+  const [showErrorDialog, setShowErrorDialog] = useState(false);
   // ゲーム完了フラグ（trueで完了画面を表示→次のゲームへ遷移）
   const [isCompleted, setIsCompleted] = useState(false);
 
@@ -68,6 +79,14 @@ export default function TermsGameFlow() {
     mailMagazine: false,
     thirdPartyShare: false,
   });
+  // エラーが一度でも発火したか。afterError 判定と postErrorClicks 記録の起点
+  const hasErrorOccurredRef = useRef(false);
+  // エラー発火イベントのログ
+  const errorEventsRef = useRef<TermsErrorEvent[]>([]);
+  // エラー後のクリックストリーム（連打検出用）
+  const postErrorClicksRef = useRef<TermsPostErrorClick[]>([]);
+  // チェックボックス操作のタイムスタンプログ（afterError フラグ付き）
+  const checkboxEventsRef = useRef<TermsCheckboxEvent[]>([]);
 
   useEffect(() => {
     const bgm = new Audio('/sounds/start-bgm.mp3');
@@ -126,6 +145,19 @@ export default function TermsGameFlow() {
     }
   }, []);
 
+  // ゲーム開始からの経過時間（ms）。各種イベントログの timestamp に使う
+  const getElapsedMs = useCallback(() => Date.now() - startTimeRef.current, []);
+
+  // エラー発火後のクリックのみ記録する（postErrorClicks は Hawkes 連鎖の対象＝
+  // errorEvents 以降のクリックを見るため、エラー前のクリックは記録しない）
+  const recordPostErrorClick = useCallback(
+    (type: TermsPostErrorClick['type']) => {
+      if (!hasErrorOccurredRef.current) return;
+      postErrorClicksRef.current.push({ timestamp: getElapsedMs(), type });
+    },
+    [getElapsedMs]
+  );
+
   const handleCheckboxChange = useCallback(
     (
       key: 'readConfirm' | 'mailMagazine' | 'thirdPartyShare',
@@ -136,8 +168,18 @@ export default function TermsGameFlow() {
       se.play().catch(() => {});
       checkboxChangedRef.current[key] = true;
       setCheckboxStates((prev) => ({ ...prev, [key]: checked }));
+
+      const afterError = hasErrorOccurredRef.current;
+      checkboxEventsRef.current.push({
+        timestamp: getElapsedMs(),
+        target: key,
+        newState: { checked, changed: true },
+        afterError,
+      });
+      // エラー後のチェックボックス操作はクリックストリームにも記録する
+      if (afterError) recordPostErrorClick('checkbox');
     },
-    []
+    [getElapsedMs, recordPostErrorClick]
   );
 
   const handleHiddenInputChange = useCallback((value: string) => {
@@ -170,7 +212,7 @@ export default function TermsGameFlow() {
 
   const buildTermsGameData = useCallback(
     (action: 'agree' | 'disagree'): TermsGameData => {
-      const totalTime = Math.round((Date.now() - startTimeRef.current) / 1000);
+      const totalTime = Math.round(getElapsedMs() / 1000);
 
       return {
         totalTime,
@@ -195,15 +237,43 @@ export default function TermsGameFlow() {
         // null の場合はフィールド自体を未送信にする（JSON.stringify が undefined を省略）。
         popupStats: popupStatsRef.current ?? undefined,
         agreeButtonHoverTimeMs: getAgreeButtonHoverTimeMs(),
+        // 空配列のときはフィールドを省略する（popupStats と同方針: データがあるときのみ送る）。
+        errorEvents:
+          errorEventsRef.current.length > 0
+            ? errorEventsRef.current
+            : undefined,
+        postErrorClicks:
+          postErrorClicksRef.current.length > 0
+            ? postErrorClicksRef.current
+            : undefined,
+        checkboxEvents:
+          checkboxEventsRef.current.length > 0
+            ? checkboxEventsRef.current
+            : undefined,
       };
     },
-    [hiddenInputValue, checkboxStates, getAgreeButtonHoverTimeMs]
+    [hiddenInputValue, checkboxStates, getAgreeButtonHoverTimeMs, getElapsedMs]
   );
 
   const handleAction = useCallback(
     (action: 'agree' | 'disagree') => {
       const se = new Audio('/sounds/general-button-se.mp3');
       se.play().catch(() => {});
+
+      // 二段構えの2段目: 同意時に第5条「読みました」が未チェックならエラー差し戻し。
+      if (action === 'agree' && !checkboxStates.readConfirm) {
+        // 2回目以降の無効な同意クリックは連打として記録する
+        // （初回はこの時点で hasError=false のため recordPostErrorClick は記録しない）。
+        recordPostErrorClick('agree');
+        errorEventsRef.current.push({
+          timestamp: getElapsedMs(),
+          reason: ERROR_REASON_MISSING_READ_CONFIRM,
+          scrollPositionAtError: scrollContainerRef.current?.scrollTop ?? 0,
+        });
+        hasErrorOccurredRef.current = true;
+        setShowErrorDialog(true);
+        return;
+      }
 
       const data = buildTermsGameData(action);
       setTermsGameData(data);
@@ -218,7 +288,14 @@ export default function TermsGameFlow() {
         router.push('/diagnosis');
       }, 2000);
     },
-    [buildTermsGameData, setTermsGameData, router]
+    [
+      checkboxStates.readConfirm,
+      recordPostErrorClick,
+      getElapsedMs,
+      buildTermsGameData,
+      setTermsGameData,
+      router,
+    ]
   );
 
   if (isCompleted) {
@@ -243,6 +320,18 @@ export default function TermsGameFlow() {
           onScroll={handleScroll}
           onAction={handleAction}
           onAgreeHoverStart={handleAgreeHoverStart}
+        />
+      )}
+
+      {showErrorDialog && (
+        <ErrorDialog
+          message={ERROR_DIALOG_MESSAGE}
+          onConfirm={() => {
+            recordPostErrorClick('errorDialog');
+            setShowErrorDialog(false);
+          }}
+          onDialogClick={() => recordPostErrorClick('errorDialog')}
+          onOverlayClick={() => recordPostErrorClick('other')}
         />
       )}
     </div>

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -30,6 +30,8 @@ const REACHED_BOTTOM_THRESHOLD = 0.9;
 const ERROR_REASON_MISSING_READ_CONFIRM = 'missing_read_confirm';
 // エラー差し戻しダイアログの表示メッセージ
 const ERROR_DIALOG_MESSAGE = '未確認の必須項目があります';
+// 「同意しない」押下時に同意を促す案内ダイアログのメッセージ
+const DISAGREE_DIALOG_MESSAGE = 'ご利用には規約への同意が必要です';
 
 export default function TermsGameFlow() {
   const router = useRouter();
@@ -48,6 +50,8 @@ export default function TermsGameFlow() {
   const [showTermsModal] = useState(true);
   // エラー差し戻しダイアログの表示状態（二段構え同意プロセスの2段目）
   const [showErrorDialog, setShowErrorDialog] = useState(false);
+  // 「同意しない」押下時の同意要求ダイアログの表示状態
+  const [showDisagreeDialog, setShowDisagreeDialog] = useState(false);
   // ゲーム完了フラグ（trueで完了画面を表示→次のゲームへ遷移）
   const [isCompleted, setIsCompleted] = useState(false);
 
@@ -87,6 +91,8 @@ export default function TermsGameFlow() {
   const postErrorClicksRef = useRef<TermsPostErrorClick[]>([]);
   // チェックボックス操作のタイムスタンプログ（afterError フラグ付き）
   const checkboxEventsRef = useRef<TermsCheckboxEvent[]>([]);
+  // 「同意しない」を一度でも押したか。最終的に同意で遷移しても finalAction を 'disagree' に確定させる（本音を残す）
+  const hasPressedDisagreeRef = useRef(false);
 
   useEffect(() => {
     const bgm = new Audio('/sounds/start-bgm.mp3');
@@ -260,8 +266,17 @@ export default function TermsGameFlow() {
       const se = new Audio('/sounds/general-button-se.mp3');
       se.play().catch(() => {});
 
+      // 「同意しない」: 遷移せず、押した事実を保持して同意を促す案内ダイアログを表示。
+      // 一度でも押されたら finalAction は最終的に 'disagree' に確定する（後述の遷移処理参照）。
+      if (action === 'disagree') {
+        hasPressedDisagreeRef.current = true;
+        setShowDisagreeDialog(true);
+        return;
+      }
+
       // 二段構えの2段目: 同意時に第5条「読みました」が未チェックならエラー差し戻し。
-      if (action === 'agree' && !checkboxStates.readConfirm) {
+      // （ここに来る時点で action === 'agree' は確定）
+      if (!checkboxStates.readConfirm) {
         // 2回目以降の無効な同意クリックは連打として記録する
         // （初回はこの時点で hasError=false のため recordPostErrorClick は記録しない）。
         recordPostErrorClick('agree');
@@ -275,7 +290,10 @@ export default function TermsGameFlow() {
         return;
       }
 
-      const data = buildTermsGameData(action);
+      // 遷移は「同意する」かつ第5条チェック済みのときのみ。
+      // 一度でも「同意しない」を押していれば、翻意して同意しても本音として 'disagree' を残す。
+      const finalAction = hasPressedDisagreeRef.current ? 'disagree' : 'agree';
+      const data = buildTermsGameData(finalAction);
       setTermsGameData(data);
 
       setIsCompleted(true);
@@ -332,6 +350,13 @@ export default function TermsGameFlow() {
           }}
           onDialogClick={() => recordPostErrorClick('errorDialog')}
           onOverlayClick={() => recordPostErrorClick('other')}
+        />
+      )}
+
+      {showDisagreeDialog && (
+        <ErrorDialog
+          message={DISAGREE_DIALOG_MESSAGE}
+          onConfirm={() => setShowDisagreeDialog(false)}
         />
       )}
     </div>

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -20,7 +20,7 @@ import LoadingScreen from '@/components/common/LoadingScreen';
 // import { submitGame } from '@/lib/api';
 
 // ポップアップ広告が表示されるまでの遅延時間（ms）
-const POPUP_DELAY_MS = 15_000;
+const POPUP_DELAY_MS = 8_000;
 // スクロールイベントの記録間隔（ms）。パフォーマンスのため間引く
 const SCROLL_THROTTLE_MS = 200;
 // 「最下部まで到達した」と判定するスクロール割合（90%）

--- a/frontend/src/features/games/types/index.ts
+++ b/frontend/src/features/games/types/index.ts
@@ -17,6 +17,9 @@ export type SubmitGameResponse = components['schemas']['SubmitGameResponse'];
 export type ScrollEvent = components['schemas']['ScrollEvent'];
 export type CheckboxState = components['schemas']['CheckboxState'];
 export type PopupStats = components['schemas']['PopupStats'];
+export type TermsErrorEvent = components['schemas']['TermsErrorEvent'];
+export type TermsPostErrorClick = components['schemas']['TermsPostErrorClick'];
+export type TermsCheckboxEvent = components['schemas']['TermsCheckboxEvent'];
 export type TermsGameData = components['schemas']['TermsGameData'];
 
 // ========================================


### PR DESCRIPTION
## 概要

利用規約ゲーム（Game 1）の FE を刷新し、二段構えの同意プロセスと新規行動計測データの収集を実装する。あわせてポップアップ広告の表示タイミングを調整し、「同意しない」選択時の挙動を整備する。

BE の分析ロジック刷新（#148、HCI 6 モデル）に対応する FE 側の実装。

## 変更内容

- 第5条「読みました」未チェックでの同意押下時に、エラーダイアログ「未確認の必須項目があります」を表示して差し戻す二段構えプロセスを実装（エラー時は遷移しない）
- 新規行動データ `errorEvents` / `postErrorClicks` / `checkboxEvents` を収集して送信ペイロードに含める（BE スキーマと整合、`reason` は `missing_read_confirm` 固定）
- エラー後のクリックを 4 種別（agree / errorDialog / checkbox / other）で計測（グローバルリスナーを使わず個別 onClick で記録）
- 「同意しない」押下時は遷移せず案内ダイアログ「ご利用には規約への同意が必要です」を表示。一度でも押していれば `finalAction` を `disagree` として記録する（後から同意で遷移しても本音を残す）
- ポップアップ広告の表示タイミングを 15 秒 → 5 秒に短縮

## 動作確認（GIF）

### 1. 全体フロー

広告表示タイミング（5 秒）の確認用に、ゲーム開始から同意完了までの一連のフローを撮影。

<!-- 📎 ここに「全体フロー」の GIF を貼ってください（規約表示 → スクロール → 約5秒後に広告表示 → 同意完了まで。広告が表示されるまでの秒数が分かるように） -->
<img width="800" height="520" alt="CleanShot 2026-05-29 at 00 05 36" src="https://github.com/user-attachments/assets/e9d8424f-3a18-4742-bd26-cf2837a5978c" />


### 2. 非同意の挙動

「同意しない」を押した際に、同意するように催促。一度でも「同意しない」を押すと、データは非同意として収集

<!-- 📎 ここに「同意しないパターン」の GIF を貼ってください（同意しない押下 → 案内ダイアログ表示 → 最終的に finalAction=disagree が送信される様子。DevTools の Network / コンソールで送信データが見えるとなお良い） -->
<img width="800" height="520" alt="CleanShot 2026-05-29 at 00 08 01" src="https://github.com/user-attachments/assets/1814c167-52af-4232-b3bb-1648086885a6" />


closes #147