### PR TITLE
feat: 共有ページに総合グラフ・詳細を表示＋ツイートにハッシュタグ追加

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -155,6 +155,45 @@
   height: auto;
 }
 
+/* 自己認識精度バッジ（総合結果の左パネル・解析コメント下） */
+.accuracy-badge {
+  margin-top: 14px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  background: #fef08a;
+  border: 4px solid #000;
+  border-radius: 14px;
+  padding: 8px 18px;
+  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.15);
+}
+
+.accuracy-badge-label {
+  font-size: 14px;
+  font-weight: 900;
+  color: #555;
+  letter-spacing: 0.04em;
+}
+
+.accuracy-badge-value {
+  font-size: 34px;
+  font-weight: 900;
+  color: #f87171;
+  line-height: 1;
+  text-shadow:
+    -2px -2px 0 #000,
+    2px -2px 0 #000,
+    -2px 2px 0 #000,
+    2px 2px 0 #000;
+}
+
+.accuracy-badge-unit {
+  font-size: 18px;
+  margin-left: 2px;
+}
+
 .comment-container-detail {
   background: #fffce8;
   padding: 16px 20px;
@@ -357,6 +396,9 @@
   top: 0;
   height: 100%;
   z-index: 2;
+  transition:
+    left 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    width 0.7s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .slider-pin-point {
@@ -367,7 +409,7 @@
   height: 18px;
   background: #000;
   z-index: 4;
-  transition: left 0.4s ease;
+  transition: left 0.7s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Detail page */

--- a/frontend/src/app/share/[userId]/page.tsx
+++ b/frontend/src/app/share/[userId]/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import { unstable_cache } from 'next/cache';
 import { getResult } from '@/lib/api';
 import { SITE_URL } from '@/constants/site';
+import type { ResultResponse } from '@/features/result/types';
+import ShareResultView from '@/features/result/components/ShareResultView';
 
 export const revalidate = 3600;
 
@@ -51,17 +52,21 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function SharePage({ params }: Props) {
   const { userId } = await params;
 
-  let title: string | null = null;
-  let subtitle: string | null = null;
-
+  let result: ResultResponse | null = null;
   try {
-    const result = await getCachedResult(userId);
-    title = result.feedback.title;
-    subtitle = result.feedback.subtitle ?? null;
+    result = await getCachedResult(userId);
   } catch {
-    // 無効なユーザーIDでもフォールバック表示
+    // 無効なユーザーID等は null のままフォールバック表示
+    result = null;
   }
 
+  // 結果が取得できた場合は、本人の結果画面と同じ総合グラフ＋詳細タブを
+  // 閲覧専用ビューで表示する。
+  if (result) {
+    return <ShareResultView data={result} />;
+  }
+
+  // 取得失敗時のフォールバック（無効な user_id など）
   return (
     <div
       className="slide-container bg-top-pattern"
@@ -72,144 +77,40 @@ export default async function SharePage({ params }: Props) {
         alignItems: 'center',
         justifyContent: 'center',
         padding: '24px 20px',
+        textAlign: 'center',
+        gap: 24,
+        fontFamily: "'M PLUS Rounded 1c', sans-serif",
       }}
     >
-      <div
+      <p
         style={{
-          background: '#fff',
-          border: '6.5px solid #000',
-          borderRadius: 28,
-          boxShadow: '12px 12px 0px rgba(0,0,0,0.15)',
-          padding: '40px 48px',
-          maxWidth: 480,
-          width: '100%',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 20,
-          textAlign: 'center',
-          fontFamily: "'M PLUS Rounded 1c', sans-serif",
+          fontSize: 18,
+          fontWeight: 900,
+          color: '#555',
+          margin: 0,
         }}
       >
-        {/* ロゴ */}
-        <Image
-          src="/images/RealYouLogo.png"
-          alt="Real You"
-          width={180}
-          height={60}
-          style={{ objectFit: 'contain' }}
-        />
+        行動解析REPORTの結果が見つかりませんでした。
+      </p>
 
-        {/* タイプ表示エリア */}
-        {title ? (
-          <>
-            <p
-              style={{
-                fontSize: 13,
-                fontWeight: 900,
-                color: '#666',
-                margin: 0,
-                letterSpacing: '0.06em',
-              }}
-            >
-              ゲームが導き出した、この人の本当の姿は...
-            </p>
-
-            <div
-              style={{
-                background: '#fef08a',
-                border: '5px solid #000',
-                borderRadius: 18,
-                padding: '10px 28px 18px',
-                boxShadow: '3px 3px 0px #636262',
-              }}
-            >
-              <p
-                style={{
-                  fontSize: 42,
-                  fontWeight: 950,
-                  margin: 0,
-                  lineHeight: 1.1,
-                  color: '#f87171',
-                  textShadow:
-                    '-2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000, 4px 4px 0 rgba(0,0,0,0.25)',
-                }}
-              >
-                {title}
-              </p>
-            </div>
-
-            {subtitle && (
-              <p
-                style={{
-                  fontSize: 16,
-                  fontWeight: 900,
-                  color: '#555',
-                  margin: 0,
-                }}
-              >
-                {subtitle}
-              </p>
-            )}
-          </>
-        ) : (
-          <p
-            style={{
-              fontSize: 16,
-              fontWeight: 900,
-              color: '#555',
-              margin: 0,
-            }}
-          >
-            行動解析REPORTの結果が見つかりませんでした。
-          </p>
-        )}
-
-        {/* 区切り */}
-        <div
-          style={{
-            width: '100%',
-            borderTop: '3px dashed #e2e8f0',
-            margin: '4px 0',
-          }}
-        />
-
-        {/* 煽り文 */}
-        <p
-          style={{
-            fontSize: 15,
-            fontWeight: 900,
-            color: '#333',
-            margin: 0,
-            lineHeight: 1.7,
-          }}
-        >
-          あなたも3つのゲームで、
-          <br />
-          <span style={{ color: '#f87171' }}>本当の自分</span>
-          を暴き出してみよう。
-        </p>
-
-        {/* CTA ボタン */}
-        <Link
-          href="/"
-          style={{
-            background: '#000',
-            color: '#fff',
-            border: '4px solid #000',
-            borderRadius: 50,
-            padding: '12px 40px',
-            fontSize: 16,
-            fontWeight: 950,
-            textDecoration: 'none',
-            boxShadow: '4px 4px 0px #f97316',
-            display: 'inline-block',
-            letterSpacing: '0.04em',
-          }}
-        >
-          自分も診断する →
-        </Link>
-      </div>
+      <Link
+        href="/"
+        style={{
+          background: '#000',
+          color: '#fff',
+          border: '4px solid #000',
+          borderRadius: 50,
+          padding: '12px 40px',
+          fontSize: 16,
+          fontWeight: 900,
+          textDecoration: 'none',
+          boxShadow: '4px 4px 0px #f97316',
+          display: 'inline-block',
+          letterSpacing: '0.04em',
+        }}
+      >
+        自分も診断する →
+      </Link>
     </div>
   );
 }

--- a/frontend/src/features/result/components/BipolarSlider.tsx
+++ b/frontend/src/features/result/components/BipolarSlider.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 // 各軸の左端ラベル（0側）と右端ラベル（100側）
 const AXIS_POLES: Record<string, { left: string; right: string }> = {
   caution: { left: '大胆', right: '慎重' },
@@ -44,9 +46,29 @@ export default function BipolarSlider({
   // フィルとピンは常に (100-score)% の位置を境界とする
   const boundary = 100 - score;
 
+  // マウント後に false → true へ切り替え、CSS transition でバー/ピンを
+  // 「空」の状態から実値まで伸ばすアニメーションを発火させる。
+  const [animated, setAnimated] = useState(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setAnimated(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // 境界（ピン位置）。アニメ前は各ポール端（左モード=0% / 右モード=100%）に寄せ、
+  // アニメ後に boundary% へ。fill は端から伸びる形になる。
+  const pinLeft = animated ? `${boundary}%` : isRight ? '100%' : '0%';
+
   const fillStyle: React.CSSProperties = isRight
-    ? { background: '#4d85ff', left: `${boundary}%`, right: 0 }
-    : { background: '#f97316', left: 0, width: `${boundary}%` };
+    ? {
+        background: '#4d85ff',
+        left: animated ? `${boundary}%` : '100%',
+        right: 0,
+      }
+    : {
+        background: '#f97316',
+        left: 0,
+        width: animated ? `${boundary}%` : '0%',
+      };
 
   return (
     <div className="mbti-slider-row-new">
@@ -69,10 +91,7 @@ export default function BipolarSlider({
         <div className="slider-wrapper">
           <div className="slider-line-track">
             <div className="slider-color-fill" style={fillStyle} />
-            <div
-              className="slider-pin-point"
-              style={{ left: `${boundary}%` }}
-            />
+            <div className="slider-pin-point" style={{ left: pinLeft }} />
           </div>
 
           {/* ▼ ベースラインマーカー（baselineScore が渡されたときのみ）

--- a/frontend/src/features/result/components/OverviewTab.tsx
+++ b/frontend/src/features/result/components/OverviewTab.tsx
@@ -44,7 +44,7 @@ const AXES = [
 ] as const;
 
 export default function OverviewTab({ data }: OverviewTabProps) {
-  const { feedback, scores, baseline_scores } = data;
+  const { feedback, scores, baseline_scores, accuracy_score } = data;
 
   return (
     <div className="total-layout-reconstructed">
@@ -75,6 +75,15 @@ export default function OverviewTab({ data }: OverviewTabProps) {
               </p>
             ))}
           </div>
+        </div>
+
+        {/* 自己認識精度バッジ（自己申告と実測の一致度） */}
+        <div className="accuracy-badge">
+          <span className="accuracy-badge-label">自己認識精度</span>
+          <span className="accuracy-badge-value">
+            {accuracy_score}
+            <span className="accuracy-badge-unit">%</span>
+          </span>
         </div>
       </div>
 

--- a/frontend/src/features/result/components/SharePanel.tsx
+++ b/frontend/src/features/result/components/SharePanel.tsx
@@ -11,7 +11,7 @@ type SharePanelProps = {
 
 function buildShareText(title: string, userId: string): string {
   const shareUrl = `${SITE_URL}/share/${userId}`;
-  return `私の行動解析結果は「${title}」でした！\n#技育博 #RealYou #本当の私じゃだめですか #行動解析REPORT\n${shareUrl}`;
+  return `私の行動解析結果は「${title}」でした！\n#技育博 #RealYou #本当の私じゃだめですか\n${shareUrl}`;
 }
 
 export default function SharePanel({ title, userId }: SharePanelProps) {

--- a/frontend/src/features/result/components/SharePanel.tsx
+++ b/frontend/src/features/result/components/SharePanel.tsx
@@ -11,7 +11,7 @@ type SharePanelProps = {
 
 function buildShareText(title: string, userId: string): string {
   const shareUrl = `${SITE_URL}/share/${userId}`;
-  return `私の行動解析結果は「${title}」でした！\n#行動解析REPORT\n${shareUrl}`;
+  return `私の行動解析結果は「${title}」でした！\n#技育博 #RealYou #本当の私じゃだめですか #行動解析REPORT\n${shareUrl}`;
 }
 
 export default function SharePanel({ title, userId }: SharePanelProps) {

--- a/frontend/src/features/result/components/ShareResultView.tsx
+++ b/frontend/src/features/result/components/ShareResultView.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { GameId, ResultResponse } from '../types';
+import { GAME_META } from '../data/gameMeta';
+import GameDetailTab from './GameDetailTab';
+import OverviewTab from './OverviewTab';
+
+type Mode = 'overview' | 'detail';
+
+/** ゲーム色 → CSS クラス名のマッピング（ResultReport と同一） */
+const COLOR_TO_BTN_CLASS: Record<string, string> = {
+  '#ef4444': 'btn-red',
+  '#f97316': 'btn-orange',
+  '#22c55e': 'btn-green',
+  '#3b82f6': 'btn-blue',
+  '#4d85ff': 'btn-blue',
+};
+
+type ShareResultViewProps = {
+  data: ResultResponse;
+};
+
+/**
+ * 共有リンク（/share/[userId]）専用の「閲覧専用」結果ビュー。
+ *
+ * ResultReport をベースに、訪問者向けに以下を除外/差し替えた読み取り専用版:
+ * - BGM 自動再生・効果音なし
+ * - 「もう一度診断」ボタン（訪問者の localStorage を消す副作用）なし
+ * - シェアパネルなし
+ * - フッターの主要 CTA を「自分も診断する →」(トップへの導線) に差し替え
+ *
+ * 総合（5軸グラフ）と詳細（ゲームごとのタブ）の表示は本人の結果画面と同じ
+ * OverviewTab / GameDetailTab を再利用する。
+ */
+export default function ShareResultView({ data }: ShareResultViewProps) {
+  const [mode, setMode] = useState<Mode>('overview');
+  const [activeGameId, setActiveGameId] = useState<GameId | null>(
+    data.details[0]?.game_id ?? null
+  );
+
+  const handleGoDetail = () => {
+    setMode('detail');
+    setActiveGameId(data.details[0]?.game_id ?? null);
+  };
+  const handleGoOverview = () => setMode('overview');
+  const handleGameTab = (gameId: GameId) => setActiveGameId(gameId);
+
+  // ゲームタブリスト（details 配列の順序に従う）
+  const gameTabs = data.details.flatMap((detail) => {
+    const meta = GAME_META[detail.game_id];
+    if (!meta) return [];
+    return [{ gameId: detail.game_id, meta, detail }];
+  });
+
+  const activeDetail =
+    gameTabs.find((t) => t.gameId === activeGameId)?.detail ?? null;
+
+  return (
+    /* 外側：トップページと同じ SVG 水玉背景 */
+    <div
+      className="slide-container bg-top-pattern"
+      style={{
+        minHeight: '100vh',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '20px 35px',
+        position: 'relative',
+      }}
+    >
+      {/* メインカード */}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 10,
+          width: '100%',
+          maxWidth: 1100,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* ===== ホワイトカード ===== */}
+        <div
+          className="main-card"
+          style={
+            mode === 'detail'
+              ? {
+                  height: 'calc(100vh - 130px)',
+                  overflow: 'hidden',
+                  flexDirection: 'column',
+                }
+              : { flexDirection: 'column' }
+          }
+        >
+          {/* 詳細モード：ゲームタブナビ */}
+          {mode === 'detail' && (
+            <nav
+              className="game-nav-reconstructed"
+              style={{ marginTop: 0, marginBottom: 12 }}
+            >
+              {gameTabs.map(({ gameId, meta }) => {
+                const isActive = activeGameId === gameId;
+                const Icon = meta.icon;
+                const btnColorClass =
+                  COLOR_TO_BTN_CLASS[meta.color] ?? 'btn-blue';
+                return (
+                  <button
+                    key={gameId}
+                    type="button"
+                    onClick={() => handleGameTab(gameId)}
+                    className={`game-tab-btn${isActive ? ` active ${btnColorClass}` : ''}`}
+                  >
+                    <Icon
+                      style={{
+                        width: 14,
+                        height: 14,
+                        color: isActive ? '#fff' : meta.color,
+                      }}
+                    />
+                    {meta.label}
+                  </button>
+                );
+              })}
+            </nav>
+          )}
+
+          {/* コンテンツ */}
+          <div style={mode === 'detail' ? { flex: 1, minHeight: 0 } : undefined}>
+            {mode === 'overview' && <OverviewTab data={data} />}
+            {mode === 'detail' && activeDetail && (
+              <GameDetailTab
+                detail={activeDetail}
+                tabColor={
+                  activeGameId ? GAME_META[activeGameId]?.color : '#3b82f6'
+                }
+              />
+            )}
+          </div>
+        </div>
+
+        {/* ===== フッターボタン ===== */}
+        <div className="footer-actions-reconstructed">
+          {mode === 'overview' ? (
+            /* 総合結果モードのフッター */
+            <>
+              <Link
+                href="/"
+                className="btn-action-new"
+                style={{ textDecoration: 'none' }}
+              >
+                自分も診断する →
+              </Link>
+
+              <button
+                type="button"
+                onClick={handleGoDetail}
+                className="btn-action-new btn-orange-grad btn-primary-large"
+              >
+                詳細を見る →
+              </button>
+            </>
+          ) : (
+            /* 詳細モードのフッター */
+            <>
+              <button
+                type="button"
+                onClick={handleGoOverview}
+                className="btn-action-new"
+              >
+                ← 戻る
+              </button>
+
+              <Link
+                href="/"
+                className="btn-action-new btn-orange-grad btn-primary-large"
+                style={{ textDecoration: 'none' }}
+              >
+                自分も診断する →
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/result/components/ShareResultView.tsx
+++ b/frontend/src/features/result/components/ShareResultView.tsx
@@ -129,7 +129,9 @@ export default function ShareResultView({ data }: ShareResultViewProps) {
           )}
 
           {/* コンテンツ */}
-          <div style={mode === 'detail' ? { flex: 1, minHeight: 0 } : undefined}>
+          <div
+            style={mode === 'detail' ? { flex: 1, minHeight: 0 } : undefined}
+          >
             {mode === 'overview' && <OverviewTab data={data} />}
             {mode === 'detail' && activeDetail && (
               <GameDetailTab


### PR DESCRIPTION
## Summary
共有機能を拡張し、リンク先で「タイプ名だけ」でなく結果の中身まで見えるようにした。

- **共有ページ（`/share/[userId]`）を閲覧専用の結果ビューに刷新**
  - 本人の結果画面と同じ `OverviewTab`（5軸グラフ）＋ `GameDetailTab`（ゲームごとの詳細タブ）を表示
  - 訪問者向けに **BGM/効果音・「もう一度診断」ボタン・シェアパネルを除外**（再診断ボタンは訪問者の localStorage を消す副作用があるため）
  - フッターの主要導線を「自分も診断する →」（トップ遷移）に差し替え
  - 結果取得失敗時（無効な user_id 等）はフォールバック表示を維持
- **シェア文にハッシュタグを追加**: `#技育博 #RealYou #本当の私じゃだめですか`（既存の `#行動解析REPORT` は維持）

OGPカード画像（タイムラインのプレビュー）は今回は変更なし（指定どおりリンク先ページのみ拡張）。

## 変更ファイル
- `frontend/src/features/result/components/ShareResultView.tsx`（新規・閲覧専用ビュー）
- `frontend/src/app/share/[userId]/page.tsx`（結果取得→ShareResultView 表示へ刷新、`generateMetadata` は変更なし）
- `frontend/src/features/result/components/SharePanel.tsx`（シェア文にハッシュタグ追加）

## 影響範囲
- 本人の結果画面（`ResultReport`）には変更なし。
- tsc / eslint / `next build` 通過確認済み（`/share/[userId]` は dynamic SSR）。

## Test plan
- [ ] 結果画面で「結果をシェア」→ X/LINE/コピーのテキストに `#技育博 #RealYou #本当の私じゃだめですか` が含まれる
- [ ] 共有リンクを開くと 5軸グラフ（総合）が表示される
- [ ] 「詳細を見る →」でゲームごとの詳細タブに切り替わり、タブ切り替えも動く
- [ ] 「← 戻る」で総合に戻る／「自分も診断する →」でトップへ遷移する
- [ ] BGM が鳴らない・再診断ボタンが無い（訪問者の localStorage が消えない）
- [ ] 無効な user_id ではフォールバック表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)