### PR TITLE
feat: 空気読みチャットのBGM・説明画面・制限時間まわりを改善

### DIFF
--- a/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
+++ b/frontend/src/features/games/group-chat/components/GroupChatGameFlow.tsx
@@ -22,7 +22,10 @@ import ChoicePad from './ChoicePad';
 import GroupChatEndedOverlay from './GroupChatEndedOverlay';
 
 const SE_PATH = '/sounds/general-button-se.mp3';
-const BGM_PATH = '/sounds/group-chat-game-bgm.mp3';
+/** オンボーディング中に流す RealYou 共通 BGM（トップページ等と同じ start-bgm） */
+const COMMON_BGM_PATH = '/sounds/start-bgm.mp3';
+/** ゲーム本編（turn-cutin / turn-active）で流すゲーム BGM */
+const GAME_BGM_PATH = '/sounds/group-chat-game-bgm.mp3';
 
 type SubmitStatus = 'loading' | 'success' | 'error';
 
@@ -43,7 +46,13 @@ export default function GroupChatGameFlow() {
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('loading');
   const [errorVariant, setErrorVariant] = useState<ErrorVariant>('retry');
   const pendingDataRef = useRef<GroupChatGameData | null>(null);
-  const bgmRef = useRef<HTMLAudioElement | null>(null);
+
+  // BGM 管理。オンボーディング中は共通 BGM、ゲーム開始（turn-cutin 以降）でゲーム BGM に
+  // 切り替える（仕分けゲームと同流儀）。「いま鳴らすべき BGM」は gamePhase から下の
+  // reconciler effect が一元決定し、activeBgmRef が現在再生中の要素を指す。
+  const commonBgmRef = useRef<HTMLAudioElement | null>(null);
+  const gameBgmRef = useRef<HTMLAudioElement | null>(null);
+  const activeBgmRef = useRef<HTMLAudioElement | null>(null);
 
   // リトライ回数は描画に直接影響しないため useRef で扱う（既存ゲームと同流儀）。
   const retryCountRef = useRef(0);
@@ -54,6 +63,12 @@ export default function GroupChatGameFlow() {
     const audio = new Audio(path);
     audio.volume = 0.5;
     audio.play().catch(() => {});
+  }, []);
+
+  /** BGM を全系統まとめて停止する（送信開始 / トップ遷移時に使う） */
+  const stopAllBgm = useCallback(() => {
+    commonBgmRef.current?.pause();
+    gameBgmRef.current?.pause();
   }, []);
 
   const scheduleRedirect = useCallback(
@@ -67,30 +82,34 @@ export default function GroupChatGameFlow() {
     [router]
   );
 
-  // BGM の初期化と再生管理
+  // BGM の初期化と自動再生制限の解除。
+  // 共通 BGM（オンボーディング）とゲーム BGM（本編）を生成する。「どちらを鳴らすか」は
+  // gamePhase から下の reconciler effect が決める。ここでは生成と、autoplay 制限の解除
+  //（最初のクリックで現在の active BGM を再生し直す）だけ行う。
   useEffect(() => {
-    const bgm = new Audio(BGM_PATH);
-    bgm.loop = true;
-    bgm.volume = 0.3;
-    bgmRef.current = bgm;
+    const common = new Audio(COMMON_BGM_PATH);
+    common.loop = true;
+    // 共通 BGM はトップページ等と音量を揃える（0.4）
+    common.volume = 0.4;
+    commonBgmRef.current = common;
 
-    // 自動再生がブロックされた場合に備え、再生に成功したときだけ
-    // click リスナーを解除する（失敗時は次のクリックで再試行できるよう残す）。
-    const playBGM = () => {
-      bgm
-        .play()
-        .then(() => {
-          window.removeEventListener('click', playBGM);
-        })
-        .catch(() => {});
+    const game = new Audio(GAME_BGM_PATH);
+    game.loop = true;
+    game.volume = 0.3;
+    gameBgmRef.current = game;
+
+    // 自動再生制限の解除: マウント直後の play() は弾かれることがあるため、最初のクリックで
+    // 「いま鳴らすべき BGM」(activeBgmRef、初期はオンボーディングの共通 BGM) を再生し直す。
+    const unlockPlay = () => {
+      activeBgmRef.current?.play().catch(() => {});
+      window.removeEventListener('click', unlockPlay);
     };
-    window.addEventListener('click', playBGM);
-    // 前の画面から継続している場合は即再生
-    playBGM();
+    window.addEventListener('click', unlockPlay);
 
     return () => {
-      bgm.pause();
-      window.removeEventListener('click', playBGM);
+      common.pause();
+      game.pause();
+      window.removeEventListener('click', unlockPlay);
     };
   }, []);
 
@@ -152,10 +171,11 @@ export default function GroupChatGameFlow() {
       pendingDataRef.current = data;
       setSubmitStatus('loading');
       // 送信開始時点で BGM を停止（成功・duplicate・error すべての経路で止める）。
-      bgmRef.current?.pause();
+      // 通常は gamePhase が submitting に移った時点で reconciler が止めるが、防御的に明示する。
+      stopAllBgm();
       await submitGroupChatGame(data);
     },
-    [submitGroupChatGame]
+    [submitGroupChatGame, stopAllBgm]
   );
 
   const handleRetry = useCallback(async () => {
@@ -171,9 +191,9 @@ export default function GroupChatGameFlow() {
     playSE(SE_PATH);
     // 古い user_id を握ったままだと同じエラーで詰むため掃除する（他画面と同流儀）。
     if (typeof window !== 'undefined') localStorage.removeItem('user_id');
-    bgmRef.current?.pause();
+    stopAllBgm();
     router.push('/');
-  }, [playSE, router]);
+  }, [playSE, router, stopAllBgm]);
 
   const {
     gamePhase,
@@ -189,6 +209,24 @@ export default function GroupChatGameFlow() {
     handleOptionHover,
     handleHistoryScroll,
   } = useGroupChatGame({ onComplete: handleComplete });
+
+  // 「いま鳴らすべき BGM」を gamePhase から一元的に決めて1系統だけ再生する。
+  //   - onboarding              … 共通 BGM（トップページ等と同じ start-bgm）
+  //   - turn-cutin / turn-active … ゲーム BGM
+  //   - submitting / completed   … 無音（結果・送信表示中は BGM を流さない）
+  // 切替は「前の要素を pause → 対象を play」。対象が未生成（null）の間は無音。
+  useEffect(() => {
+    const target =
+      gamePhase === 'onboarding'
+        ? commonBgmRef.current
+        : gamePhase === 'turn-cutin' || gamePhase === 'turn-active'
+          ? gameBgmRef.current
+          : null;
+    if (activeBgmRef.current === target) return;
+    activeBgmRef.current?.pause();
+    activeBgmRef.current = target;
+    target?.play().catch(() => {});
+  }, [gamePhase]);
 
   // SE を鳴らすようにラップ
   const startGame = useCallback(() => {

--- a/frontend/src/features/games/group-chat/components/OnboardingSlides.tsx
+++ b/frontend/src/features/games/group-chat/components/OnboardingSlides.tsx
@@ -4,8 +4,8 @@ import Image from 'next/image';
 import SlideModal from '@/components/common/SlideModal';
 import {
   CHARACTERS,
-  GAME_TAGLINE,
   INTRO_CHARACTERS,
+  ONBOARDING_INSTRUCTION,
   ONBOARDING_TITLE,
   PLAYER_INTRO_TEXT,
   SCENE_DESCRIPTION,
@@ -21,14 +21,14 @@ interface OnboardingSlidesProps {
  * 仕様書: `notion-docs/screen-design.md` の Game 3 新実装「オンボーディング画面の内容」。
  * 共通の `SlideModal`（強制チュートリアル = onClose 未指定）を 1 スライドで使用。
  *
- * 構成（参考: notion-docs に紐づくスナップショット）:
- * 1. タイトル: 黄色ステッカー風（タイトル + タグラインを 1 行併記、控えめサイズ）
- * 2. プレイヤー役割サブタイトル
- * 3. 状況説明: 黄色ベタの枠でシーンをナレーション
- * 4. 「登場人物」見出し（黄色ステッカー）+ 大きめキャラアイコン 4 人並べ（密に）
+ * 構成（仕分けゲームのオンボーディングとデザインを揃える）:
+ * 1. タイトル: 黒文字のシンプルな見出し（枠なし）
+ * 2. 指示文: タイトル直下に 1 行（「空気を読んで返信しよう」）
+ * 3. 状況説明: 黄色ベタ枠。プレイヤーの役割（PLAYER_INTRO_TEXT）+ シーンのナレーション
+ * 4. 「登場人物」見出し（黄色ステッカー）+ キャラアイコン 4 人並べ（密に）
  *
- * モーダル body は flex-col + justify-center でコンテンツを縦中央寄せし、
- * SlideModal の min-h によって生じる上下の余白を均等化する。
+ * モーダル body は flex-col + justify-center でコンテンツを縦中央寄せする。
+ * 中身はスクロールが出ないよう、各要素を控えめなサイズ・余白に収める。
  */
 export default function OnboardingSlides({ onStart }: OnboardingSlidesProps) {
   return (
@@ -37,33 +37,33 @@ export default function OnboardingSlides({ onStart }: OnboardingSlidesProps) {
       onComplete={onStart}
       completeLabel="START"
       ariaLabel="空気読みチャットゲーム 説明"
+      // body の高さ = この min-h。中身（タイトル + 指示文 + 黄色枠 + 登場人物）が
+      // 収まる高さを確保しないと SlideModal 側でスライドが overflow-y-auto になり
+      // スクロールが出る。SlideModal 既定（440/420/400）よりわずかに低い値にしつつ、
+      // 下の gap・サイズ調整で中身をコンパクトにして余白に収める。
+      classNames={{ body: 'min-h-[430px] sm:min-h-[400px] lg:min-h-[380px]' }}
     >
-      <div className="flex h-full flex-col justify-center gap-3 sm:gap-4">
-        {/* タイトル: 黄色ステッカー風（タイトル + タグラインを 1 行併記、控えめサイズ） */}
-        <div className="text-center">
-          <h2 className="inline-flex flex-wrap items-baseline justify-center gap-x-2.5 gap-y-1 rounded-xl border-[3px] border-black bg-[#f1cf44] px-4 py-1 text-base font-black tracking-[0.06em] shadow-[3px_3px_0_0_#000] sm:text-lg lg:text-xl">
-            <span>{ONBOARDING_TITLE}</span>
-            <span className="text-xs font-bold text-black/70 sm:text-sm">
-              / {GAME_TAGLINE}
-            </span>
-          </h2>
-        </div>
+      <div className="flex h-full flex-col justify-center gap-2 sm:gap-3">
+        {/* タイトル: 黒文字のシンプルな見出し（仕分けゲームと同様、枠なし） */}
+        <h2 className="text-center text-xl font-black tracking-widest sm:text-2xl lg:text-3xl">
+          {ONBOARDING_TITLE}
+        </h2>
 
-        {/* プレイヤーの役割サブタイトル */}
-        <p className="-mt-1 text-center text-xs font-bold text-gray-700 sm:text-sm">
-          {PLAYER_INTRO_TEXT}
+        {/* 指示文: タイトル直下に 1 行 */}
+        <p className="-mt-1 text-center text-sm font-bold sm:text-base lg:text-lg">
+          {ONBOARDING_INSTRUCTION}
         </p>
 
-        {/* 状況説明: 黄色ベタ枠でシーンをナレーション */}
-        <div className="rounded-lg border-2 border-black/20 bg-[#fff8dc] px-4 py-2.5 sm:px-5 sm:py-3">
-          <p className="text-xs font-bold leading-relaxed text-black sm:text-sm">
-            {SCENE_DESCRIPTION}
+        {/* 状況説明: 黄色ベタ枠。プレイヤーの役割 + シーンのナレーションを 1 段落で続ける */}
+        <div className="rounded-lg border-2 border-black/20 bg-[#fff8dc] px-4 py-2 sm:px-5 sm:py-2.5">
+          <p className="text-xs font-bold leading-snug text-black sm:text-sm">
+            {PLAYER_INTRO_TEXT}。{SCENE_DESCRIPTION}
           </p>
         </div>
 
         {/* 登場人物セクション: 黄色ステッカー見出し + キャラアイコン（密に） */}
         <section>
-          <div className="mb-3 text-center">
+          <div className="mb-2 text-center">
             <h3 className="inline-block rounded-lg border-[3px] border-black bg-[#f1cf44] px-4 py-1 text-sm font-black tracking-[0.08em] shadow-[2px_2px_0_0_#000] sm:text-base">
               登場人物
             </h3>
@@ -73,14 +73,14 @@ export default function OnboardingSlides({ onStart }: OnboardingSlidesProps) {
             {INTRO_CHARACTERS.map((c) => (
               <div
                 key={c.characterId}
-                className="flex flex-col items-center gap-1.5"
+                className="flex flex-col items-center gap-1"
               >
                 <Image
                   src={CHARACTERS[c.characterId].iconPath}
                   alt={c.role}
                   width={64}
                   height={64}
-                  className="h-14 w-14 rounded-full border-[3px] border-black bg-white object-cover shadow-[2px_2px_0_0_#000] sm:h-16 sm:w-16"
+                  className="h-12 w-12 rounded-full border-[3px] border-black bg-white object-cover shadow-[2px_2px_0_0_#000] sm:h-14 sm:w-14"
                 />
                 <span className="text-xs font-black tracking-wide sm:text-sm">
                   {c.role}

--- a/frontend/src/features/games/group-chat/data/turns.ts
+++ b/frontend/src/features/games/group-chat/data/turns.ts
@@ -129,12 +129,6 @@ export interface ChoiceOption {
   /** 内部意図 ID（1,2=協調系 / 3,4=独自系）。表示順とは独立 */
   selectedOptionId: OptionIntentId;
   text: string;
-  /**
-   * `true` の場合、この選択肢を選んでも user メッセージとしてチャットに表示しない。
-   * 「（黙って様子を見る）」などの「無反応」を意図する選択肢に付与する。
-   * BE には `selectedOptionId` のみ送るため、このフラグは FE の表示制御専用。
-   */
-  isSilent?: boolean;
 }
 
 export interface TurnDefinition {
@@ -163,7 +157,6 @@ export const TURNS: TurnDefinition[] = [
       {
         selectedOptionId: 2,
         text: '（黙って様子を見る）',
-        isSilent: true,
       }, // 協調: 同期Aに譲る／場を読む（無反応）
     ],
     timerMs: TURN_TIMER_MS[1],
@@ -182,7 +175,6 @@ export const TURNS: TurnDefinition[] = [
       {
         selectedOptionId: 3,
         text: '（黙って様子を見る）',
-        isSilent: true,
       }, // 独自: 流れに乗らない／同調しない（無反応）
     ],
     timerMs: TURN_TIMER_MS[2],
@@ -204,7 +196,6 @@ export const TURNS: TurnDefinition[] = [
       {
         selectedOptionId: 3,
         text: '（黙って様子を見る）',
-        isSilent: true,
       }, // 独自: 指名を無視（無反応）
     ],
     timerMs: TURN_TIMER_MS[3],

--- a/frontend/src/features/games/group-chat/data/turns.ts
+++ b/frontend/src/features/games/group-chat/data/turns.ts
@@ -96,15 +96,32 @@ export const T1_CATCHUP_USER_MESSAGE_MS = 500;
 export const T1_CATCHUP_ADVANCE_MS = 800;
 
 /**
- * 各ターンの制限時間。
- * - T1: 14s — 同期A 先回り発言（=5.0s 地点）後に約 9.0s の判断時間を確保
- * - T2: 15s — 上司+同期A+同期B 段階表示後に約 12.8s
+ * 制限時間の倍率。プレイヤーに考える余裕を持たせるため、基準値（TURN_TIMER_BASE_MS）を
+ * 一律に引き伸ばす。1.2〜1.5 のレンジで調整する想定（現状 1.5）。
+ * ここを変えれば全ターンの制限時間がまとめて追従する（真実の単一ソース）。
+ */
+const TIMER_SCALE = 1.5;
+
+/**
+ * 各ターンの制限時間の基準値（ms。TIMER_SCALE=1.0 のときの素の長さ）。
+ * - T1: 14s — 同期A 先回り発言（=5.0s 地点）後の判断時間を確保
+ * - T2: 15s — 上司+同期A+同期B 段階表示（〜2.2s）後の判断時間を確保
  * - T3: 7s  — 名指し返球の緊張感を出すため短め
  */
-export const TURN_TIMER_MS = {
+const TURN_TIMER_BASE_MS = {
   1: 14_000,
   2: 15_000,
   3: 7_000,
+} as const satisfies Record<1 | 2 | 3, number>;
+
+/**
+ * 各ターンの実効制限時間（ms）= 基準値 × TIMER_SCALE。
+ * 現状（×1.5）: T1=21s / T2=22.5s / T3=10.5s。
+ */
+export const TURN_TIMER_MS = {
+  1: TURN_TIMER_BASE_MS[1] * TIMER_SCALE,
+  2: TURN_TIMER_BASE_MS[2] * TIMER_SCALE,
+  3: TURN_TIMER_BASE_MS[3] * TIMER_SCALE,
 } as const satisfies Record<1 | 2 | 3, number>;
 
 // =========================================================

--- a/frontend/src/features/games/group-chat/data/turns.ts
+++ b/frontend/src/features/games/group-chat/data/turns.ts
@@ -57,10 +57,10 @@ export const INTRO_CHARACTERS: IntroCharacter[] = [
 
 export const ONBOARDING_TITLE = '空気読みチャットゲーム';
 
-/** オンボーディング: タイトル右に併記する短いタグライン（ゲームのコア体験を1語で示す） */
-export const GAME_TAGLINE = '空気を読んで返信！';
+/** オンボーディング: タイトル直下に置く1行の操作指示（仕分けゲームの「〜しよう！」と同トーン） */
+export const ONBOARDING_INSTRUCTION = '空気を読んで返信しよう！';
 
-/** オンボーディング: サブタイトル（プレイヤーの役割説明） */
+/** オンボーディング: プレイヤーの役割説明（状況説明の黄色枠の先頭に置く） */
 export const PLAYER_INTRO_TEXT = 'あなたは開発チームのメンバーの一人です';
 
 /** オンボーディング: 状況説明（タイトル下に表示する場面のナレーション） */

--- a/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
+++ b/frontend/src/features/games/group-chat/hooks/useGroupChatGame.ts
@@ -396,13 +396,17 @@ export function useGroupChatGame(options: {
           computeTurn1HoverChanged();
       }
 
-      // 無言系の選択肢（isSilent: true、例:「黙って様子を見る」）は chat に
-      // 表示しない。BE には selectedOptionId を送るので分析には影響しない。
+      // 選択した選択肢のテキストを user メッセージとして chat に表示する。
+      //「（黙って様子を見る）」のような無反応系の選択肢も、プレイヤーに「反応した」ことが
+      // 伝わるよう表示する（無表示だと反応の有無が分かりにくいため）。なお BE には
+      // selectedOptionId のみ送るので、表示の有無は分析に影響しない。上司の反応分岐
+      //（TURN2_BOSS_BRANCH）は selectedOptionId 基準のため「無反応扱い」の挙動は変わらない。
       const choice = turn.choices.find(
         (c) => c.selectedOptionId === selectedOptionId
       );
-      const userMessage: ChatMessage | null =
-        choice && !choice.isSilent ? { type: 'user', text: choice.text } : null;
+      const userMessage: ChatMessage | null = choice
+        ? { type: 'user', text: choice.text }
+        : null;
 
       // ターン1で、同期Aの先回り発言がまだ出ていないうちに答えた（早押し）場合:
       // 「同期Aの挙手 → 自分の発言」の順を必ず保つため、自分の発言の表示とターン遷移を
@@ -429,7 +433,7 @@ export function useGroupChatGame(options: {
         setTypingSpeakerId('colleague-a');
         setIsTypingIndicatorVisible(true);
 
-        // 無言系の選択肢では自分の発言を出さないので、その分の待ち時間も入れない
+        // 自分の発言を表示する分の待ち時間（choice 不在の防御で userMessage が null の場合のみ 0）
         const userMessageDelay = userMessage ? T1_CATCHUP_USER_MESSAGE_MS : 0;
 
         // 同期A「私やりましょうか！」
@@ -441,7 +445,7 @@ export function useGroupChatGame(options: {
             toChatBotMessage(T1_PREEMPT_MESSAGE),
           ]);
         }, T1_CATCHUP_TYPING_MS);
-        // 自分の発言（無言系の選択肢では出さない）
+        // 自分の発言（「（黙って様子を見る）」等も含めて表示する）
         if (userMessage) {
           trackTimeout(() => {
             setChatMessages((prev) => [...prev, userMessage]);


### PR DESCRIPTION
## 概要

空気読みグループチャット（Game 3）の体験を改善する。BGM の流し方・オンボーディング画面・「様子を見る」選択時の表示・各ターンの制限時間を見直した。

## 変更内容

### BGM の切り替え（説明画面 / ゲーム中）
- 説明画面では共通 BGM（start-bgm）、ゲーム開始（turn-cutin 以降）でゲーム BGM に切り替える。仕分けゲームと同じく `gamePhase` から「鳴らすべき BGM」を一元決定する reconciler 方式。

### オンボーディング画面の刷新
- タイトルを黒文字のシンプルな見出しに変更（黄色ステッカーを廃止）。
- タイトル直下に1行の指示文「空気を読んで返信しよう！」を追加。
- 役割文「あなたは開発チームのメンバーの一人です」を状況説明（黄色枠）の先頭へ移動。
- 共通モーダルに収まりきらずスクロールが出ていたため、高さ・余白を調整して1画面に収めた。

### 「様子を見る」選択時にメッセージを表示
- これまで無反応系の選択肢は発言を表示していなかったが、反応が分かりにくいため発言を表示するようにした。
- 表示専用フラグ `isSilent` を撤去。上司の反応分岐（`TURN2_BOSS_BRANCH`）は `selectedOptionId` 基準のため「無反応扱い」の挙動は不変。

### 制限時間を1.5倍に調整
- 考える余裕を持たせるため、基準値 × 倍率（`TIMER_SCALE`）の構成にして T1=21s / T2=22.5s / T3=10.5s にした。
- 補足: タイムアウト時に記録される `reactionTimeMs`（= 制限時間）が伸びるため、BE 分析のうち raw 値を使う `reactionStdDev`（慎重さ軸）に僅かに影響し得るが許容範囲。平均反応時間（`reactionMs`）は絶対閾値（worst 8000ms）でクランプされるため影響なし。

## 動作確認


### オンボーディング画面
<!-- ここにスクリーンショットを添付する -->
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/c7e1de6d-0d02-401b-bd22-0299841ace35" />

### 全体フロー
<!-- ここに GIF / スクリーンショットを添付する -->
<img width="800" height="520" alt="CleanShot 2026-05-29 at 03 11 48" src="https://github.com/user-attachments/assets/321c8b16-de4d-4a43-a60f-d495fcbc9742" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ゲームフェーズに応じた背景音楽の自動切り替えを実装しました。オンボーディング中と本編でそれぞれ異なるBGMが流れます。

* **改善**
  * オンボーディング画面のレイアウトと表示内容を最適化しました。
  * ゲーム進行中の時間設定ロジックを改善しました。
  * プレイヤーの選択肢に関するメッセージ表示の処理を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->