### PR TITLE
fix: 5軸スライダーの▼マーカーのラベルを実データに合わせて修正

### DIFF
--- a/frontend/src/features/result/components/OverviewTab.tsx
+++ b/frontend/src/features/result/components/OverviewTab.tsx
@@ -84,7 +84,7 @@ export default function OverviewTab({ data }: OverviewTabProps) {
           あなたの５軸ポジション（本能＝実測）
         </span>
         <span className="five-axis-headline">
-          あなたのMBTIの目安
+          あなたの自己申告の目安
           <span className="average-icon">▼</span>
         </span>
 


### PR DESCRIPTION
## Summary
- 総合結果画面の5軸スライダーにある ▼ マーカーのラベルを「あなたのMBTIの目安」→「あなたの自己申告の目安」に変更。
- ▼ マーカーが指している値は `baseline_scores`（事前アンケート × MBTI理論値の 70:30 ブレンド）であり、純粋なMBTI理論値ではないため、ラベルと実データの意味を一致させた。

## 変更ファイル
- `frontend/src/features/result/components/OverviewTab.tsx`（文言1行のみ）

## 影響範囲
- 表示文言のみの変更。挙動・データ・型には一切影響なし。

## Test plan
- [ ] 結果画面（総合）で ▼ マーカー上部のラベルが「あなたの自己申告の目安」と表示される
- [ ] それ以外の表示・スライダー挙動に変化がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル/UI更新**
  * 概要タブの右カラム見出しの説明テキストを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->