### PR TITLE
fix: 結果画面のタイトルを常に中央寄せにする

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -143,6 +143,9 @@
   line-height: 1.1;
   margin: 0;
   letter-spacing: -0.5px;
+  /* ステッカー幅は前置きラベルなど最長要素で決まるため、
+     短いタイトル（例「特攻隊長」）でも常に中央寄せにする */
+  text-align: center;
 }
 
 .type-main-title span.orange-highlight {


### PR DESCRIPTION
## Summary
- 短いタイトル（例「特攻隊長」）が左詰めになっていた問題を修正
- ステッカー幅は前置きラベル等の最長要素で決まるため、`.type-main-title` に `text-align: center` を付与して文字数に関わらず常に中央表示にする

## Test plan
- [ ] 短いタイトルが中央に表示されること
- [ ] 長いタイトルでも従来通り中央表示でレイアウト崩れがないこと
- [ ] 共有画面（OverviewTab 共通）でも同様に中央寄せになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)