### PR TITLE
feat: 結果詳細ページにも「もう一度診断」ボタンを追加

### DIFF
--- a/frontend/src/features/result/components/ResultReport.tsx
+++ b/frontend/src/features/result/components/ResultReport.tsx
@@ -233,6 +233,15 @@ export default function ResultReport({ data }: ResultReportProps) {
               </button>
 
               <SharePanel title={data.feedback.title} userId={data.user_id} />
+
+              <button
+                type="button"
+                onClick={handleRetake}
+                className="btn-action-new"
+              >
+                <RefreshCw style={{ width: 16, height: 16 }} />
+                もう一度診断
+              </button>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary
- 結果画面の詳細モードのフッターに「もう一度診断」ボタンを追加。
- これまで総合結果モードのフッターにのみ存在していたが、詳細ページを見たまま再診断したいニーズに対応。
- 既存の `handleRetake` ハンドラと文言・スタイル（`RefreshCw` アイコン + `btn-action-new`）をそのまま再利用し、画面間で挙動・表記を統一。

## 変更ファイル
- `frontend/src/features/result/components/ResultReport.tsx`

## 影響範囲
- 詳細モードのフッターにボタンが1つ増えるのみ。総合モードや他の挙動には影響なし。
- tsc / eslint 通過確認済み。

## Test plan
- [ ] 結果画面で「詳細を見る」→ 詳細モードのフッターに「もう一度診断」ボタンが表示される
- [ ] そのボタンを押すと（既存の総合モードと同様に）localStorage の user_id がクリアされトップへ遷移する
- [ ] 総合モードのフッターは従来どおり

🤖 Generated with [Claude Code](https://claude.com/claude-code)