### PR TITLE
feat: トップのボタンをコード化し音量設定UI・レスポンシブ対応を追加

### DIFF
--- a/frontend/src/components/audio/VolumeControl.tsx
+++ b/frontend/src/components/audio/VolumeControl.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { Music, Volume2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { bgmVolumeAtom, seVolumeAtom } from '@/stores/audio';
+import { useSe } from './useSe';
+
+type SliderRowProps = {
+  icon: ReactNode;
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  /** スライダー操作を確定したとき（プレビュー音などに使う） */
+  onCommit?: () => void;
+};
+
+function SliderRow({ icon, label, value, onChange, onCommit }: SliderRowProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="flex w-20 shrink-0 items-center gap-1.5 text-base font-extrabold text-gray-800">
+        {icon}
+        {label}
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={1}
+        step={0.05}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        onPointerUp={onCommit}
+        onKeyUp={onCommit}
+        aria-label={`${label}の音量`}
+        className="h-3 flex-1 cursor-pointer accent-rose-400"
+      />
+      <span className="w-12 shrink-0 text-right text-sm font-extrabold tabular-nums text-gray-600">
+        {Math.round(value * 100)}%
+      </span>
+    </div>
+  );
+}
+
+/**
+ * BGM / 効果音の音量を調整するスライダー UI。
+ * `bgmVolumeAtom` / `seVolumeAtom`（localStorage 永続化）を読み書きし、
+ * 変更は AudioController（BGM）と useSe（SE）に即時反映される。
+ */
+export function VolumeControl() {
+  const [bgmVolume, setBgmVolume] = useAtom(bgmVolumeAtom);
+  const [seVolume, setSeVolume] = useAtom(seVolumeAtom);
+  const playSe = useSe();
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <SliderRow
+        icon={<Music size={16} aria-hidden />}
+        label="BGM"
+        value={bgmVolume}
+        onChange={setBgmVolume}
+      />
+      <SliderRow
+        icon={<Volume2 size={16} aria-hidden />}
+        label="効果音"
+        value={seVolume}
+        onChange={setSeVolume}
+        // 効果音は鳴らさないと音量が分からないため、調整後にプレビュー再生する。
+        onCommit={() => playSe('buttonClick')}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/top/components/MbtiDecorations.tsx
+++ b/frontend/src/features/top/components/MbtiDecorations.tsx
@@ -22,6 +22,8 @@ const MBTI_DECORATIONS = [
 /**
  * トップ画面の背景を彩る MBTI キャラ装飾画像。
  * 静的な装飾のみで状態を持たないため Server Component として描画する。
+ *
+ * 四隅への絶対配置が前提のため、ロゴ・ボタンと重なる狭い画面（lg 未満）では非表示にする。
  */
 export default function MbtiDecorations() {
   return (
@@ -33,7 +35,7 @@ export default function MbtiDecorations() {
           alt=""
           width={100}
           height={100}
-          className={`absolute pointer-events-none ${className}`}
+          className={`absolute hidden pointer-events-none lg:block ${className}`}
           style={WHITE_OUTLINE}
         />
       ))}

--- a/frontend/src/features/top/components/TopMenu.tsx
+++ b/frontend/src/features/top/components/TopMenu.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { HelpCircle, Volume2 } from 'lucide-react';
 import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
 import SlideModal from '@/components/common/SlideModal';
 import { useSe } from '@/components/audio/useSe';
 import SparklesExplosion from './SparklesExplosion';
+import VolumeModal from './VolumeModal';
 
 /**
- * トップ画面のインタラクティブ部分（スタート / あそびかたボタン・爆発演出・
- * あそびかたモーダル）。クリック操作と状態を持つためここだけ Client Component。
+ * トップ画面のインタラクティブ部分（スタート / あそびかた / おとボタン・爆発演出・
+ * あそびかた / 音量モーダル）。クリック操作と状態を持つためここだけ Client Component。
  * 静的な背景・ロゴ・装飾は page.tsx（Server Component）側が描画する。
  */
 export default function TopMenu() {
@@ -18,10 +19,10 @@ export default function TopMenu() {
   const playSe = useSe();
   const [showExplosion, setShowExplosion] = useState(false);
   const [showHowToPlay, setShowHowToPlay] = useState(false);
+  const [showVolume, setShowVolume] = useState(false);
 
   const handleStartClick = () => {
     setShowExplosion(true);
-
     playSe('start');
 
     setTimeout(() => {
@@ -34,41 +35,57 @@ export default function TopMenu() {
   };
 
   const openHowToPlay = () => {
+    playSe('buttonClick');
     setShowHowToPlay(true);
   };
 
-  const closeHowToPlay = () => {
-    setShowHowToPlay(false);
+  const openVolume = () => {
+    playSe('buttonClick');
+    setShowVolume(true);
   };
 
   return (
     <>
-      <div className="relative flex flex-col items-center">
+      <div className="relative flex flex-col items-center gap-4">
+        {/* スタート（主役の rose pill） */}
         <button
+          type="button"
           onClick={handleStartClick}
-          className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
+          className="w-[80vw] max-w-xs min-w-[200px] rounded-full border-4 border-gray-800 bg-gradient-to-br from-rose-400 to-rose-500 py-4 text-[28px] font-black text-white shadow-[0_7px_0_#1f2937] transition-transform hover:-translate-y-0.5 active:translate-y-[5px] active:shadow-[0_2px_0_#1f2937]"
         >
-          <Image
-            src="/images/StartButton.png"
-            alt="診断スタート"
-            width={320}
-            height={120}
-            className="w-[40vw] max-w-xs min-w-[180px] drop-shadow-md"
-          />
+          スタート ▶
         </button>
 
-        <button
-          onClick={openHowToPlay}
-          className="transition-all duration-100 ease-out hover:scale-110 active:scale-95 active:opacity-50"
-        >
-          <Image
-            src="/images/asobikata_button.png"
-            alt="あそびかた"
-            width={120}
-            height={120}
-            className="w-[20vw] max-w-[180px] min-w-[90px] drop-shadow-md"
-          />
-        </button>
+        {/* あそびかた / おと（丸アイコン＋ラベル） */}
+        <div className="flex gap-7">
+          <button
+            type="button"
+            onClick={openHowToPlay}
+            aria-label="あそびかた"
+            className="flex flex-col items-center gap-1.5"
+          >
+            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#8EE3FA] text-white shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
+              <HelpCircle size={28} strokeWidth={2.5} aria-hidden />
+            </span>
+            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
+              あそびかた
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={openVolume}
+            aria-label="おと"
+            className="flex flex-col items-center gap-1.5"
+          >
+            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#FFD77B] text-gray-800 shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
+              <Volume2 size={28} strokeWidth={2.5} aria-hidden />
+            </span>
+            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
+              おと
+            </span>
+          </button>
+        </div>
 
         {showExplosion && <SparklesExplosion />}
       </div>
@@ -76,7 +93,7 @@ export default function TopMenu() {
       {/* SlideModal に children 配列を渡す（SlideModal が children 配列を受け取る実装の前提） */}
       <SlideModal
         open={showHowToPlay}
-        onComplete={closeHowToPlay}
+        onComplete={() => setShowHowToPlay(false)}
         completeLabel="完了！"
         ariaLabel="あそびかた 説明"
         classNames={{
@@ -86,6 +103,8 @@ export default function TopMenu() {
       >
         {howToPlaySlides}
       </SlideModal>
+
+      <VolumeModal open={showVolume} onClose={() => setShowVolume(false)} />
     </>
   );
 }

--- a/frontend/src/features/top/components/VolumeModal.tsx
+++ b/frontend/src/features/top/components/VolumeModal.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { VolumeControl } from '@/components/audio/VolumeControl';
+
+type VolumeModalProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+/**
+ * 「おと」ボタンから開く音量設定モーダル。
+ * オーバーレイのクリック / 「とじる」で閉じる。中身は共通の VolumeControl。
+ */
+export default function VolumeModal({ open, onClose }: VolumeModalProps) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 backdrop-blur-md"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          onClick={onClose}
+          role="dialog"
+          aria-modal="true"
+          aria-label="おとのせってい"
+        >
+          <motion.div
+            className="relative w-[420px] max-w-full rounded-[32px] border-4 border-gray-800 bg-white px-8 pt-12 pb-7 shadow-[0_8px_0_#1f2937]"
+            initial={{ scale: 0.9, y: 8 }}
+            animate={{ scale: 1, y: 0 }}
+            exit={{ scale: 0.9, y: 8 }}
+            transition={{ duration: 0.2 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* タイトル pill（カード上端にかぶせる） */}
+            <div className="absolute -top-6 left-1/2 -translate-x-1/2">
+              <div className="rounded-full border-4 border-gray-800 bg-[#FFD77B] px-8 py-2 shadow-[0_4px_0_#1f2937]">
+                <p className="text-xl font-black whitespace-nowrap text-gray-900">
+                  おとのせってい
+                </p>
+              </div>
+            </div>
+
+            <div className="mb-7">
+              <VolumeControl />
+            </div>
+
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full cursor-pointer rounded-2xl border-[3px] border-gray-800 bg-rose-300 py-3.5 text-base font-black text-gray-900 shadow-[0_4px_0_#1f2937] transition-transform hover:-translate-y-0.5 active:translate-y-0"
+            >
+              とじる
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## 概要

トップ画面のボタンを画像（PNG）からコードベースに刷新し、音量設定 UI とトップの最低限のレスポンシブ対応を追加する。これまで構築した BGM/SE 共通基盤（`bgmVolumeAtom` / `seVolumeAtom`）をユーザーが操作できるようにする。

closes #188

## 変更内容

### 1. ボタンのコード化（デザイン案D） `TopMenu.tsx`
- スタート / あそびかたの PNG 画像ボタンを廃止し、コードベースのボタンに刷新（サイズ・余白・配色を CSS で調整可能に）。
- スタート＝rose グラデの pill、あそびかた＝水色（#8EE3FA）の丸アイコン、おと＝黄（#FFD77B）の丸アイコン。Real You の既存パレット・太枠・ハードシャドウに統一。

### 2. 音量設定 UI `VolumeModal.tsx` / `VolumeControl.tsx`（新規）
- 「おと」ボタンから音量設定モーダルを開く。タイトルは黄 pill をカード上端にかぶせる Real You トーン。
- BGM / 効果音の2スライダーで `bgmVolumeAtom` / `seVolumeAtom` を操作。再生中の BGM と以降の SE に即時反映（localStorage 永続化）。効果音は調整確定時にプレビュー再生。

### 3. トップの最低限のレスポンシブ対応 `MbtiDecorations.tsx`
- MBTI キャラ装飾は四隅への絶対配置が前提で、狭い画面ではロゴ・ボタンに被って破綻するため `lg` 未満で非表示にする。
- モバイル / タブレットはロゴ＋ボタンに絞り、PC（`lg` 以上）でのみ装飾を表示。Playwright で 390 / 768 / 1280 幅の表示を確認済み。

## 補足

- 音量 UI はトップページのみに表示（全画面フローティングはスコープ外）。
- モーダルの Esc 閉じ / フォーカストラップは未実装（必要なら follow-up）。
