### PR TITLE
feat: 仕分けゲームのUIブラッシュアップ

### DIFF
--- a/frontend/src/features/games/sorter/components/BinTray.tsx
+++ b/frontend/src/features/games/sorter/components/BinTray.tsx
@@ -26,6 +26,12 @@ interface BinTrayProps {
    * 一致する bin を拡大 + グロー枠でハイライトし「ここでドロップできる」を視覚的に示す。
    */
   hoveredBinType: PackageType | null;
+  /**
+   * ルール変更で正解が動いた荷物を誤投入した直後にガイド表示する「正しい入れ先」bin 種別。
+   * 一致する bin をハイライト（hoveredBinType と同じ強調機構）し、上に「こっちへ！」バブルを
+   * 出して正解を示す。一定時間後に親が null へ戻す。
+   */
+  guideBinType: PackageType | null;
 }
 
 /**
@@ -46,6 +52,7 @@ export default function BinTray({
   onBinClick,
   lastFeedback,
   hoveredBinType,
+  guideBinType,
 }: BinTrayProps) {
   return (
     // bin をやや大きく見せるため最大幅を広げる（盤面の隙間解消に合わせ bin を強調）。
@@ -56,6 +63,10 @@ export default function BinTray({
         const showFeedback = lastFeedback?.binType === binType;
         // D&D 中、ポインタがこの bin の上に重なっているか（ドロップ可能の合図）
         const isDropTarget = hoveredBinType === binType;
+        // ルール変更の誤投入後、この bin が「正しい入れ先」としてガイド表示中か
+        const isGuideTarget = guideBinType === binType;
+        // グロー / 拡大パルスは「ドロップ可能」「正解ガイド」どちらでも出す（同じ強調機構を流用）
+        const isHighlighted = isDropTarget || isGuideTarget;
         return (
           <div key={binType} className="relative flex flex-col items-center">
             <motion.button
@@ -65,9 +76,9 @@ export default function BinTray({
               // document.elementFromPoint から `data-bin-type` を辿って仕分け先を特定する。
               data-bin-type={binType}
               className={`relative w-full max-h-60 ${
-                // ホバー（ドロップ可能）中はグロー / scale を framer-motion で継続パルスさせるため
-                // CSS の transition / hover scale は付けない（競合と二重補間を避ける）。
-                isDropTarget
+                // 強調（ドロップ可能 / 正解ガイド）中はグロー / scale を framer-motion で継続
+                // パルスさせるため、CSS の transition / hover scale は付けない（競合と二重補間を避ける）。
+                isHighlighted
                   ? ''
                   : 'transition-transform duration-150 hover:scale-105'
               } active:scale-95`}
@@ -78,7 +89,7 @@ export default function BinTray({
               // drop-shadow・scale 1）へ補間し、framer-motion がグローを確実にフェードアウトさせる
               // （drop-shadow ↔ 'none' は数値補間できず残留するため、同種値で補間する）。
               animate={
-                isDropTarget
+                isHighlighted
                   ? {
                       scale: [1.06, 1.12],
                       filter: [
@@ -96,7 +107,7 @@ export default function BinTray({
                     }
               }
               transition={
-                isDropTarget
+                isHighlighted
                   ? {
                       duration: 0.6,
                       repeat: Infinity,
@@ -106,7 +117,11 @@ export default function BinTray({
                   : { duration: 0.2 }
               }
               aria-label={`${PACKAGE_LABELS[binType]}の仕分け先${
-                isDropTarget ? '・ここにドロップ' : ''
+                isDropTarget
+                  ? '・ここにドロップ'
+                  : isGuideTarget
+                    ? '・こちらが正しい入れ先'
+                    : ''
               }`}
             >
               {/* bin 画像（文字・シンボル焼き込み済み）。下部に並ぶ大きな画像で LCP 候補に近いため priority 付き */}
