### PR TITLE
Feat/share mobile sns UI

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -108,6 +108,8 @@
 }
 
 .type-main-title-sticker {
+  position: relative;
+  z-index: 2;
   background: #fef08a;
   border: 5px solid #000;
   border-radius: 18px;
@@ -130,10 +132,21 @@
 .type-intro-label {
   font-size: 20px;
   font-weight: 900;
-  color: #555;
+  color: #4d85ff;
   margin-top: 8px;
   white-space: nowrap;
   text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+/* QRモーダル表示時: 青い解説（サブタイトル）を背面へ */
+body.share-qr-modal-open .type-intro-label {
+  z-index: 0;
+}
+
+body.share-qr-modal-open .type-main-title-sticker {
+  z-index: 2;
 }
 
 .type-main-title {
@@ -1168,7 +1181,256 @@
   display: block;
 }
 
-/* ===== SNS 共有ボタン行 ===== */
+/* ===== QR シェアモーダル（body 直下 portal） ===== */
+.share-qr-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.share-qr-modal-dialog {
+  background: #fff;
+  border: 5px solid #000;
+  border-radius: 24px;
+  padding: 28px 32px;
+  text-align: center;
+  box-shadow: 8px 8px 0 #000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 320;
+  width: 100%;
+  position: relative;
+}
+
+.share-qr-modal-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #888;
+  padding: 4px;
+}
+
+.share-qr-modal-heading {
+  font-weight: 900;
+  font-size: 18px;
+  color: #000;
+  letter-spacing: 0.03em;
+  margin: 0;
+}
+
+.share-qr-modal-nickname {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 950;
+  line-height: 1.1;
+}
+
+.share-qr-modal-qr-wrap {
+  padding: 8px;
+  border: 3px solid #000;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.share-qr-modal-url {
+  font-size: 11px;
+  color: #888;
+  word-break: break-all;
+  max-width: 240;
+  line-height: 1.5;
+}
+
+.share-qr-modal-copy-btn {
+  color: #fff;
+  border: 3px solid #000;
+  border-radius: 50px;
+  padding: 8px 28px;
+  font-size: 14px;
+  font-weight: 900;
+  cursor: pointer;
+  transition: background 0.2s;
+  width: 100%;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+}
+
+/* ===== スマホ共有: PCプレイ推奨 ===== */
+.share-pc-recommend {
+  width: 100%;
+  max-width: 480px;
+  background: #eff6ff;
+  border: 3.5px solid #3b82f6;
+  border-radius: 16px;
+  padding: 14px 16px;
+  box-shadow: 4px 4px 0 rgba(59, 130, 246, 0.25);
+}
+
+.share-pc-recommend-title {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 900;
+  color: #1e3a8a;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.share-pc-recommend-title strong {
+  color: #2563eb;
+}
+
+.share-pc-recommend-body {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: #475569;
+  line-height: 1.6;
+  text-align: center;
+}
+
+/* ===== SNS シェア導線（結果をシェアボタンと同デザイン） ===== */
+.share-sns-trigger-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.share-sns-hint {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 900;
+  color: #555;
+  letter-spacing: 0.03em;
+}
+
+.share-sns-trigger-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  min-width: 200px;
+  padding: 0 24px;
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 9999px;
+  font-size: 15px;
+  font-weight: 900;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  box-shadow: 4px 4px 0 #fbbf24;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
+}
+
+.share-sns-trigger-btn:active {
+  transform: translateY(2px);
+  box-shadow: none;
+}
+
+/* SNS 選択モーダル */
+.share-sns-picker-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 20px;
+}
+
+.share-sns-picker-dialog {
+  background: #fff;
+  border: 5px solid #000;
+  border-radius: 24px 24px 18px 18px;
+  padding: 24px 20px 20px;
+  width: 100%;
+  max-width: 400px;
+  position: relative;
+  box-shadow: 8px 8px 0 #000;
+}
+
+.share-sns-picker-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #888;
+  padding: 4px;
+}
+
+.share-sns-picker-heading {
+  margin: 0 0 16px;
+  font-size: 17px;
+  font-weight: 900;
+  color: #000;
+  text-align: center;
+  letter-spacing: 0.03em;
+}
+
+.share-sns-picker-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.share-sns-picker-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  background: #fff;
+  border: 3px solid #000;
+  border-radius: 14px;
+  padding: 14px 16px;
+  font-size: 15px;
+  font-weight: 900;
+  font-family: 'M PLUS Rounded 1c', sans-serif;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 #000;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
+}
+
+.share-sns-picker-option:active {
+  transform: translate(1px, 1px);
+  box-shadow: 2px 2px 0 #000;
+}
+
+.share-sns-picker-icon {
+  font-size: 18px;
+  width: 24px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  .share-sns-picker-overlay {
+    align-items: center;
+  }
+
+  .share-sns-picker-dialog {
+    border-radius: 24px;
+  }
+}
+
+/* ===== SNS 共有ボタン行（旧・横並び） ===== */
 .share-sns-row {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/features/result/components/SharePanel.tsx
+++ b/frontend/src/features/result/components/SharePanel.tsx
@@ -2,6 +2,7 @@
 
 import { Share2, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { QRCodeSVG } from 'qrcode.react';
 import { SITE_URL } from '@/constants/site';
 
@@ -25,11 +26,15 @@ export default function SharePanel({ title, userId }: SharePanelProps) {
 
   useEffect(() => {
     if (!open) return;
+    document.body.classList.add('share-qr-modal-open');
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') setOpen(false);
     }
     document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
+    return () => {
+      document.body.classList.remove('share-qr-modal-open');
+      document.removeEventListener('keydown', handleKey);
+    };
   }, [open]);
 
   useEffect(() => {
@@ -96,115 +101,56 @@ export default function SharePanel({ title, userId }: SharePanelProps) {
         </span>
       </button>
 
-      {open && (
-        <div
-          style={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 9999,
-            background: 'rgba(0,0,0,0.6)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '20px',
-          }}
-          onClick={() => setOpen(false)}
-        >
+      {open &&
+        createPortal(
           <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qr-modal-title"
-            style={{
-              background: '#fff',
-              border: '5px solid #000',
-              borderRadius: 24,
-              padding: '28px 32px',
-              textAlign: 'center',
-              boxShadow: '8px 8px 0 #000',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: 16,
-              maxWidth: 320,
-              width: '100%',
-              position: 'relative',
-            }}
-            onClick={(e) => e.stopPropagation()}
+            className="share-qr-modal-overlay"
+            onClick={() => setOpen(false)}
           >
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              style={{
-                position: 'absolute',
-                top: 12,
-                right: 12,
-                background: 'none',
-                border: 'none',
-                cursor: 'pointer',
-                color: '#888',
-                padding: 4,
-              }}
-              aria-label="閉じる"
-            >
-              <X size={20} />
-            </button>
-
             <div
-              id="qr-modal-title"
-              style={{
-                fontWeight: 900,
-                fontSize: 18,
-                color: '#000',
-                letterSpacing: '0.03em',
-              }}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="qr-modal-title"
+              className="share-qr-modal-dialog"
+              onClick={(e) => e.stopPropagation()}
             >
-              スマホで読み取ってね！
-            </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="share-qr-modal-close"
+                aria-label="閉じる"
+              >
+                <X size={20} />
+              </button>
 
-            <div
-              style={{
-                padding: 8,
-                border: '3px solid #000',
-                borderRadius: 12,
-                background: '#fff',
-              }}
-            >
-              <QRCodeSVG value={shareUrl} size={180} />
-            </div>
+              <div id="qr-modal-title" className="share-qr-modal-heading">
+                スマホで読み取ってね！
+              </div>
 
-            <div
-              style={{
-                fontSize: 11,
-                color: '#888',
-                wordBreak: 'break-all',
-                maxWidth: 240,
-                lineHeight: 1.5,
-              }}
-            >
-              {shareUrl}
-            </div>
+              <p className="share-qr-modal-nickname">
+                <span className="orange-highlight">{title}</span>
+              </p>
 
-            <button
-              type="button"
-              onClick={handleCopyUrl}
-              style={{
-                background: copied ? '#22c55e' : '#000',
-                color: '#fff',
-                border: '3px solid #000',
-                borderRadius: 50,
-                padding: '8px 28px',
-                fontSize: 14,
-                fontWeight: 900,
-                cursor: 'pointer',
-                transition: 'background 0.2s',
-                width: '100%',
-              }}
-            >
-              {copied ? '✓ コピーしました！' : '📋 URLをコピー'}
-            </button>
-          </div>
-        </div>
-      )}
+              <div className="share-qr-modal-qr-wrap">
+                <QRCodeSVG value={shareUrl} size={180} />
+              </div>
+
+              <div className="share-qr-modal-url">{shareUrl}</div>
+
+              <button
+                type="button"
+                onClick={handleCopyUrl}
+                className="share-qr-modal-copy-btn"
+                style={{
+                  background: copied ? '#22c55e' : '#000',
+                }}
+              >
+                {copied ? '✓ コピーしました！' : '📋 URLをコピー'}
+              </button>
+            </div>
+          </div>,
+          document.body
+        )}
     </>
   );
 }

--- a/frontend/src/features/result/components/ShareResultView.tsx
+++ b/frontend/src/features/result/components/ShareResultView.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import type { GameId, ResultResponse } from '../types';
 import { GAME_META } from '../data/gameMeta';
 import BipolarSlider from './BipolarSlider';
 import OverviewTab from './OverviewTab';
 import GameDetailTab from './GameDetailTab';
+import SnsShareTrigger from './SnsShareTrigger';
 import { renderComment, computeBiggestGap } from '../utils/commentUtils';
-import { SITE_URL } from '@/constants/site';
 
 type ShareResultViewProps = {
   data: ResultResponse;
@@ -32,81 +32,6 @@ const AXES = [
   'cooperativeness',
   'positivity',
 ] as const;
-
-// ===== SNS 共有ヘルパー =====
-
-function buildShareText(title: string, shareUrl: string): string {
-  return `私の行動解析結果は「${title}」でした！\n#技育博 #RealYou #本当の私じゃだめですか\n${shareUrl}`;
-}
-
-type SnsPanelProps = {
-  title: string;
-  userId: string;
-};
-
-function SnsShareButtons({ title, userId }: SnsPanelProps) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const shareUrl = `${SITE_URL}/share/${userId}`;
-  const text = buildShareText(title, shareUrl);
-
-  const shareToX = () => {
-    const params = new URLSearchParams({ text });
-    window.open(
-      `https://twitter.com/intent/tweet?${params}`,
-      '_blank',
-      'noopener,noreferrer'
-    );
-  };
-
-  const shareToLine = () => {
-    const params = new URLSearchParams({ text, url: shareUrl });
-    window.open(
-      `https://social-plugins.line.me/lineit/share?${params}`,
-      '_blank',
-      'noopener,noreferrer'
-    );
-  };
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const el = document.createElement('textarea');
-      el.value = text;
-      el.style.cssText = 'position:fixed;opacity:0';
-      document.body.appendChild(el);
-      el.select();
-      const ok = document.execCommand('copy');
-      document.body.removeChild(el);
-      if (ok) {
-        setCopied(true);
-        if (timerRef.current) clearTimeout(timerRef.current);
-        timerRef.current = setTimeout(() => setCopied(false), 2000);
-      }
-    }
-  }, [text]);
-
-  return (
-    <div className="share-sns-row">
-      <button type="button" onClick={shareToX} className="share-sns-btn">
-        <span className="share-sns-icon">𝕏</span>
-        <span>Xでシェア</span>
-      </button>
-      <button type="button" onClick={shareToLine} className="share-sns-btn">
-        <span className="share-sns-icon">💬</span>
-        <span>LINE</span>
-      </button>
-      <button type="button" onClick={handleCopy} className="share-sns-btn">
-        <span className="share-sns-icon">{copied ? '✓' : '📋'}</span>
-        <span>{copied ? 'コピー済！' : 'テキストコピー'}</span>
-      </button>
-    </div>
-  );
-}
 
 // ===== メインコンポーネント =====
 
