### PR TITLE
feat: MBTI選択画面のUIをv5モックに刷新

### DIFF
--- a/frontend/src/app/diagnosis/page.tsx
+++ b/frontend/src/app/diagnosis/page.tsx
@@ -12,7 +12,7 @@ export default function DiagnosisPage() {
       className="flex min-h-screen w-full flex-col items-center justify-center p-4"
       style={diagnosisBackgroundStyle}
     >
-      <div className="flex w-full max-w-5xl flex-1 flex-col items-center justify-center">
+      <div className="flex w-full max-w-7xl flex-1 flex-col items-center justify-center">
         <DiagnosisFlow />
       </div>
     </div>

--- a/frontend/src/features/diagnosis/components/MbtiSelect.tsx
+++ b/frontend/src/features/diagnosis/components/MbtiSelect.tsx
@@ -2,29 +2,25 @@
 
 import Image from 'next/image';
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { flushSync } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSetAtom } from 'jotai';
 import { mbtiAtom, diagnosisStepAtom } from '@/stores/diagnosis';
 import { MBTI_TYPES, MBTI_GROUPS, type MbtiType } from '@/constants/mbti';
 
-// タブとカードで同じ色を使用（ジャンルごと）
+// タブ・カード・モーダルで共有するジャンル色（分析家 / 外交官 / 番人 / 探検家）
 const GROUP_COLORS = [
-  'bg-[#E5A1F4]', // 分析家 - light purple
-  'bg-[#89F1C8]', // 外交官 - teal
-  'bg-[#8EE3FA]', // 番人 - light blue
-  'bg-[#FFD77B]', // 探検家 - light orange
+  'bg-[#E5A1F4]', // 分析家
+  'bg-[#89F1C8]', // 外交官
+  'bg-[#8EE3FA]', // 番人
+  'bg-[#FFD77B]', // 探検家
 ] as const;
 
