### PR TITLE
refactor: トップページを Server/Client 分割し爆発を framer-motion 化

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,93 +1,12 @@
-'use client';
-
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import type { CSSProperties } from 'react';
-import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
-import SlideModal from '@/components/common/SlideModal';
-import { useSe } from '@/components/audio/useSe';
+import MbtiDecorations from '@/features/top/components/MbtiDecorations';
+import TopMenu from '@/features/top/components/TopMenu';
 
-// --- まる爆発アニメーションコンポーネント ---
-const SparklesExplosion = () => {
-  const count = 20;
-  const colors = ['#e9eb7c', '#ee7ee6', '#6eb8ca', '#e17a78', '#91ec77'];
-
-  const sparkles = Array.from({ length: count }, (_, index) => {
-    const angle = (360 / count) * index;
-    const distance = 60 + index * 3;
-    const style = {
-      position: 'absolute',
-      backgroundColor: colors[index % colors.length],
-      width: `${6 + (index % 5) * 2}px`,
-      height: `${6 + (index % 5) * 2}px`,
-      borderRadius: '50%',
-      top: '50%',
-      left: '50%',
-      '--angle': `${angle}deg`,
-      '--distance': `${distance}px`,
-      opacity: 0,
-      animation: 'sparkle-burst 600ms ease-out forwards',
-    } as CSSProperties;
-
-    return { id: index, style };
-  });
-
-  return (
-    <div className="absolute inset-0 pointer-events-none">
-      <style>{`
-        @keyframes sparkle-burst {
-          0% {
-            opacity: 1;
-            transform: translate(-50%, -50%) rotate(var(--angle)) translateY(0px) scale(0);
-          }
-          50% {
-            opacity: 1;
-            transform: translate(-50%, -50%) rotate(var(--angle)) translateY(var(--distance)) scale(1.2);
-          }
-          100% {
-            opacity: 0;
-            transform: translate(-50%, -50%) rotate(var(--angle)) translateY(var(--distance)) scale(0);
-          }
-        }
-      `}</style>
-
-      {sparkles.map((s) => (
-        <div key={s.id} style={s.style} />
-      ))}
-    </div>
-  );
-};
-
-// --- メインのトップページコンポーネント ---
+/**
+ * トップ画面。背景・ロゴ・MBTI 装飾などの静的要素を Server Component として描画し、
+ * インタラクション（ボタン・モーダル・SE）は末端の TopMenu（Client）に委譲する。
+ */
 export default function TopPage() {
-  const router = useRouter();
-  const playSe = useSe();
-  const [showExplosion, setShowExplosion] = useState(false);
-  const [showHowToPlay, setShowHowToPlay] = useState(false);
-
-  const handleStartClick = () => {
-    setShowExplosion(true);
-
-    playSe('start');
-
-    setTimeout(() => {
-      router.push('/games/terms');
-    }, 800);
-
-    setTimeout(() => {
-      setShowExplosion(false);
-    }, 800);
-  };
-
-  const openHowToPlay = () => {
-    setShowHowToPlay(true);
-  };
-
-  const closeHowToPlay = () => {
-    setShowHowToPlay(false);
-  };
-
   return (
     <div
       className="flex h-dvh w-full flex-col items-center justify-center overflow-hidden bg-top-pattern"
@@ -110,114 +29,9 @@ export default function TopPage() {
           className="max-h-[65vh] w-auto object-contain drop-shadow-2xl animate-[fadeInUp_0.5s_ease-out] pointer-events-none mt-[4vh]"
         />
 
-        {/** MBTIキャラの追加 */}
-        <Image
-          src="/images/mbti/ESFP.png"
-          alt=""
-          width={100}
-          height={100}
-          className="absolute top-5 right-20 w-60 rotate-[-15deg] pointer-events-none"
-          style={{
-            filter: `
-            drop-shadow(5px 0 0 white)
-            drop-shadow(-5px 0 0 white)
-            drop-shadow(0 5px 0 white)
-            drop-shadow(0 -5px 0 white)
-            `,
-          }}
-        />
+        <MbtiDecorations />
 
-        <Image
-          src="/images/mbti/INTJ.png"
-          alt=""
-          width={100}
-          height={100}
-          className="absolute bottom-8 right-50 w-65 rotate-[15deg] pointer-events-none"
-          style={{
-            filter: `
-            drop-shadow(5px 0 0 white)
-            drop-shadow(-5px 0 0 white)
-            drop-shadow(0 5px 0 white)
-            drop-shadow(0 -5px 0 white)
-            `,
-          }}
-        />
-
-        <Image
-          src="/images/mbti/INFP.png"
-          alt=""
-          width={100}
-          height={100}
-          className="absolute top-5 left-20 w-60 rotate-[3deg] pointer-events-none"
-          style={{
-            filter: `
-            drop-shadow(5px 0 0 white)
-            drop-shadow(-5px 0 0 white)
-            drop-shadow(0 5px 0 white)
-            drop-shadow(0 -5px 0 white)
-            `,
-          }}
-        />
-
-        <Image
-          src="/images/mbti/ISFJ.png"
-          alt=""
-          width={100}
-          height={100}
-          className="absolute bottom-8 left-50 w-65 rotate-[-10deg] pointer-events-none"
-          style={{
-            filter: `
-            drop-shadow(5px 0 0 white)
-            drop-shadow(-5px 0 0 white)
-            drop-shadow(0 5px 0 white)
-            drop-shadow(0 -5px 0 white)
-            `,
-          }}
-        />
-
-        <div className="relative flex flex-col items-center">
-          <button
-            onClick={handleStartClick}
-            className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
-          >
-            <Image
-              src="/images/StartButton.png"
-              alt="診断スタート"
-              width={320}
-              height={120}
-              className="w-[40vw] max-w-xs min-w-[180px] drop-shadow-md"
-            />
-          </button>
-
-          <button
-            onClick={openHowToPlay}
-            className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
-          >
-            <Image
-              src="/images/asobikata_button.png"
-              alt="あそびかた"
-              width={120}
-              height={120}
-              className="w-[20vw] max-w-[180px] min-w-[90px] drop-shadow-md"
-            />
-          </button>
-
-          {showExplosion && <SparklesExplosion />}
-        </div>
-
-        {/* SlideModal に children 配列を渡す（SlideModal が children 配列を受け取る実装の前提） */}
-        <SlideModal
-          open={showHowToPlay}
-          onComplete={closeHowToPlay}
-          completeLabel="完了！"
-          ariaLabel="あそびかた 説明"
-          classNames={{
-            // 背景画像をカード内に収める（切れないように contain 指定、真ん中に）
-            card: 'relative bg-white overflow-hidden [&>*]:relative [&>*]:z-10',
-          }}
-        >
-          {howToPlaySlides}
-        </SlideModal>
+        <TopMenu />
       </div>
     </div>
   );

--- a/frontend/src/features/top/components/MbtiDecorations.tsx
+++ b/frontend/src/features/top/components/MbtiDecorations.tsx
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+import type { CSSProperties } from 'react';
+
+/** MBTI キャラ画像共通の白フチ（drop-shadow 4 方向）。 */
+const WHITE_OUTLINE: CSSProperties = {
+  filter: `
+    drop-shadow(5px 0 0 white)
+    drop-shadow(-5px 0 0 white)
+    drop-shadow(0 5px 0 white)
+    drop-shadow(0 -5px 0 white)
+  `,
+};
+
+/** トップ画面の四隅に配置する MBTI キャラ装飾（位置・回転のみ個別）。 */
+const MBTI_DECORATIONS = [
+  { code: 'ESFP', className: 'top-5 right-20 w-60 rotate-[-15deg]' },
+  { code: 'INTJ', className: 'bottom-8 right-50 w-65 rotate-[15deg]' },
+  { code: 'INFP', className: 'top-5 left-20 w-60 rotate-[3deg]' },
+  { code: 'ISFJ', className: 'bottom-8 left-50 w-65 rotate-[-10deg]' },
+] as const;
+
+/**
+ * トップ画面の背景を彩る MBTI キャラ装飾画像。
+ * 静的な装飾のみで状態を持たないため Server Component として描画する。
+ */
+export default function MbtiDecorations() {
+  return (
+    <>
+      {MBTI_DECORATIONS.map(({ code, className }) => (
+        <Image
+          key={code}
+          src={`/images/mbti/${code}.png`}
+          alt=""
+          width={100}
+          height={100}
+          className={`absolute pointer-events-none ${className}`}
+          style={WHITE_OUTLINE}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/features/top/components/SparklesExplosion.tsx
+++ b/frontend/src/features/top/components/SparklesExplosion.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+const SPARKLE_COUNT = 20;
+const SPARKLE_COLORS = ['#e9eb7c', '#ee7ee6', '#6eb8ca', '#e17a78', '#91ec77'];
+
+/**
+ * スタートボタン押下時に中心から弾けるまる爆発エフェクト。
+ * マウント時に 1 回だけ再生する（表示制御は親の条件レンダリングで行う）。
+ */
+export default function SparklesExplosion() {
+  const sparkles = Array.from({ length: SPARKLE_COUNT }, (_, index) => {
+    const angle = (360 / SPARKLE_COUNT) * index;
+    const rad = (angle * Math.PI) / 180;
+    const distance = 60 + index * 3;
+    // 元の transform: rotate(angle) translateY(distance) と同じ到達点を直交座標で算出
+    return {
+      id: index,
+      size: 6 + (index % 5) * 2,
+      color: SPARKLE_COLORS[index % SPARKLE_COLORS.length],
+      dx: -distance * Math.sin(rad),
+      dy: distance * Math.cos(rad),
+    };
+  });
+
+  return (
+    <div className="absolute inset-0 pointer-events-none">
+      {sparkles.map((s) => (
+        <motion.div
+          key={s.id}
+          className="absolute top-1/2 left-1/2 rounded-full"
+          style={{ width: s.size, height: s.size, backgroundColor: s.color }}
+          initial={{ x: 0, y: 0, scale: 0, opacity: 1 }}
+          animate={{
+            x: [0, s.dx, s.dx],
+            y: [0, s.dy, s.dy],
+            scale: [0, 1.2, 0],
+            opacity: [1, 1, 0],
+          }}
+          transition={{ duration: 0.6, ease: 'easeOut', times: [0, 0.5, 1] }}
+          // 中心合わせ（-50%）と framer の x/y/scale を合成する
+          transformTemplate={({ x, y, scale }) =>
+            `translate(-50%, -50%) translateX(${x}) translateY(${y}) scale(${scale})`
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/top/components/TopMenu.tsx
+++ b/frontend/src/features/top/components/TopMenu.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
+import SlideModal from '@/components/common/SlideModal';
+import { useSe } from '@/components/audio/useSe';
+import SparklesExplosion from './SparklesExplosion';
+
+/**
+ * トップ画面のインタラクティブ部分（スタート / あそびかたボタン・爆発演出・
+ * あそびかたモーダル）。クリック操作と状態を持つためここだけ Client Component。
+ * 静的な背景・ロゴ・装飾は page.tsx（Server Component）側が描画する。
+ */
+export default function TopMenu() {
+  const router = useRouter();
+  const playSe = useSe();
+  const [showExplosion, setShowExplosion] = useState(false);
+  const [showHowToPlay, setShowHowToPlay] = useState(false);
+
+  const handleStartClick = () => {
+    setShowExplosion(true);
+
+    playSe('start');
+
+    setTimeout(() => {
+      router.push('/games/terms');
+    }, 800);
+
+    setTimeout(() => {
+      setShowExplosion(false);
+    }, 800);
+  };
+
+  const openHowToPlay = () => {
+    setShowHowToPlay(true);
+  };
+
+  const closeHowToPlay = () => {
+    setShowHowToPlay(false);
+  };
+
+  return (
+    <>
+      <div className="relative flex flex-col items-center">
+        <button
+          onClick={handleStartClick}
+          className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
+        >
+          <Image
+            src="/images/StartButton.png"
+            alt="診断スタート"
+            width={320}
+            height={120}
+            className="w-[40vw] max-w-xs min-w-[180px] drop-shadow-md"
+          />
+        </button>
+
+        <button
+          onClick={openHowToPlay}
+          className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
+        >
+          <Image
+            src="/images/asobikata_button.png"
+            alt="あそびかた"
+            width={120}
+            height={120}
+            className="w-[20vw] max-w-[180px] min-w-[90px] drop-shadow-md"
+          />
+        </button>
+
+        {showExplosion && <SparklesExplosion />}
+      </div>
+
+      {/* SlideModal に children 配列を渡す（SlideModal が children 配列を受け取る実装の前提） */}
+      <SlideModal
+        open={showHowToPlay}
+        onComplete={closeHowToPlay}
+        completeLabel="完了！"
+        ariaLabel="あそびかた 説明"
+        classNames={{
+          // 背景画像をカード内に収める（切れないように contain 指定、真ん中に）
+          card: 'relative bg-white overflow-hidden [&>*]:relative [&>*]:z-10',
+        }}
+      >
+        {howToPlaySlides}
+      </SlideModal>
+    </>
+  );
+}


### PR DESCRIPTION
## 概要

トップページ（`page.tsx`）を frontend.md のルール（page.tsx は Server Component に保つ / `'use client'` はインタラクション末端に限定 / 巨大な Client Component を避ける）に沿ってリファクタする。**見た目・挙動は変えない純粋リファクタ**（Playwright でトップ表示が元どおりであることを確認済み）。

このリファクタの後に、音量調整 UI（タイトル画面の「おと」ボタン → 設定モーダル方式）を追加する予定です。

> このPRは #192（se-foundation）から派生したスタックPRです。#192 マージ後にベースを develop へ繰り上げます。

## 変更内容

- `app/page.tsx`: `'use client'` を外して **Server Component 化**。背景・ロゴ・装飾・`<TopMenu/>` の組み立てのみに。
- `features/top/components/TopMenu.tsx`（新規・Client）: スタート/あそびかたボタン・爆発演出・あそびかたモーダル・SE(`useSe`)・遷移を集約。インタラクションはここに閉じる。
- `features/top/components/MbtiDecorations.tsx`（新規・Server）: MBTIキャラ4枚。重複していた4つの Image を配列で map 描画（位置・回転のみ個別、白フチ filter は共通定数）＝DRY 化。
- `features/top/components/SparklesExplosion.tsx`（新規・Client）: 爆発エフェクトを分離し、inline `<style>` + `@keyframes` + CSS 変数を **framer-motion に置き換え**（到達点・タイミング・中心合わせは元と同等）。

## 補足

- `/`（トップ）はリファクタ後も静的プリレンダリング（Server Component 化が効いている）。
