### PR TITLE
fix: 利用規約の読了確認チェックボックスに必須表示を追加

### DIFF
--- a/frontend/src/features/games/terms/components/TermsContent.tsx
+++ b/frontend/src/features/games/terms/components/TermsContent.tsx
@@ -81,7 +81,10 @@ export default function TermsContent({
             onChange={(e) => onCheckboxChange('readConfirm', e.target.checked)}
             className="h-4 w-4"
           />
-          <span className="text-xs text-gray-500">上記の内容を読みました</span>
+          <span className="text-xs text-gray-500">
+            上記の内容を読みました
+            <span className="ml-1 font-bold text-red-500">必須</span>
+          </span>
         </label>
       </section>
 


### PR DESCRIPTION
## 概要

利用規約画面（第5条）の「上記の内容を読みました」チェックボックスに、必須項目であることを示す赤字の「必須」表示を追加した。

このチェックボックスは未チェックのまま「同意する」を押すと「未確認の必須項目があります」エラーで差し戻される実際の必須項目だが、ラベル上は必須と分かりづらかったため明記した。

## 変更内容

- `TermsContent.tsx`: 第5条チェックボックスのラベルに `必須` バッジ（赤字・太字）を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * 利用規約の必須項目表示が改善されました。チェックボックスのラベルに赤い「必須」バッジが追加表示され、必須項目であることがより明確に識別できるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->