@@ -189,6 +204,39 @@ export default function BinTray({
                   {lastFeedback.correct
                     ? `+${lastFeedback.scoreChange}`
                     : `${lastFeedback.scoreChange}`}
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {/*
+              ルール変更の誤投入後ガイド。「正しい入れ先」bin の上に「こっちへ！」バブルを
+              出し、ルール変更に気づかず旧 bin に入れ続ける理不尽さを軽減する。bin 本体は
+              isHighlighted で緑グロー + 拡大パルス（D&D ホバーと同じ強調機構を流用）。
+              継続バウンス（y の repeat: Infinity）を持つため、exit には独自 transition を
+              必ず指定する（親の repeat を継承して exit が完了せず、opacity:0 のゾンビ要素として
+              残るのを防ぐ — frontend.md の framer-motion 注意点に従う）。
+            */}
+            <AnimatePresence>
+              {isGuideTarget && (
+                <motion.div
+                  key="rule-guide"
+                  aria-hidden
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1, y: [0, -6, 0] }}
+                  exit={{
+                    opacity: 0,
+                    scale: 0.8,
+                    transition: { duration: 0.2 },
+                  }}
+                  transition={{
+                    opacity: { duration: 0.2 },
+                    scale: { duration: 0.2 },
+                    y: { duration: 0.8, repeat: Infinity, ease: 'easeInOut' },
+                  }}
+                  className="pointer-events-none absolute -top-3 left-1/2 z-30 -translate-x-1/2 -translate-y-full rounded-lg border-[3px] border-black px-3 py-1 text-sm font-black tracking-widest whitespace-nowrap text-white shadow-[3px_3px_0_0_#000] sm:text-base"
+                  style={{ backgroundColor: SORTER_UI_COLORS.success }}
+                >
+                  こっちへ！
                 </motion.div>
               )}
             </AnimatePresence>

