### PR TITLE
fix: 結果/共有画面の自己認識精度バッジを削除

### DIFF
--- a/frontend/src/features/result/components/OverviewTab.tsx
+++ b/frontend/src/features/result/components/OverviewTab.tsx
@@ -44,7 +44,7 @@ const AXES = [
 ] as const;
 
 export default function OverviewTab({ data }: OverviewTabProps) {
-  const { feedback, scores, baseline_scores, accuracy_score } = data;
+  const { feedback, scores, baseline_scores } = data;
 
   return (
     <div className="total-layout-reconstructed">
@@ -75,15 +75,6 @@ export default function OverviewTab({ data }: OverviewTabProps) {
               </p>
             ))}
           </div>
-        </div>
-
-        {/* 自己認識精度バッジ（自己申告と実測の一致度） */}
-        <div className="accuracy-badge">
-          <span className="accuracy-badge-label">自己認識精度</span>
-          <span className="accuracy-badge-value">
-            {accuracy_score}
-            <span className="accuracy-badge-unit">%</span>
-          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- 解析コメントに同じ内容が書かれており情報が二重になっていたため、`OverviewTab` から自己認識精度バッジを削除
- 結果画面・共有画面の両方に適用（共通コンポーネントのため）
- 未使用になった `accuracy_score` の分割代入も除去

## Test plan
- [ ] 結果画面（総合タブ）にバッジが表示されないこと
- [ ] 共有画面（/share/[userId] 総合タブ）にバッジが表示されないこと
- [ ] レイアウト崩れがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)