@@ -242,7 +167,7 @@ export default function ShareResultView({ data }: ShareResultViewProps) {
                     自分も診断する →
                   </Link>
 
-                  <SnsShareButtons
+                  <SnsShareTrigger
                     title={feedback.title}
                     userId={data.user_id}
                   />
@@ -268,7 +193,7 @@ export default function ShareResultView({ data }: ShareResultViewProps) {
                     ← 戻る
                   </button>
 
-                  <SnsShareButtons
+                  <SnsShareTrigger
                     title={feedback.title}
                     userId={data.user_id}
                   />
@@ -293,6 +218,15 @@ export default function ShareResultView({ data }: ShareResultViewProps) {
       <div className="share-mobile-only">
         <div className="share-page">
           <div className="share-app-label">Real You 行動解析REPORT</div>
+
+          <div className="share-pc-recommend" role="note">
+            <p className="share-pc-recommend-title">
+              💻 この診断は <strong>PC</strong> でのプレイを推奨しています
+            </p>
+            <p className="share-pc-recommend-body">
+              スマホでは結果の閲覧・シェア専用です。自分も診断する場合は会場のPCブースへどうぞ。
+            </p>
+          </div>
 
           {/* 2カラム on タブレット+ / 1カラム on SP */}
           <div className="share-main-grid">
@@ -520,10 +454,10 @@ export default function ShareResultView({ data }: ShareResultViewProps) {
             <p className="share-footer-copy">
               あなたも3つのゲームで、本当の自分を暴き出してみよう。
             </p>
+            <SnsShareTrigger title={feedback.title} userId={data.user_id} />
             <Link href="/" className="share-cta-btn">
               自分も診断する →
             </Link>
-            <SnsShareButtons title={feedback.title} userId={data.user_id} />
             <p className="share-footer-brand">Real You — 行動解析REPORT</p>
           </div>
         </div>

--- a/frontend/src/features/result/components/SnsShareTrigger.tsx
+++ b/frontend/src/features/result/components/SnsShareTrigger.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { Share2, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { SITE_URL } from '@/constants/site';
+
+type SnsShareTriggerProps = {
+  title: string;
+  userId: string;
+};
+
+function buildShareText(title: string, shareUrl: string): string {
+  return `私の行動解析結果は「${title}」でした！\n#技育博 #RealYou #本当の私じゃだめですか\n${shareUrl}`;
+}
+
+export default function SnsShareTrigger({
+  title,
+  userId,
+}: SnsShareTriggerProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const shareUrl = `${SITE_URL}/share/${userId}`;
+  const text = buildShareText(title, shareUrl);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const shareToX = () => {
+    const params = new URLSearchParams({ text });
+    window.open(
+      `https://twitter.com/intent/tweet?${params}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    setOpen(false);
+  };
+
+  const shareToLine = () => {
+    const params = new URLSearchParams({ text, url: shareUrl });
+    window.open(
+      `https://social-plugins.line.me/lineit/share?${params}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    setOpen(false);
+  };
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+        setOpen(false);
+      }, 1500);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = text;
+      el.style.cssText = 'position:fixed;opacity:0';
+      document.body.appendChild(el);
+      el.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(el);
+      if (ok) {
+        setCopied(true);
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => {
+          setCopied(false);
+          setOpen(false);
+        }, 1500);
+      }
+    }
+  }, [text]);
+
+  return (
+    <div className="share-sns-trigger-block">
+      <p className="share-sns-hint">SNSでもシェアしてね！</p>
+
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="share-sns-trigger-btn"
+      >
+        <Share2 className="w-5 h-5 mr-2 stroke-[3px]" />
+        <span>SNSでシェア！</span>
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            className="share-sns-picker-overlay"
+            onClick={() => setOpen(false)}
+          >
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="sns-picker-title"
+              className="share-sns-picker-dialog"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="share-sns-picker-close"
+                aria-label="閉じる"
+              >
+                <X size={20} />
+              </button>
+
+              <p id="sns-picker-title" className="share-sns-picker-heading">
+                シェア先を選んでね
+              </p>
+
+              <div className="share-sns-picker-options">
+                <button
+                  type="button"
+                  onClick={shareToX}
+                  className="share-sns-picker-option"
+                >
+                  <span className="share-sns-picker-icon">𝕏</span>
+                  <span>X (Twitter) でシェア</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={shareToLine}
+                  className="share-sns-picker-option"
+                >
+                  <span className="share-sns-picker-icon">💬</span>
+                  <span>LINE でシェア</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  className="share-sns-picker-option"
+                >
+                  <span className="share-sns-picker-icon">
+                    {copied ? '✓' : '📋'}
+                  </span>
+                  <span>
+                    {copied ? 'コピーしました！' : 'テキストをコピー'}
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
共有画面（スマホ）に PC プレイ推奨の案内を追加し、SNS シェアを「SNSでシェア！」ボタン＋選択モーダルに整理した。あわせて QR モーダルがタイトルブロックに被る不具合を修正した。

## 変更内容

### QR モーダル（結果画面 `/result`）
- モーダルを `document.body` に portal し、最前面に表示
- モーダル内にあだ名（タイプ名）を表示
- ページ上の青いサブタイトル（解説）がモーダルに被らないよう z-index を調整

### 共有画面（`/share/[userId]`・スマホ）
- ページ上部に **PC プレイ推奨** バナーを追加
  - 診断は PC 推奨、スマホは閲覧・シェア専用である旨を記載

### SNS シェア導線（`SnsShareTrigger` 新規）
- 「SNSでもシェアしてね！」の文言を表示
- 「SNSでシェア！」ボタン（結果画面の「結果をシェア」と同デザイン）
- タップでモーダルが開き、以下から選択
  - X (Twitter) でシェア
  - LINE でシェア
  - テキストをコピー
- PC 共有画面のフッターにも同コンポーネントを適用

## 関連 Issue
<!-- 右サイドバーの「Development」から Issue をリンクする -->

## 動作確認
- [ ] `/result` — 「結果をシェア」で QR モーダルが最前面に表示され、サブタイトルが被らない
- [ ] `/result` — モーダル内にあだ名が表示される
- [ ] `/share/[userId]`（スマホ）— PC プレイ推奨バナーが表示される
- [ ] `/share/[userId]`（スマホ）— 「SNSでシェア！」→ X / LINE / テキストコピーが動作する
- [ ] `/share/[userId]`（PC）— フッターの SNS シェア導線が動作する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SNS共有機能を拡充し、モーダルウィンドウでX・LINEへの共有が可能に
  * クリップボードへのテキストコピー機能を追加
  * モバイルデバイスでのPC推奨案内を追加

* **改善**
  * 共有モーダルでEscapeキーおよびオーバーレイクリックで閉じられるように改善
  * レイアウトとUIの視認性を向上

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->