--- a/frontend/src/features/games/sorter/components/OnboardingSlides.tsx
+++ b/frontend/src/features/games/sorter/components/OnboardingSlides.tsx
@@ -38,11 +38,11 @@ interface OnboardingSlidesProps {
  * - 強制チュートリアル用途のため `onClose` は渡さない（× / 背景クリック / ESC 不可）。
  *
  * 内容詳細:
- *   - スライド 1/2: 概要 + 2 カラム（左: 仕分け方 / 右: 操作方法）。タイトルのみ
- *     上段に置き、1 行説明は左カラム冒頭に移動。PC（lg）では操作 2 方式カードを
- *     横並びにして縦サイズを圧縮し 1 画面に収める。
+ *   - スライド 1/2: 概要 + 2 カラム（左: 仕分け方 / 右: 操作方法）。タイトルと
+ *     1 行説明を上段に置き、PC（lg）では操作 2 方式カードを横並びにして縦サイズを
+ *     圧縮し 1 画面に収める。
  *   - スライド 2/2: ルール（「目標は {TARGET_SCORE} 点！」「制限時間は
- *     {TIME_CAP_SEC} 秒！！」を話口調で強調 + 採点 1 行）
+ *     {TIME_CAP_SEC} 秒！！」を話口調で強調 + 採点 1 行 + ギミックのヒント 1 行）
  */
 export default function OnboardingSlides({
   open,
@@ -54,10 +54,10 @@ export default function OnboardingSlides({
       onComplete={onStart}
       ariaLabel="仕分けゲームのチュートリアル"
       classNames={{
-        // PC（lg）で操作 2 方式を横並びにし、サブタイトルを左カラムへ移動した結果、
-        // slide1 の縦サイズが大幅圧縮された。SlideModal 既定（440/420/400）に
-        // 近い水準で両スライドが収まる。
-        body: 'min-h-[520px] sm:min-h-[440px] lg:min-h-[400px]',
+        // PC（lg）で操作 2 方式を横並びにして slide1 の縦サイズを圧縮しつつ、
+        // 1 行説明をタイトル直下に置いた分の高さを min-h に上乗せして、主要サイズ
+        // （sm / lg）でスクロールを発生させずに両スライドを 1 画面へ収める。
+        body: 'min-h-[520px] sm:min-h-[480px] lg:min-h-[440px]',
       }}
     >
       <SlideHowToPlay />
@@ -73,13 +73,12 @@ export default function OnboardingSlides({
 /**
  * スライド 1/2: 概要 + 2 カラム（左: 仕分け方 / 右: 操作方法）。
  *
- * 上段にゲーム名のみを置き、1 行説明は左カラム冒頭に配置することで上部の
- * 縦サイズを圧縮する。下段を 2 カラム構成にして PC で 1 画面に収める。
+ * 上段にゲーム名 + 1 行説明を置く。下段を 2 カラム構成にして PC で 1 画面に収める。
  *
- * **左カラム**: 1 行説明 + 「仕分け方」見出し + 3 カテゴリーの色対応（荷物 →
+ * **左カラム**: 「仕分け方」見出し + 3 カテゴリーの色対応（荷物 →
  * 仕分け先）を 1 枚の白カード内に 3 行で並べた早見表。
  *
- * **右カラム**: 「操作方法」見出し + D&D / クリック 2 ステップの 2 方式カード。
+ * **右カラム**: 「操作方法」見出し + D&D / クリックのみの 2 方式カード。
  * 狭幅 / sm では縦積み（カード → または → カード）、PC（lg）では横並び
  * （カード | または | カード）にして縦サイズをさらに圧縮する。各操作カードの
  * 下部にはそれぞれの取消方法を併記する。
@@ -90,21 +89,21 @@ export default function OnboardingSlides({
 function SlideHowToPlay() {
   return (
     <div>
-      {/* 上段: ゲーム名のみ。1 行説明は左カラム冒頭に移動して上部の縦サイズを節約。 */}
+      {/* 上段: ゲーム名 + 1 行説明。説明はタイトル直下に置く。 */}
       <h2 className="text-center text-2xl font-black tracking-widest sm:text-3xl lg:text-4xl">
         仕分けゲーム
       </h2>
+      <p className="mt-2 text-center text-sm font-bold sm:text-base lg:text-lg">
+        流れてくる荷物を適切に仕分けよう！
+      </p>
 
       {/* 下段: 2 カラム（左: 仕分け方 / 右: 操作方法）。狭幅は縦積み、sm 以上で左右並び。
           items-stretch でカラム高さを揃え、bordered card 側を flex-1 で残り高さを
           埋めることで両カラムの黒枠カードの底辺を揃える。間に縦の区切り線を入れる。 */}
       <div className="mt-4 flex flex-col gap-4 sm:mt-5 sm:flex-row sm:items-stretch sm:gap-5 lg:gap-6">
-        {/* === 左カラム: 1 行説明 + 仕分け方（カテゴリー早見表） === */}
+        {/* === 左カラム: 仕分け方（カテゴリー早見表） === */}
         <section className="flex flex-col sm:basis-2/5">
-          <p className="text-center text-sm font-bold sm:text-base lg:text-lg">
-            流れてくる荷物を適切に仕分けよう！
-          </p>
-          <h3 className="mt-3 text-center text-base font-black tracking-widest sm:text-lg lg:text-xl">
+          <h3 className="text-center text-base font-black tracking-widest sm:text-lg lg:text-xl">
             仕分け方
           </h3>
           {/*
@@ -159,7 +158,7 @@ function SlideHowToPlay() {
           className="hidden w-px self-stretch bg-gray-300 sm:block"
         />
 
-        {/* === 右カラム: 操作方法（D&D / クリック 2 ステップ） === */}
+        {/* === 右カラム: 操作方法（D&D / クリックのみ） === */}
         <section className="flex flex-col sm:basis-3/5">
           <h3 className="text-center text-base font-black tracking-widest sm:text-lg lg:text-xl">
             操作方法（どちらでもOK！）
@@ -188,7 +187,7 @@ function SlideHowToPlay() {
                 </span>
               </div>
               {/* イラストは左カラム「仕分け方」と重複するため省略し、説明テキストのみで簡潔に。
-                  クリック 2 ステップ側と同じくらいの padding・テキスト密度で視覚的に並ぶよう調整する。 */}
+                  クリックのみ側と同じくらいの padding・テキスト密度で視覚的に並ぶよう調整する。 */}
               <p className="mt-1.5 px-2 text-center text-sm font-bold sm:mt-2 sm:px-4 sm:text-base">
                 荷物をつかんで仕分け先へドロップ
               </p>
@@ -211,7 +210,7 @@ function SlideHowToPlay() {
               </span>
             </div>
 
-            {/* 方式 B: クリック 2 ステップ。
+            {/* 方式 B: クリックのみ。
                 黒枠 + ベタ影を廃止し、link（青）系の薄背景でやさしく区別する。
                 badge の青と背景の青が呼応して「クリック方式」とひと目で分かる。 */}
             <div
@@ -223,7 +222,7 @@ function SlideHowToPlay() {
                   className="rounded-md border-[2px] border-black px-2 py-0.5 text-xs font-black tracking-wider text-white sm:text-sm"
                   style={{ backgroundColor: SORTER_UI_COLORS.link }}
                 >
-                  クリック 2 ステップ
+                  クリックのみ
                 </span>
               </div>
               <div className="mt-1.5 flex flex-col items-start justify-center gap-1 px-2 text-xs font-bold sm:mt-2 sm:px-4 sm:text-sm">
@@ -312,6 +311,14 @@ function SlideRules() {
         >
           -{SCORE_WRONG_PENALTY} 点
         </span>
+      </p>
+
+      {/* ギミックのヒント。2 倍速・機械停止・ルール変更などの具体内容は伏せ、
+          「何か起きそう」と匂わせるだけに留めてワクワク感を残す
+          （実際の演出は SorterEventBanner がゲーム中に表示する）。 */}
+      <p className="mt-6 text-center text-sm font-bold text-gray-500 sm:mt-8 sm:text-base">
+        時々<span className="mx-0.5 font-black text-black">ハプニング</span>
+        が起きるかも。
       </p>
     </div>
   );

--- a/frontend/src/features/games/sorter/components/PackageItem.tsx
+++ b/frontend/src/features/games/sorter/components/PackageItem.tsx
@@ -72,14 +72,6 @@ const PACKAGE_HIT_PADDING_PX = 14;
 const PACKAGE_HIT_SIZE_PX = PACKAGE_IMAGE_SIZE_PX + PACKAGE_HIT_PADDING_PX * 2;
 
 /**
- * 折り返し位置の X 座標を決める際の視覚的な微調整値（px）。
- * button（HIT サイズ）の左上を基準に置くと、画像中心は `buttonLeft + HIT/2` に来る。
- * `beltWidth - BELT_TURN_WIDTH_PX - PACKAGE_HIT_SIZE_PX` のままだと画像が折り返し
- * 領域の手前に寄りすぎるため、内側に少し寄せて画像をわずかに折り返しへ重ねる。
- */
-const PACKAGE_TURN_X_NUDGE_PX = 30;
-
-/**
  * 上 lane / 下 lane の中央 Y 座標（button = HIT サイズの左上基準）。
  * button 中心が lane の縦中央に来るよう HIT サイズで算出する。
  * 画像は button 内で中央寄せのため、結果として画像も lane 中央に保たれる。
@@ -259,12 +251,12 @@ export default function PackageItem({
   useEffect(() => {
     if (!scope.current || beltWidth === 0) return;
 
+    // 折り返し（縦ベルト）の中央に荷物画像を載せる。画像は button（HIT サイズ）内で
+    // 中央寄せのため、button 左端 = 縦ベルト中心 − HIT/2 とすると、画像中心が
+    // 縦ベルト中心（beltWidth − BELT_TURN_WIDTH_PX/2）に一致して左右に浮かない。
     const turnX = Math.max(
       0,
-      beltWidth -
-        BELT_TURN_WIDTH_PX -
-        PACKAGE_HIT_SIZE_PX +
-        PACKAGE_TURN_X_NUDGE_PX
+      beltWidth - BELT_TURN_WIDTH_PX / 2 - PACKAGE_HIT_SIZE_PX / 2
     );
     const controls = animate(
       scope.current,

--- a/frontend/src/features/games/sorter/components/SorterEventBanner.tsx
+++ b/frontend/src/features/games/sorter/components/SorterEventBanner.tsx
@@ -116,13 +116,13 @@ export default function SorterEventBanner({
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: -50, opacity: 0 }}
             transition={{ duration: 0.3 }}
-            className="absolute top-4 left-1/2 z-20 -translate-x-1/2 rounded-2xl border-[5px] border-black px-6 py-3 text-center shadow-[5px_5px_0_0_#000]"
+            className="absolute top-4 left-1/2 z-20 -translate-x-1/2 rounded-2xl border-[6px] border-black px-8 py-4 text-center shadow-[6px_6px_0_0_#000]"
             style={{ backgroundColor: SORTER_UI_COLORS.danger }}
           >
-            <p className="text-lg font-black tracking-widest text-white sm:text-xl">
+            <p className="text-xl font-black tracking-widest text-white sm:text-2xl">
               ルール変更！
             </p>
-            <p className="text-xs font-bold text-white sm:text-sm">
+            <p className="text-sm font-bold text-white sm:text-base">
               {RULE_CHANGE_NOTICE_TEXT}
             </p>
           </motion.div>

--- a/frontend/src/features/games/sorter/components/SorterGameFlow.tsx
+++ b/frontend/src/features/games/sorter/components/SorterGameFlow.tsx
@@ -267,6 +267,7 @@ export default function SorterGameFlow() {
     showRuleChangeNotice,
     showSpeedUpBanner,
     freezeStage,
+    ruleGuideBinType,
     isRuleChanged,
     isFrozen,
     isSpeedUp,
@@ -466,6 +467,8 @@ export default function SorterGameFlow() {
             lastFeedback={lastFeedback}
             // 機械停止中はドロップ操作が無効なのでハイライトも出さない
             hoveredBinType={isFrozen ? null : hoveredBinType}
+            // 機械停止中は bin が操作不能なので誤投入ガイドも出さない
+            guideBinType={isFrozen ? null : ruleGuideBinType}
           />
         </div>
 

--- a/frontend/src/features/games/sorter/components/SorterHUD.tsx
+++ b/frontend/src/features/games/sorter/components/SorterHUD.tsx
@@ -172,7 +172,11 @@ export default function SorterHUD({
   });
 
   return (
-    <div className="relative mx-auto h-[88px] w-full max-w-7xl">
+    // shrink-0: 縦幅が狭い環境（ブラウザのブックマークバー表示など）でも HUD を 88px から
+    // 圧縮させない。ベルト等（min-content の大きい shrink-0 要素）が flex の縮小を一方的に
+    // HUD へ押し付けると、HUD が潰れて中央のタイマー pill（HUD 内で縦中央）が下のベルトへ
+    // せり出して重なる。HUD を固定し、不足分は下側（spacer → bin）で吸収させて重なりを防ぐ。
+    <div className="relative mx-auto h-[88px] w-full max-w-7xl shrink-0">
       {/*
         === バッジエリア（左 absolute、horizontal 固定で 1 行） ===
         バッジ群は AnimatePresence で出入り。出現時は上からスライドイン + スケールイン、

--- a/frontend/src/features/games/sorter/data/sorterConstants.ts
+++ b/frontend/src/features/games/sorter/data/sorterConstants.ts
@@ -120,6 +120,14 @@ export const EVENT_ANCHORS: ReadonlyArray<{
 /** ルール変更通知バナーの表示時間（ms）。表示後に自動で消える（プレイは阻害しない） */
 export const RULE_CHANGE_NOTICE_DURATION_MS = 3_000;
 
+/**
+ * ルール変更で正解が動いた荷物（特急）を誤投入した直後、正しい入れ先 bin（重量物）を
+ * ハイライト +「こっちへ！」でガイド表示する時間（ms）。一定時間後に自動で消える。
+ * ルール変更に気づかず旧 bin に入れ続ける理不尽さを軽減するためのリアクティブなガイド
+ * （初回ミスは記録され、適応時間 ruleChangeAdaptMs などの診断シグナルは保たれる）。
+ */
+export const RULE_GUIDE_DURATION_MS = 3_000;
+
 /** 機械停止: 予告（赤バナー shake、まだ操作可）の時間（ms） */
 export const FROZEN_WARNING_DURATION_MS = 2_000;
 /** 機械停止: 停止（クリック無効化 + panicClick 計測、ベルト・荷物は流れ続ける）の時間（ms） */

--- a/frontend/src/features/games/sorter/data/sorterConstants.ts
+++ b/frontend/src/features/games/sorter/data/sorterConstants.ts
@@ -166,8 +166,14 @@ export const BELT_HEIGHT_PX = 420;
  * 荷物サイズを変える場合はこの制約を満たすこと。
  */
 export const BELT_LANE_HEIGHT_PX = 150;
-/** U 字の折り返し部分の幅（px） */
-export const BELT_TURN_WIDTH_PX = 80;
+/**
+ * U 字の折り返し（右の縦ベルト）部分の幅（px）。
+ * 縦ベルトを下る荷物がはみ出して浮かないよう、荷物画像（PackageItem.tsx の
+ * PACKAGE_IMAGE_SIZE_PX = 110px）が左右マージン付きで収まる幅にする
+ * （BELT_TURN_WIDTH_PX ≥ PACKAGE_IMAGE_SIZE_PX）。荷物は縦ベルトの中央に載るよう
+ * PackageItem 側で turnX（折り返し X 座標）を算出する。
+ */
+export const BELT_TURN_WIDTH_PX = 140;
 
 /** ベルトのシマシマパターン 1 周分（秒、通常速度）。荷物アニメと別系統 */
 export const BELT_FLOW_DURATION_SEC = 1.2;

--- a/frontend/src/features/games/sorter/hooks/useSorterGame.ts
+++ b/frontend/src/features/games/sorter/hooks/useSorterGame.ts
@@ -18,6 +18,7 @@ import {
   RECOVERY_DURATION_MS,
   RULE_CHANGE_NOTICE_DURATION_MS,
   RULE_CHANGED_CORRECT_BIN,
+  RULE_GUIDE_DURATION_MS,
   SCORE_CORRECT,
   SCORE_WRONG_PENALTY,
   SPAWN_INTERVAL_MS,
@@ -160,6 +161,13 @@ export function useSorterGame(options: {
   const [isSpeedUp, setIsSpeedUp] = useState(false);
   /** 速度上昇予告バナーの表示フラグ（発火直後 SPEED_UP_BANNER_DURATION_MS 表示） */
   const [showSpeedUpBanner, setShowSpeedUpBanner] = useState(false);
+  /**
+   * ルール変更で正解が動いた荷物（特急）を誤投入した直後に、正しい入れ先 bin（重量物）を
+   * ハイライト +「こっちへ！」でガイド表示する種別。RULE_GUIDE_DURATION_MS 後に null へ戻す。
+   */
+  const [ruleGuideBinType, setRuleGuideBinType] = useState<PackageType | null>(
+    null
+  );
 
   // =========================================================
   // 計測データ（再 render 不要なので ref で管理）
@@ -187,6 +195,13 @@ export function useSorterGame(options: {
   const ruleChangeAdaptMsRef = useRef<number | null>(null);
   /** ルール変更後の初正解判定フラグ（true = まだ未適応） */
   const firstCorrectAfterRuleChangeRef = useRef(true);
+
+  /**
+   * 誤投入ガイドの世代トークン。誤投入のたびにインクリメントし、自動消去の trackTimeout は
+   * 自分が起動した世代と一致するときだけ消す。これにより連続ミス時に、前のミスのタイマーが
+   * 後のミスのガイドを早く消してしまうのを防ぐ（lastFeedback の `at` と同趣旨）。
+   */
+  const ruleGuideTokenRef = useRef(0);
 
   /** displayScore の最新値を ref で保持（ハンドラ内で setState 前の累計に加算する用） */
   const displayScoreRef = useRef(0);
@@ -314,6 +329,10 @@ export function useSorterGame(options: {
       events: [...eventsRef.current],
     };
 
+    // 終了時に誤投入ガイドの state を確実に消す（自動消去タイマーを一括 clear するため、
+    // 残っていると state が固着しうる。結果オーバーレイの下に取り残さない）。
+    setRuleGuideBinType(null);
+
     setOutcome(result);
     setPhase('ended');
     onCompleteRef.current(data);
@@ -354,6 +373,10 @@ export function useSorterGame(options: {
       setFreezeStage('frozen');
       setSelectedPackageId(null);
       selectedAtRef.current = null;
+      // 停止突入時は誤投入ガイドも消す。token も進めて、保留中の自動消去タイマーや
+      // 停止明けにガイドが点滅復活しないよう無効化する（表示側でも frozen 中はマスク済み）。
+      ruleGuideTokenRef.current += 1;
+      setRuleGuideBinType(null);
 
       trackTimeout(() => {
         // 復旧
@@ -602,6 +625,23 @@ export function useSorterGame(options: {
       firstCorrectAfterRuleChangeRef.current = false;
     }
 
+    // 誤投入ガイドの出し入れ（ルール変更で正解が動いた荷物 = 特急 のときのみ）。
+    // 誤投入時は正しい入れ先 bin（重量物）を RULE_GUIDE_DURATION_MS ハイライトし、
+    // ルール変更に気づかず旧 bin に入れ続ける理不尽さを軽減する。正しく入れ直せたら即解除。
+    // token で「最新の誤投入が起動したタイマーだけが消せる」ようにし、連続ミスで早く消えないようにする。
+    if (touchesChangedRule) {
+      if (correct) {
+        ruleGuideTokenRef.current += 1;
+        setRuleGuideBinType(null);
+      } else {
+        const token = (ruleGuideTokenRef.current += 1);
+        setRuleGuideBinType(correctBin);
+        trackTimeout(() => {
+          if (ruleGuideTokenRef.current === token) setRuleGuideBinType(null);
+        }, RULE_GUIDE_DURATION_MS);
+      }
+    }
+
     // hesitation 蓄積
     hesitationSumRef.current += hesitationMs;
     hesitationSamplesRef.current += 1;
@@ -804,6 +844,7 @@ export function useSorterGame(options: {
     showRuleChangeNotice,
     showSpeedUpBanner,
     freezeStage,
+    ruleGuideBinType,
     // 派生値
     isRuleChanged,
     isFrozen,


### PR DESCRIPTION
## 概要

仕分けゲームの UI ブラッシュアップ。説明モーダルの文言・レイアウト調整、ベルト表示の不具合修正、ルール変更まわりの UX 改善、狭い縦幅でのタイマー重なり修正をまとめて対応する。フロントエンドのみの変更。

## 変更内容

- **説明モーダル**: サブ説明「流れてくる荷物を…」をタイトル直下へ移動 / ギミックは具体名を伏せ「時々ハプニングが起きるかも。」のヒント文に / 操作表記を「クリック2ステップ」→「クリックのみ」に変更 / スクロール抑止のため min-h を調整
- **ベルト**: 右の縦ベルトから荷物がはみ出して浮く不具合を修正（縦ベルト幅を 80→140px に拡張し、荷物が縦ベルトの中央に載るよう turnX を算出）
- **通知バナー**: ルール変更通知を少し大きく
- **誤投入ガイド**: ルール変更中に「特急」を誤った bin に入れた直後、正解の「重量物」bin を緑グロー +「こっちへ！」で誘導（3秒/正解で解除、初回ミスは記録され診断シグナルは維持）
- **タイマー重なり**: 縦幅が狭い環境（ブラウザのブックマークバー表示など）でタイマーがベルトに重なる不具合を修正（HUD を shrink-0 で固定）

## スクリーンショット / 動作GIF

<!--
各変更のスクショ / GIF を下に貼ってください。貼りやすいよう、項目ごとに「どんな画があると伝わりやすいか」をコメントで書いています。
「（ここに貼る）」の行を画像ドラッグ&ドロップで置き換えるだけでOK（不要な項目は削除可）。
GIF は QuickTime 画面収録 → Gifski / ezgif などで変換すると軽くて貼りやすいです。
-->

### 説明モーダル
<!--
静止画でOK。開始直後のオンボーディング モーダル。
- スライド1: タイトル直下にサブ説明、操作カードが「クリックのみ」表記
- スライド2: 最下部に「時々ハプニングが起きるかも。」のヒント
- できれば PC幅(lg)と狭い幅(sm)の2枚があると、スクロールが出ないことが伝わる
-->
<img width="2940" height="1912" alt="CleanShot 2026-05-29 at 04 00 14@2x" src="https://github.com/user-attachments/assets/cfd29b96-c305-4a18-b103-9395950e3969" />
<img width="2940" height="1912" alt="CleanShot 2026-05-29 at 04 00 41@2x" src="https://github.com/user-attachments/assets/7b17a9fa-90ea-48fc-948d-334bad5cef97" />

### ゲーム
<img width="2940" height="1912" alt="CleanShot 2026-05-29 at 04 01 37@2x" src="https://github.com/user-attachments/assets/fd46a976-8dc9-4301-9063-092203740053" />
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/2b71cefe-d16c-491c-a49a-ce1931f92db5" />