-// 水玉模様用（ジャンルごとの色・HEX）
-const GROUP_COLOR_HEX = ['#E5A1F4', '#89F1C8', '#8EE3FA', '#FFD77B'] as const;
-
-// オーバーレイ用（ジャンルごとの少し濃い色）
-const GROUP_OVERLAY_COLORS = [
-  'bg-[#c77dd9]', // 分析家 - darker magenta
-  'bg-[#52c9a0]', // 外交官 - darker mint
-  'bg-[#55c9e8]', // 番人 - darker cyan
-  'bg-[#e6b84d]', // 探検家 - darker gold
+// キャラカード背景のグラデーション（白 → ジャンルの淡色）
+const GROUP_CARD_GRADIENT = [
+  'linear-gradient(120deg, #ffffff 52%, #f3d2ff 100%)', // 分析家
+  'linear-gradient(120deg, #ffffff 52%, #c8f8e2 100%)', // 外交官
+  'linear-gradient(120deg, #ffffff 52%, #c8effc 100%)', // 番人
+  'linear-gradient(120deg, #ffffff 52%, #ffe9b8 100%)', // 探検家
 ] as const;
 
 function getTypesByGroup(group: string): MbtiType[] {
@@ -36,9 +32,7 @@ export default function MbtiSelect() {
   const setStep = useSetAtom(diagnosisStepAtom);
   const [groupIndex, setGroupIndex] = useState(0);
   const [selected, setSelected] = useState<string | null>(null);
-  const [transitionVia, setTransitionVia] = useState<
-    'tab' | 'arrow-left' | 'arrow-right'
-  >('tab');
+  const [skipModalOpen, setSkipModalOpen] = useState(false);
   const bgmRef = useRef<HTMLAudioElement | null>(null);
 
   const playSE = useCallback((path: string) => {
@@ -47,9 +41,8 @@ export default function MbtiSelect() {
     audio.play().catch(() => {});
   }, []);
 
-  // BGMの初期化と再生管理
+  // BGM の初期化と再生管理（TopPage と同じ start-bgm を使用）
   useEffect(() => {
-    // TopPageと同じ start-bgm を使用
     const bgm = new Audio('/sounds/start-bgm.mp3');
     bgm.loop = true;
     bgm.volume = 0.4;
@@ -76,32 +69,22 @@ export default function MbtiSelect() {
     ? MBTI_TYPES.find((t) => t.code === selected)
     : null;
 
-  const handleTabClick = useCallback(
-    (index: number) => {
-      if (index === groupIndex) return;
-      // タブクリック時は transitionVia を先に 'tab' に反映してから groupIndex を更新
-      // （矢印遷移後の初回タブクリックで正しいアニメーションが使われるようにする）
-      flushSync(() => setTransitionVia('tab'));
-      setGroupIndex(index);
-      setSelected(null);
-      playSE('/sounds/general-button-se.mp3');
-    },
-    [groupIndex, playSE]
-  );
-
-  const handleArrowPrev = useCallback(() => {
-    setTransitionVia('arrow-right'); // コンテンツは右から入る
-    setGroupIndex((i) => (i - 1 + MBTI_GROUPS.length) % MBTI_GROUPS.length);
+  const handleTabClick = (index: number) => {
+    if (index === groupIndex) return;
+    setGroupIndex(index);
     setSelected(null);
     playSE('/sounds/general-button-se.mp3');
-  }, [playSE]);
+  };
 
-  const handleArrowNext = useCallback(() => {
-    setTransitionVia('arrow-left'); // コンテンツは左から入る
-    setGroupIndex((i) => (i + 1) % MBTI_GROUPS.length);
-    setSelected(null);
+  const handleSelectType = (code: string) => {
+    setSelected(code);
     playSE('/sounds/general-button-se.mp3');
-  }, [playSE]);
+  };
+
+  const handleReselect = () => {
+    playSE('/sounds/general-button-se.mp3');
+    setSelected(null);
+  };
 
   const handleConfirm = () => {
     playSE('/sounds/general-button-se.mp3');
@@ -110,217 +93,231 @@ export default function MbtiSelect() {
     setStep('quiz');
   };
 
-  const handleReselect = () => {
+  const openSkip = () => {
     playSE('/sounds/general-button-se.mp3');
-    setSelected(null);
+    setSkipModalOpen(true);
   };
 
-  const handleSkip = () => {
+  const cancelSkip = () => {
+    playSE('/sounds/general-button-se.mp3');
+    setSkipModalOpen(false);
+  };
+
+  const confirmSkip = () => {
     playSE('/sounds/general-button-se.mp3');
     setMbti(null);
     setStep('quiz');
   };
 
-  const getContentVariants = () => {
-    if (transitionVia === 'tab') {
-      return {
-        enter: { opacity: 0 },
-        center: { opacity: 1, x: 0 },
-        exit: { opacity: 0 },
-      };
-    }
-    if (transitionVia === 'arrow-left') {
-      return {
-        enter: { opacity: 0, x: 80 },
-        center: { opacity: 1, x: 0 },
-        exit: { opacity: 0, x: -80 },
-      };
-    }
-    return {
-      enter: { opacity: 0, x: -80 },
-      center: { opacity: 1, x: 0 },
-      exit: { opacity: 0, x: 80 },
-    };
-  };
-
-  const contentVariants = getContentVariants();
-
   return (
-    <div className="relative flex min-h-0 w-full flex-1 flex-col items-center justify-center py-2">
-      {/* メインカード + タブ */}
-      <div className="flex min-h-0 w-full flex-1 flex-col items-center px-1">
-        {/* 4ジャンルタブ - 左詰め、少し大きく */}
-        <div className="flex w-full justify-start gap-0">
-          {MBTI_GROUPS.map((group, index) => (
-            <motion.button
-              key={group}
-              type="button"
-              onClick={() => handleTabClick(index)}
-              className={`relative z-10 cursor-pointer rounded-t-lg border-4 border-b-0 border-gray-800 px-4 py-2 text-base font-semibold text-gray-800 ${
-                GROUP_COLORS[index]
-              } ${groupIndex === index ? 'mb-[-4px]' : ''}`}
-              animate={{
-                y: groupIndex === index ? 2 : 0,
-                boxShadow:
-                  groupIndex === index
-                    ? 'inset 0 3px 6px rgba(0,0,0,0.12)'
-                    : 'none',
-              }}
-              transition={{ duration: 0.2 }}
-            >
-              {group}
-            </motion.button>
-          ))}
+    <div className="relative flex h-full w-full flex-1 flex-col items-center justify-center gap-3.5 py-2">
+      {/* ページタイトル（白 pill バナー・カード外） */}
+      <h1 className="shrink-0 rounded-full border-4 border-gray-800 bg-white px-11 py-3 text-center text-3xl font-black text-gray-800 shadow-[0_4px_0_#1f2937]">
+        あなたのMBTIを選んでね！
+      </h1>
+
+      {/* ステージ: タブ + カード */}
+      <div className="flex max-h-[800px] w-full max-w-[1280px] min-h-0 flex-1 flex-col">
+        {/* 4ジャンルタブ（横幅4等分） */}
+        <div className="relative z-10 grid grid-cols-4 gap-1 -mb-1">
+          {MBTI_GROUPS.map((group, index) => {
+            const active = groupIndex === index;
+            return (
+              <button
+                key={group}
+                type="button"
+                onClick={() => handleTabClick(index)}
+                className={`cursor-pointer rounded-t-2xl border-4 border-b-0 border-gray-800 py-3.5 text-lg font-extrabold text-gray-800 transition-transform duration-200 ${
+                  GROUP_COLORS[index]
+                } ${
+                  active
+                    ? 'translate-y-1 shadow-[inset_0_3px_6px_rgba(0,0,0,0.12)]'
+                    : 'brightness-[1.08] saturate-[0.82] hover:-translate-y-0.5 hover:brightness-100 hover:saturate-100'
+                }`}
+              >
+                {group}
+              </button>
+            );
+          })}
         </div>
 
-        {/* カード本体 - items-center 親でも幅を確保するため w-full */}
+        {/* カード本体 */}
         <div
-          className={`relative flex w-full min-h-[70vh] max-h-[85vh] flex-1 flex-col justify-center items-center overflow-visible rounded-4xl rounded-tl-none border-4 border-gray-800 shadow-lg ${GROUP_COLORS[groupIndex]}`}
+          className={`flex min-h-0 flex-1 flex-col rounded-b-[32px] border-4 border-gray-800 px-8 pt-[22px] pb-[26px] ${GROUP_COLORS[groupIndex]}`}
         >
-          {/* わからないボタン - カード内右上 */}
-          <button
-            type="button"
-            onClick={handleSkip}
-            className="absolute right-2 top-2 z-10 cursor-pointer rounded-lg border-4 border-gray-800 bg-white px-3 py-1.5 text-sm font-medium text-gray-800 shadow-sm transition-all duration-200 hover:scale-105 hover:bg-gray-50 hover:shadow-md active:scale-95"
-          >
-            わからない
-          </button>
-          <p className="shrink-0 mb-2 pb-1 text-center text-5xl font-bold text-gray-900">
-            あなたのMBTIを選んでね！！
-          </p>
-
-          {/* キャラ表示エリア + 左右矢印 - グリッドでボタンとカードを分離 */}
-          <div className="mx-4 grid min-h-0 w-full max-h-[420px] flex-1 grid-cols-[auto_1fr_auto] items-center gap-1 px-2 py-1">
+          {/* ジャンル名 + わからないボタン */}
+          <div className="mb-3.5 flex items-center justify-between">
+            <p className="text-3xl font-black leading-none text-gray-900">
+              {currentGroup}
+            </p>
             <button
               type="button"
-              onClick={handleArrowPrev}
-              aria-label="前のジャンル"
-              className="h-0 w-0 shrink-0 cursor-pointer border-y-18 border-r-24 border-l-0 border-y-transparent border-r-white transition hover:border-r-gray-200 hover:scale-110"
-            />
+              onClick={openSkip}
+              className="shrink-0 cursor-pointer rounded-xl border-[3px] border-gray-800 bg-white px-[18px] py-[9px] text-sm font-extrabold text-gray-800 shadow-[0_3px_0_#1f2937] transition-transform duration-150 hover:-translate-y-0.5"
+            >
+              わからない
+            </button>
+          </div>
 
-            <div className="relative min-h-52 overflow-visible">
-              <AnimatePresence mode="wait" initial={false}>
-                <motion.div
-                  key={groupIndex}
-                  initial="enter"
-                  animate="center"
-                  exit="exit"
-                  variants={contentVariants}
-                  transition={{ duration: 0.25 }}
-                  className="absolute inset-0 flex items-center justify-center gap-1"
-                >
-                  <div
-                    className="flex h-full w-full items-stretch justify-center gap-2 rounded-lg bg-white px-1 py-1"
-                    style={{
-                      backgroundImage: `radial-gradient(circle, ${GROUP_COLOR_HEX[groupIndex]} 2px, transparent 2px)`,
-                      backgroundSize: '20px 20px',
-                    }}
+          {/* キャラ表示エリア（白枠内 2×2 グリッド） */}
+          <div className="flex min-h-0 flex-1 flex-col rounded-3xl border-[3px] border-gray-800 bg-white p-4">
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={groupIndex}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="grid min-h-0 flex-1 grid-cols-2 grid-rows-2 gap-4"
+              >
+                {currentTypes.map((type) => (
+                  <button
+                    key={type.code}
+                    type="button"
+                    onClick={() => handleSelectType(type.code)}
+                    style={{ background: GROUP_CARD_GRADIENT[groupIndex] }}
+                    className="grid min-h-0 cursor-pointer grid-cols-[1fr_auto] items-center gap-3 overflow-hidden rounded-[20px] border-[3px] border-gray-800 py-2 pr-7 pl-2 transition-[transform,box-shadow] duration-200 hover:-translate-y-[5px] hover:scale-[1.02] hover:shadow-[0_8px_0_#1f2937]"
                   >
-                    {currentTypes.map((type) => (
-                      <motion.button
-                        key={type.code}
-                        type="button"
-                        onClick={() => {
-                          setSelected(type.code);
-                          playSE('/sounds/general-button-se.mp3');
-                        }}
-                        className="relative z-0 flex flex-1 basis-0 flex-col cursor-pointer items-center justify-center overflow-hidden rounded-4xl border-2 border-gray-800 bg-white/80 outline-none ring-0 hover:z-50"
-                        whileHover={{
-                          scale: 1.2,
-                          y: -16,
-                          transition: { duration: 0.2 },
-                        }}
-                        whileTap={{ scale: 1.02 }}
-                        style={{ boxShadow: 'none' }}
-                      >
-                        <div className="relative flex min-h-0 flex-1 items-center justify-center w-full">
-                          <Image
-                            src={`/images/mbti/${type.code}.png`}
-                            alt={type.name}
-                            width={176}
-                            height={176}
-                            className="max-h-44 w-auto border-0 object-contain outline-none"
-                          />
-                          <div
-                            className={`absolute bottom-0 left-0 right-0 ${GROUP_OVERLAY_COLORS[groupIndex]} py-1.5 px-2 text-center`}
-                          >
-                            <p className="text-sm font-bold text-white">
-                              {type.code} / {type.name}
-                            </p>
-                          </div>
-                        </div>
-                      </motion.button>
-                    ))}
-                  </div>
-                </motion.div>
-              </AnimatePresence>
-            </div>
-
-            <button
-              type="button"
-              onClick={handleArrowNext}
-              aria-label="次のジャンル"
-              className="h-0 w-0 shrink-0 cursor-pointer border-y-18 border-l-24 border-r-0 border-y-transparent border-l-white transition hover:border-l-gray-200 hover:scale-110"
-            />
+                    {/* イラスト（下揃え + 影） */}
+                    <div className="relative flex h-full min-h-0 items-end justify-center">
+                      <div className="absolute bottom-1 left-1/2 h-3 w-[70%] -translate-x-1/2 rounded-[50%] bg-gray-800/15 blur-[4px]" />
+                      <Image
+                        src={`/images/mbti/${type.code}.png`}
+                        alt={type.name}
+                        width={160}
+                        height={160}
+                        className="relative z-[1] max-h-full w-auto object-contain"
+                      />
+                    </div>
+                    {/* MBTI コード + 名前 */}
+                    <div className="text-right">
+                      <div className="text-[56px] font-black leading-[0.95] tracking-[-0.02em] text-gray-900">
+                        {type.code}
+                      </div>
+                      <div className="mt-2 text-xl font-bold text-gray-800/80">
+                        {type.name}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </motion.div>
+            </AnimatePresence>
           </div>
         </div>
       </div>
 
-      {/* 決定確認ポップアップ */}
-      {selectedType && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="mbti-confirm-title"
-        >
-          <div
-            className={`mx-4 w-full max-w-md rounded-2xl border-4 border-gray-800 p-6 shadow-xl ${
-              GROUP_COLORS[
-                Math.max(
-                  0,
-                  MBTI_GROUPS.findIndex((g) => g === selectedType.group)
-                )
-              ]
-            }`}
+      {/* 決定確認モーダル */}
+      <AnimatePresence>
+        {selectedType && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 backdrop-blur-md"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={handleReselect}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mbti-confirm-title"
           >
-            <p
-              id="mbti-confirm-title"
-              className="text-center text-lg font-bold text-gray-900"
+            <motion.div
+              className={`mx-4 w-[380px] max-w-full rounded-[28px] border-4 border-gray-800 px-8 py-6 text-center shadow-[0_8px_0_#1f2937] ${GROUP_COLORS[groupIndex]}`}
+              initial={{ scale: 0.92 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0.92 }}
+              transition={{ duration: 0.2 }}
+              onClick={(e) => e.stopPropagation()}
             >
-              あなたのMBTIは
-            </p>
-            <div className="my-4 flex justify-center">
-              <Image
-                src={`/images/mbti/${selectedType.code}.png`}
-                alt={selectedType.name}
-                width={128}
-                height={128}
-                className="h-32 w-auto border-0 object-contain outline-none"
-              />
-            </div>
-            <p className="text-center text-xl font-bold text-gray-900">
-              {selectedType.code} / {selectedType.name}
-            </p>
-            <div className="mt-6 flex gap-4">
-              <button
-                type="button"
-                onClick={handleReselect}
-                className="flex-1 cursor-pointer rounded-lg border-4 border-gray-800 bg-white px-4 py-3 font-semibold text-gray-800 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:shadow-md active:scale-95"
+              <p
+                id="mbti-confirm-title"
+                className="mb-1.5 text-[15px] font-bold text-gray-900"
               >
-                選び直す
-              </button>
-              <button
-                type="button"
-                onClick={handleConfirm}
-                className="flex-1 cursor-pointer rounded-lg border-4 border-gray-800 bg-white px-4 py-3 font-semibold text-gray-800 transition-all duration-200 hover:scale-105 hover:bg-gray-100 hover:shadow-md active:scale-95"
+                あなたのMBTIは
+              </p>
+              <div className="mb-1 flex h-40 items-center justify-center">
+                <Image
+                  src={`/images/mbti/${selectedType.code}.png`}
+                  alt={selectedType.name}
+                  width={160}
+                  height={160}
+                  className="max-h-full w-auto object-contain"
+                />
+              </div>
+              <p className="mb-4 text-[28px] font-black text-gray-900">
+                {selectedType.code} / {selectedType.name}
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={handleReselect}
+                  className="flex-1 cursor-pointer rounded-xl border-[3px] border-gray-800 bg-white py-3 text-[15px] font-extrabold text-gray-800 shadow-[0_3px_0_#1f2937] transition-transform duration-150 hover:-translate-y-0.5"
+                >
+                  選び直す
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirm}
+                  className="flex-1 cursor-pointer rounded-xl border-[3px] border-gray-800 bg-white py-3 text-[15px] font-extrabold text-gray-800 shadow-[0_3px_0_#1f2937] transition-transform duration-150 hover:-translate-y-0.5"
+                >
+                  決定
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* スキップ確認モーダル */}
+      <AnimatePresence>
+        {skipModalOpen && (
+          <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 backdrop-blur-md"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={cancelSkip}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mbti-skip-title"
+          >
+            <motion.div
+              className="mx-4 w-[420px] max-w-full rounded-[28px] border-4 border-gray-800 bg-white px-8 py-6 text-center shadow-[0_8px_0_#1f2937]"
+              initial={{ scale: 0.92 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0.92 }}
+              transition={{ duration: 0.2 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p
+                id="mbti-skip-title"
+                className="mt-2 mb-1.5 text-lg font-extrabold text-gray-900"
               >
-                決定
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+                MBTIを選ばずに進みますか？
+              </p>
+              <p className="mb-4 text-xs text-gray-800/70">
+                わからない場合はそのまま次に進めます。
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={cancelSkip}
+                  className="flex-1 cursor-pointer rounded-xl border-[3px] border-gray-800 bg-white py-3 text-[15px] font-extrabold text-gray-800 shadow-[0_3px_0_#1f2937] transition-transform duration-150 hover:-translate-y-0.5"
+                >
+                  いいえ
+                </button>
+                <button
+                  type="button"
+                  onClick={confirmSkip}
+                  className="flex-1 cursor-pointer rounded-xl border-[3px] border-gray-800 bg-white py-3 text-[15px] font-extrabold text-gray-800 shadow-[0_3px_0_#1f2937] transition-transform duration-150 hover:-translate-y-0.5"
+                >
+                  はい、進む
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/frontend/src/features/diagnosis/components/MbtiSelect.tsx
+++ b/frontend/src/features/diagnosis/components/MbtiSelect.tsx
@@ -110,7 +110,7 @@ export default function MbtiSelect() {
   };
 
   return (
-    <div className="relative flex h-full w-full flex-1 flex-col items-center justify-center gap-3.5 py-2">
+    <div className="relative flex w-full flex-1 flex-col items-center justify-center gap-3.5 py-2">
       {/* ページタイトル（白 pill バナー・カード外） */}
       <h1 className="shrink-0 rounded-full border-4 border-gray-800 bg-white px-11 py-3 text-center text-3xl font-black text-gray-800 shadow-[0_4px_0_#1f2937]">
         あなたのMBTIを選んでね！
@@ -186,7 +186,7 @@ export default function MbtiSelect() {
                         alt={type.name}
                         width={160}
                         height={160}
-                        className="relative z-[1] max-h-full w-auto object-contain"
+                        className="relative z-[1] max-h-full w-auto max-w-full object-contain"
                       />
                     </div>
                     {/* MBTI コード + 名前 */}


### PR DESCRIPTION
## 概要

MBTI 選択画面（`/diagnosis` Step 1）の UI をデザインモック v5（`design/mbti-select` の `v5-wide-above-bigcode`）に合わせて刷新する。矢印カルーセル + 過剰な縦余白を廃し、タブのみのシンプルな選択 UI にする。

## 変更内容

- 矢印カルーセルを廃止し、4ジャンルタブのみのナビに統一
- キャラを 2×2 グリッドで表示し、MBTI 4 文字を大きく配置
- タイトルをカード外の白 pill バナーへ移動
- 「わからない」スキップに確認モーダルを追加（誤スキップ防止）
- 決定後は即 quiz へ遷移（done オーバーレイは出さない）
- 白枠の高さを flexbox（`flex-1`）で埋める構成に変更（`min-h-screen` 環境で `h-full` パーセントが解決しない余白問題を解消）
- `diagnosis` ページのコンテナ幅を拡張（`max-w-5xl` → `max-w-7xl`）

## 動作確認
<!-- ▼ ここに動作 GIF をドラッグ&ドロップで添付 ▼ -->
<img width="800" height="520" alt="CleanShot 2026-05-29 at 01 31 19" src="https://github.com/user-attachments/assets/fa2811d4-f845-48cd-a724-eed0eb99938a" />


<!-- ▲ ここに動作 GIF をドラッグ&ドロップで添付 ▲ -->