### PR TITLE
feat: トップページに音量調整UIを追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,7 @@ import type { CSSProperties } from 'react';
 import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
 import SlideModal from '@/components/common/SlideModal';
 import { useSe } from '@/components/audio/useSe';
+import { VolumeControl } from '@/components/audio/VolumeControl';
 
 // --- まる爆発アニメーションコンポーネント ---
 const SparklesExplosion = () => {
@@ -195,6 +196,14 @@ export default function TopPage() {
           >
             あそびかた
           </button>
+
+          {/* 音量設定（トップページのみ） */}
+          <div className="mt-1 rounded-2xl border-[3px] border-gray-800 bg-white/90 px-5 py-3 shadow-[0_3px_0_#1f2937]">
+            <p className="mb-2 text-center text-xs font-bold text-gray-700">
+              音量設定
+            </p>
+            <VolumeControl />
+          </div>
 
           {showExplosion && <SparklesExplosion />}
         </div>

--- a/frontend/src/components/audio/VolumeControl.tsx
+++ b/frontend/src/components/audio/VolumeControl.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { Music, Volume2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { bgmVolumeAtom, seVolumeAtom } from '@/stores/audio';
+import { useSe } from './useSe';
+
+type SliderRowProps = {
+  icon: ReactNode;
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  /** スライダー操作を確定したとき（プレビュー音などに使う） */
+  onCommit?: () => void;
+};
+
+function SliderRow({ icon, label, value, onChange, onCommit }: SliderRowProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="flex w-16 shrink-0 items-center gap-1.5 text-sm font-bold text-gray-800">
+        {icon}
+        {label}
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.05}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        onPointerUp={onCommit}
+        onKeyUp={onCommit}
+        aria-label={`${label}の音量`}
+        className="h-2 flex-1 cursor-pointer accent-rose-400"
+      />
+      <span className="w-10 shrink-0 text-right text-xs font-bold tabular-nums text-gray-500">
+        {Math.round(value * 100)}%
+      </span>
+    </div>
+  );
+}
+
+/**
+ * BGM / 効果音の音量を調整するスライダー UI。
+ * `bgmVolumeAtom` / `seVolumeAtom`（localStorage 永続化）を読み書きし、
+ * 変更は AudioController（BGM）と useSe（SE）に即時反映される。
+ */
+export function VolumeControl() {
+  const [bgmVolume, setBgmVolume] = useAtom(bgmVolumeAtom);
+  const [seVolume, setSeVolume] = useAtom(seVolumeAtom);
+  const playSe = useSe();
+
+  return (
+    <div className="flex w-full max-w-xs flex-col gap-3">
+      <SliderRow
+        icon={<Music size={16} aria-hidden />}
+        label="BGM"
+        value={bgmVolume}
+        onChange={setBgmVolume}
+      />
+      <SliderRow
+        icon={<Volume2 size={16} aria-hidden />}
+        label="効果音"
+        value={seVolume}
+        onChange={setSeVolume}
+        // 効果音は鳴らさないと音量が分からないため、調整後にプレビュー再生する。
+        onCommit={() => playSe('buttonClick')}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

トップページに BGM / 効果音の音量を調整する UI を追加する。#185〜#187 で用意した `bgmVolumeAtom` / `seVolumeAtom`（localStorage 永続化）を操作し、再生中の BGM と以降の SE に即時反映する。

closes #188

> このPRは #187（PR #192）のブランチから派生したスタックPRです。#189 → #190 → #192 マージ後にベースが develop に切り替わります。

## 変更内容

- `components/audio/VolumeControl.tsx`（新規）: BGM / 効果音の2スライダー（0〜1, 5%刻み）。`bgmVolumeAtom` / `seVolumeAtom` を読み書きする。効果音は調整確定時（pointerup / keyup）にプレビュー音を鳴らす。
- `app/page.tsx`: トップページのボタン列の下に音量設定パネルを追加。

## 設計上のポイント

- 音量の合成（基準音量 × ユーザー設定）は基盤側（AudioController / useSe）に集約済みのため、UI は atom を更新するだけ。音量計算を UI に再実装しない。
- `atomWithStorage` の既定値 1.0 によりサーバー / クライアント初回描画が一致し、マウント後に localStorage 値へ反映される（hydration mismatch なし）。
- 音量調整 UI はトップページのみに表示する（全画面共通のフローティング UI は今回のスコープから外した）。
