### PR TITLE
style: 利用規約UIをreal-youのデザイントーンに統一

### DIFF
--- a/frontend/src/features/games/terms/components/ErrorDialog.tsx
+++ b/frontend/src/features/games/terms/components/ErrorDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FC } from 'react';
+import { motion } from 'framer-motion';
 
 interface ErrorDialogProps {
   message: string;
@@ -12,6 +13,10 @@ interface ErrorDialogProps {
   onOverlayClick?: () => void;
 }
 
+// real-you 共通のネオブルータリズム調ボタン（SlideModal の NEO_FOOTER_BUTTON_BASE と同調）
+const NEO_BUTTON =
+  'rounded-xl border-[3px] border-black bg-[#ffd54a] px-8 py-2 text-sm font-black text-black shadow-[3px_3px_0_0_#000] transition-transform hover:-translate-y-0.5 hover:shadow-[4px_4px_0_0_#000] active:translate-y-0.5 active:shadow-[1px_1px_0_0_#000] sm:py-3 sm:text-base';
+
 /**
  * 規約同意フローの差し戻し / 案内ダイアログ。2 つの用途で再利用する。
  *
@@ -19,6 +24,10 @@ interface ErrorDialogProps {
  *   エラー後のクリック行動（連打・無関係操作）を計測するため、オーバーレイ背景／
  *   ダイアログ本体／OK ボタンのクリックを別経路（onOverlayClick / onDialogClick）で通知する。
  * - 同意要求: 「同意しない」押下時に同意を促す案内。計測は不要なので onConfirm のみ渡す。
+ *
+ * 見た目は real-you 全体のトーン（ネオブルータリズム + 丸ゴシック）に統一しつつ、
+ * 差し戻しのストレスを和らげるため赤いアラート調ではなくヒント調（黄色バッジ）にしている。
+ * 差し戻しの発火そのものは維持しており、エラー計測（論理性・冷静さ）には影響しない。
  */
 const ErrorDialog: FC<ErrorDialogProps> = ({
   message,
@@ -27,13 +36,17 @@ const ErrorDialog: FC<ErrorDialogProps> = ({
   onOverlayClick,
 }) => {
   return (
-    <div
+    <motion.div
       // PopupTerms(z-50) / PopupAd(z-60) より前面に出す
       className="fixed inset-0 z-[70] flex items-center justify-center bg-black/40"
       onClick={onOverlayClick}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.15 }}
+      style={{ fontFamily: "'M PLUS Rounded 1c', sans-serif" }}
     >
-      <div
-        className="mx-4 w-full max-w-sm rounded-lg bg-white p-6 shadow-xl"
+      <motion.div
+        className="mx-4 w-full max-w-sm rounded-3xl border-[4px] border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
         role="alertdialog"
         aria-modal="true"
         onClick={(e) => {
@@ -41,8 +54,15 @@ const ErrorDialog: FC<ErrorDialogProps> = ({
           e.stopPropagation();
           onDialogClick?.();
         }}
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 320, damping: 22 }}
       >
-        <p className="text-center text-base font-bold text-gray-800">
+        {/* ストレスを和らげるためのヒント調バッジ（赤アラートにしない） */}
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full border-[3px] border-black bg-[#ffd54a] text-2xl shadow-[2px_2px_0_0_#000]">
+          💡
+        </div>
+        <p className="text-center text-base font-black text-black sm:text-lg">
           {message}
         </p>
         <div className="mt-5 flex justify-center">
@@ -52,13 +72,13 @@ const ErrorDialog: FC<ErrorDialogProps> = ({
               e.stopPropagation();
               onConfirm();
             }}
-            className="rounded bg-red-600 px-6 py-2 text-sm font-bold text-white hover:bg-red-700"
+            className={NEO_BUTTON}
           >
             OK
           </button>
         </div>
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 };
 

--- a/frontend/src/features/games/terms/components/PopupTerms.tsx
+++ b/frontend/src/features/games/terms/components/PopupTerms.tsx
@@ -2,6 +2,7 @@
 
 import TermsContent from './TermsContent';
 import type { FC } from 'react';
+import { motion } from 'framer-motion';
 
 interface PopupTermsProps {
   onCheckboxChange: (
@@ -20,6 +21,11 @@ interface PopupTermsProps {
   onAgreeHoverStart?: () => void;
 }
 
+// real-you 共通のネオブルータリズム調ボタン（SlideModal / ErrorDialog と同調）。
+// 色（bg/text）は各ボタンで上書きする前提で、押下感まわりだけ共通化する。
+const NEO_BUTTON_BASE =
+  'rounded-xl border-[3px] border-black py-2 text-sm font-black shadow-[3px_3px_0_0_#000] transition-transform hover:-translate-y-0.5 hover:shadow-[4px_4px_0_0_#000] active:translate-y-0.5 active:shadow-[1px_1px_0_0_#000]';
+
 const PopupTerms: FC<PopupTermsProps> = ({
   onCheckboxChange,
   onHiddenInputChange,
@@ -31,10 +37,19 @@ const PopupTerms: FC<PopupTermsProps> = ({
   onAgreeHoverStart,
 }) => {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-      <div
-        className="relative mx-4 w-full max-w-3xl rounded-lg bg-white p-6 shadow-xl"
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+      style={{ fontFamily: "'M PLUS Rounded 1c', sans-serif" }}
+    >
+      <motion.div
+        className="relative mx-4 w-full max-w-3xl rounded-3xl border-[4px] border-black bg-white p-6 shadow-[6px_6px_0_0_#000]"
         onClick={(e) => e.stopPropagation()}
+        initial={{ opacity: 0, scale: 0.96, y: 12 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 24 }}
       >
         {/* スクロール領域 */}
         <div
@@ -45,7 +60,7 @@ const PopupTerms: FC<PopupTermsProps> = ({
           onScroll={() => {
             if (onScroll) onScroll();
           }}
-          className="mt-6 max-h-[70vh] overflow-y-auto px-2"
+          className="mt-2 max-h-[70vh] overflow-y-auto px-2"
         >
           <TermsContent
             onCheckboxChange={onCheckboxChange}
@@ -56,25 +71,25 @@ const PopupTerms: FC<PopupTermsProps> = ({
         </div>
 
         {/* アクションボタン領域 */}
-        <div className="border-t bg-white px-4 py-3">
+        <div className="mt-2 border-t-2 border-black/10 bg-white px-4 pt-4">
           <div className="mx-auto flex max-w-2xl items-center justify-center gap-3">
             <button
               onClick={() => onAction && onAction('disagree')}
-              className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50"
+              className={`${NEO_BUTTON_BASE} bg-white px-6 text-black`}
             >
               同意しない
             </button>
             <button
               onClick={() => onAction && onAction('agree')}
               onMouseEnter={() => onAgreeHoverStart && onAgreeHoverStart()}
-              className="rounded bg-red-600 px-6 py-2 text-sm font-bold text-white hover:bg-red-700"
+              className={`${NEO_BUTTON_BASE} bg-red-500 px-8 text-white`}
             >
               同意する
             </button>
           </div>
         </div>
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 };
 

--- a/frontend/src/features/games/terms/components/TermsContent.tsx
+++ b/frontend/src/features/games/terms/components/TermsContent.tsx
@@ -16,11 +16,13 @@ export default function TermsContent({
   hiddenInputValue,
 }: TermsContentProps) {
   return (
-    <div className="space-y-8 pb-8 text-sm leading-relaxed text-gray-700">
-      <h2 className="text-lg font-bold">サービス利用規約</h2>
+    <div className="space-y-8 pb-8 text-sm leading-loose text-gray-800">
+      <h2 className="inline-block border-b-4 border-[#ffd54a] pb-1 text-2xl font-black text-black">
+        サービス利用規約
+      </h2>
 
       <section>
-        <h3 className="mb-2 font-bold">第1条（目的）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第1条（目的）</h3>
         <p>
           本規約は、当社が提供するサービス（以下「本サービス」といいます。）の利用条件を定めるものです。
           登録ユーザーの皆さま（以下「ユーザー」といいます。）には、本規約に従って本サービスをご利用いただきます。
@@ -29,7 +31,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第2条（定義）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第2条（定義）</h3>
         <p>
           本規約において使用する用語の定義は、次の各号に定めるとおりとします。
           「本サービス」とは、当社が運営するウェブサイトおよびアプリケーションを通じて提供されるすべてのサービスを意味します。
@@ -40,7 +42,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第3条（利用登録）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第3条（利用登録）</h3>
         <p>
           登録希望者は、当社所定の方法により利用登録を申請し、当社がこれを承認することによって、
           本サービスの利用登録が完了するものとします。当社は、以下の各号のいずれかに該当する場合、
@@ -52,7 +54,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
           第4条（ユーザーIDおよびパスワードの管理）
         </h3>
         <p>
@@ -67,7 +69,7 @@ export default function TermsContent({
 
       {/* トラップ1: 第5条の「読みました」チェックボックス */}
       <section>
-        <h3 className="mb-2 font-bold">第5条（サービス内容の変更等）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第5条（サービス内容の変更等）</h3>
         <p>
           当社は、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を
           中止することができるものとし、これによってユーザーに生じた損害について一切の責任を
@@ -89,7 +91,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第6条（禁止事項）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第6条（禁止事項）</h3>
         <p>
           ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
           法令または公序良俗に違反する行為、犯罪行為に関連する行為、
@@ -102,7 +104,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第7条（利用料金および支払方法）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第7条（利用料金および支払方法）</h3>
         <p>
           ユーザーは、本サービスの有料部分の対価として、当社が別途定め、
           本ウェブサイトに表示する利用料金を、当社が指定する方法により支払うものとします。
@@ -116,7 +118,7 @@ export default function TermsContent({
 
       {/* トラップ2: 第8条のメルマガ・第三者提供チェックボックス（初期値ON） */}
       <section>
-        <h3 className="mb-2 font-bold">第8条（個人情報の取扱い）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第8条（個人情報の取扱い）</h3>
         <p>
           当社は、本サービスの利用によって取得する個人情報については、
           当社「プライバシーポリシー」に従い適切に取り扱うものとします。
@@ -155,7 +157,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第9条（免責事項）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第9条（免責事項）</h3>
         <p>
           当社の債務不履行責任は、当社の故意または重過失によらない場合には免責されるものとします。
           当社は、何らかの理由によって責任を負う場合にも、通常生じうる損害の範囲内かつ
@@ -168,7 +170,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第10条（サービス内容の変更等）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第10条（サービス内容の変更等）</h3>
         <p>
           当社は、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの
           提供を中止することができるものとし、これによってユーザーに生じた損害について一切の
@@ -179,7 +181,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第11条（利用規約の変更）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第11条（利用規約の変更）</h3>
         <p>
           当社は、必要と判断した場合には、ユーザーに通知することなくいつでも本規約を変更する
           ことができるものとします。なお、本規約の変更後、本サービスの利用を開始した場合には、
@@ -191,7 +193,7 @@ export default function TermsContent({
 
       {/* トラップ3: 第12条の隠し入力指示 */}
       <section>
-        <h3 className="mb-2 font-bold">第12条（通知または連絡）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第12条（通知または連絡）</h3>
         <p>
           ユーザーと当社との間の通知または連絡は、当社の定める方法によって行うものとします。
           当社は、ユーザーから、当社が別途定める方式に従った変更届け出がない限り、
@@ -211,7 +213,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第13条（権利義務の譲渡の禁止）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第13条（権利義務の譲渡の禁止）</h3>
         <p>
           ユーザーは、当社の書面による事前の承諾なく、利用契約上の地位または本規約に基づく
           権利もしくは義務を第三者に譲渡し、または担保に供することはできません。
@@ -223,7 +225,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">第14条（準拠法・裁判管轄）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第14条（準拠法・裁判管轄）</h3>
         <p>
           本規約の解釈にあたっては、日本法を準拠法とします。
           本サービスに関して紛争が生じた場合には、当社の本店所在地を管轄する裁判所を
@@ -233,7 +235,7 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-2 font-bold">附則</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">附則</h3>
         <p>本規約は2025年1月1日から施行します。</p>
       </section>
     </div>

--- a/frontend/src/features/games/terms/components/TermsContent.tsx
+++ b/frontend/src/features/games/terms/components/TermsContent.tsx
@@ -76,16 +76,18 @@ export default function TermsContent({
           負いません。サービスの変更、中断、終了等について、当社は可能な限り事前に通知するよう
           努めますが、緊急の場合はこの限りではありません。
         </p>
-        <label className="mt-3 flex items-center gap-2">
+        {/* 必須チェックはアクション枠（ネオブル調カード）にして「操作項目」と分かるようにする。
+            位置（第5条内）・onChange・checked は不変で計測には影響しない。 */}
+        <label className="mt-4 flex cursor-pointer items-center gap-3 rounded-xl border-2 border-black bg-[#fff9e0] px-4 py-3 shadow-[2px_2px_0_0_#000]">
           <input
             type="checkbox"
             checked={checkboxStates.readConfirm}
             onChange={(e) => onCheckboxChange('readConfirm', e.target.checked)}
-            className="h-4 w-4"
+            className="h-5 w-5 accent-black"
           />
-          <span className="text-xs text-gray-500">
+          <span className="text-sm font-bold text-gray-800">
             上記の内容を読みました
-            <span className="ml-1 font-bold text-red-500">必須</span>
+            <span className="ml-1 font-black text-red-500">必須</span>
           </span>
         </label>
       </section>

--- a/frontend/src/features/games/terms/components/TermsContent.tsx
+++ b/frontend/src/features/games/terms/components/TermsContent.tsx
@@ -22,7 +22,9 @@ export default function TermsContent({
       </h2>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第1条（目的）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第1条（目的）
+        </h3>
         <p>
           本規約は、当社が提供するサービス（以下「本サービス」といいます。）の利用条件を定めるものです。
           登録ユーザーの皆さま（以下「ユーザー」といいます。）には、本規約に従って本サービスをご利用いただきます。
@@ -31,7 +33,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第2条（定義）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第2条（定義）
+        </h3>
         <p>
           本規約において使用する用語の定義は、次の各号に定めるとおりとします。
           「本サービス」とは、当社が運営するウェブサイトおよびアプリケーションを通じて提供されるすべてのサービスを意味します。
@@ -42,7 +46,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第3条（利用登録）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第3条（利用登録）
+        </h3>
         <p>
           登録希望者は、当社所定の方法により利用登録を申請し、当社がこれを承認することによって、
           本サービスの利用登録が完了するものとします。当社は、以下の各号のいずれかに該当する場合、
@@ -69,7 +75,9 @@ export default function TermsContent({
 
       {/* トラップ1: 第5条の「読みました」チェックボックス */}
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第5条（サービス内容の変更等）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第5条（サービス内容の変更等）
+        </h3>
         <p>
           当社は、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの提供を
           中止することができるものとし、これによってユーザーに生じた損害について一切の責任を
@@ -93,7 +101,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第6条（禁止事項）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第6条（禁止事項）
+        </h3>
         <p>
           ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
           法令または公序良俗に違反する行為、犯罪行為に関連する行為、
@@ -106,7 +116,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第7条（利用料金および支払方法）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第7条（利用料金および支払方法）
+        </h3>
         <p>
           ユーザーは、本サービスの有料部分の対価として、当社が別途定め、
           本ウェブサイトに表示する利用料金を、当社が指定する方法により支払うものとします。
@@ -120,7 +132,9 @@ export default function TermsContent({
 
       {/* トラップ2: 第8条のメルマガ・第三者提供チェックボックス（初期値ON） */}
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第8条（個人情報の取扱い）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第8条（個人情報の取扱い）
+        </h3>
         <p>
           当社は、本サービスの利用によって取得する個人情報については、
           当社「プライバシーポリシー」に従い適切に取り扱うものとします。
@@ -159,7 +173,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第9条（免責事項）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第9条（免責事項）
+        </h3>
         <p>
           当社の債務不履行責任は、当社の故意または重過失によらない場合には免責されるものとします。
           当社は、何らかの理由によって責任を負う場合にも、通常生じうる損害の範囲内かつ
@@ -172,7 +188,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第10条（サービス内容の変更等）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第10条（サービス内容の変更等）
+        </h3>
         <p>
           当社は、ユーザーに通知することなく、本サービスの内容を変更しまたは本サービスの
           提供を中止することができるものとし、これによってユーザーに生じた損害について一切の
@@ -183,7 +201,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第11条（利用規約の変更）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第11条（利用規約の変更）
+        </h3>
         <p>
           当社は、必要と判断した場合には、ユーザーに通知することなくいつでも本規約を変更する
           ことができるものとします。なお、本規約の変更後、本サービスの利用を開始した場合には、
@@ -195,7 +215,9 @@ export default function TermsContent({
 
       {/* トラップ3: 第12条の隠し入力指示 */}
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第12条（通知または連絡）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第12条（通知または連絡）
+        </h3>
         <p>
           ユーザーと当社との間の通知または連絡は、当社の定める方法によって行うものとします。
           当社は、ユーザーから、当社が別途定める方式に従った変更届け出がない限り、
@@ -215,7 +237,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第13条（権利義務の譲渡の禁止）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第13条（権利義務の譲渡の禁止）
+        </h3>
         <p>
           ユーザーは、当社の書面による事前の承諾なく、利用契約上の地位または本規約に基づく
           権利もしくは義務を第三者に譲渡し、または担保に供することはできません。
@@ -227,7 +251,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">第14条（準拠法・裁判管轄）</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          第14条（準拠法・裁判管轄）
+        </h3>
         <p>
           本規約の解釈にあたっては、日本法を準拠法とします。
           本サービスに関して紛争が生じた場合には、当社の本店所在地を管轄する裁判所を
@@ -237,7 +263,9 @@ export default function TermsContent({
       </section>
 
       <section>
-        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">附則</h3>
+        <h3 className="mb-3 border-l-[5px] border-[#ffd54a] pl-3 text-base font-black text-black">
+          附則
+        </h3>
         <p>本規約は2025年1月1日から施行します。</p>
       </section>
     </div>

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -321,7 +321,7 @@ export default function TermsGameFlow() {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-[#F0F380]">
+    <div className="bg-page-pattern flex h-screen flex-col">
       <div className="flex-1" />
 
       {showPopup && (

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -28,10 +28,10 @@ const REACHED_BOTTOM_THRESHOLD = 0.9;
 // 第5条「読みました」未チェックで同意を試みた際のエラー理由。
 // BE 分析（termsGame.ts）が完全一致で判定するため固定値（仕様書「データ構造」準拠）。
 const ERROR_REASON_MISSING_READ_CONFIRM = 'missing_read_confirm';
-// エラー差し戻しダイアログの表示メッセージ
-const ERROR_DIALOG_MESSAGE = '未確認の必須項目があります';
+// エラー差し戻しダイアログの表示メッセージ（表示専用。BE 判定は ERROR_REASON_* で行う）
+const ERROR_DIALOG_MESSAGE = 'あと一歩！「読みました」のチェックがまだみたいです';
 // 「同意しない」押下時に同意を促す案内ダイアログのメッセージ
-const DISAGREE_DIALOG_MESSAGE = 'ご利用には規約への同意が必要です';
+const DISAGREE_DIALOG_MESSAGE = '先に進むには、規約への同意が必要です';
 
 export default function TermsGameFlow() {
   const router = useRouter();

--- a/frontend/src/features/games/terms/components/TermsGameFlow.tsx
+++ b/frontend/src/features/games/terms/components/TermsGameFlow.tsx
@@ -29,7 +29,7 @@ const REACHED_BOTTOM_THRESHOLD = 0.9;
 // BE 分析（termsGame.ts）が完全一致で判定するため固定値（仕様書「データ構造」準拠）。
 const ERROR_REASON_MISSING_READ_CONFIRM = 'missing_read_confirm';
 // エラー差し戻しダイアログの表示メッセージ（表示専用。BE 判定は ERROR_REASON_* で行う）
-const ERROR_DIALOG_MESSAGE = 'あと一歩！「読みました」のチェックがまだみたいです';
+const ERROR_DIALOG_MESSAGE = '「読みました」にチェックを入れてください';
 // 「同意しない」押下時に同意を促す案内ダイアログのメッセージ
 const DISAGREE_DIALOG_MESSAGE = '先に進むには、規約への同意が必要です';
 


### PR DESCRIPTION
## 概要

利用規約ゲームの UI を real-you 全体のデザイントーン（ネオブルータリズム + 丸ゴシック）に統一した。あわせて、規約画面の「真面目すぎてつまらない・エラーがストレス」という課題に対し、トーン・文言をやわらげた。

広告ポップアップ（`PopupAd`）は、リアルさの演出として意図的に現状の見た目を維持し変更していない。

## 変更内容

### 規約モーダル本体（`PopupTerms.tsx`）
- 太黒枠（`border-[4px]`）+ ずらし黒影（`shadow-[6px_6px_0_0_#000]`）+ 大きめ角丸 + 丸ゴシック（M PLUS Rounded 1c）に統一
- framer-motion で登場アニメ（オーバーレイ fade + カード spring）を追加
- 「同意しない」= 白ネオブルボタン、「同意する」= 赤ネオブルボタンに変更

### 規約本文（`TermsContent.tsx`）
- 見出し（h2: 黄色下線アクセント / h3: 黄色左アクセントバー）と本文（`leading-loose` + 可読性向上）のタイポグラフィを調整

### エラー / 同意要求ダイアログ（`ErrorDialog.tsx`）
- ネオブル調 + 丸ゴシック + 登場アニメに統一
- 赤いアラート調 → 黄色ヒントバッジ（💡）のやわらかいトーンに変更
- OK ボタンをネオブル調に

### 表示文言（`TermsGameFlow.tsx`）
- エラー: `「読みました」にチェックを入れてください`
- 同意要求: `先に進むには、規約への同意が必要です`
- いずれも表示専用。BE 判定の固定値 `missing_read_confirm` は未変更のため計測に影響なし

## 計測への影響

スクロール計測（`setScrollContainerRef` / `onScroll`）、同意ボタンのホバー/クリック計測、エラー後のクリック計測経路（`onConfirm` / `onDialogClick` / `onOverlayClick` と `stopPropagation`、role/aria、z-index）、トラップ要素（チェックボックス・隠し入力・必須バッジ）はすべて変更前と同一挙動を維持している。