### PR TITLE
トップ：音量メニューに即ミュート追加・遊び方のスタイル統一

### DIFF
--- a/frontend/src/components/audio/useVolumeMute.ts
+++ b/frontend/src/components/audio/useVolumeMute.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useAtom } from 'jotai';
+import { bgmVolumeAtom, seVolumeAtom } from '@/stores/audio';
+
+/** ミュート解除時に復元する音量の退避先（localStorage キー） */
+const MUTE_BACKUP_KEY = 'realyou:premuteVolumes';
+/** 退避値が無い場合に復元するデフォルト音量（0〜1） */
+const FALLBACK_VOLUME = 1;
+
+/**
+ * BGM / SE の即ミュート切り替え。
+ * ミュート時は現在値を localStorage に退避し、解除時に復元する。
+ */
+export function useVolumeMute() {
+  const [bgmVolume, setBgmVolume] = useAtom(bgmVolumeAtom);
+  const [seVolume, setSeVolume] = useAtom(seVolumeAtom);
+  const muted = bgmVolume === 0 && seVolume === 0;
+
+  const toggleMute = () => {
+    if (muted) {
+      let restore = { bgm: FALLBACK_VOLUME, se: FALLBACK_VOLUME };
+      try {
+        const raw = localStorage.getItem(MUTE_BACKUP_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as { bgm?: number; se?: number };
+          if (typeof parsed.bgm === 'number') restore.bgm = parsed.bgm;
+          if (typeof parsed.se === 'number') restore.se = parsed.se;
+        }
+      } catch {
+        // 読み込み失敗時は既定値で復元
+      }
+      setBgmVolume(restore.bgm > 0 ? restore.bgm : FALLBACK_VOLUME);
+      setSeVolume(restore.se > 0 ? restore.se : FALLBACK_VOLUME);
+    } else {
+      try {
+        localStorage.setItem(
+          MUTE_BACKUP_KEY,
+          JSON.stringify({ bgm: bgmVolume, se: seVolume })
+        );
+      } catch {
+        // 退避失敗しても 0 にはする
+      }
+      setBgmVolume(0);
+      setSeVolume(0);
+    }
+  };
+
+  return { muted, toggleMute };
+}

--- a/frontend/src/components/audio/useVolumeMute.ts
+++ b/frontend/src/components/audio/useVolumeMute.ts
@@ -19,19 +19,20 @@ export function useVolumeMute() {
 
   const toggleMute = () => {
     if (muted) {
-      let restore = { bgm: FALLBACK_VOLUME, se: FALLBACK_VOLUME };
+      let bgm = FALLBACK_VOLUME;
+      let se = FALLBACK_VOLUME;
       try {
         const raw = localStorage.getItem(MUTE_BACKUP_KEY);
         if (raw) {
           const parsed = JSON.parse(raw) as { bgm?: number; se?: number };
-          if (typeof parsed.bgm === 'number') restore.bgm = parsed.bgm;
-          if (typeof parsed.se === 'number') restore.se = parsed.se;
+          if (typeof parsed.bgm === 'number') bgm = parsed.bgm;
+          if (typeof parsed.se === 'number') se = parsed.se;
         }
       } catch {
         // 読み込み失敗時は既定値で復元
       }
-      setBgmVolume(restore.bgm > 0 ? restore.bgm : FALLBACK_VOLUME);
-      setSeVolume(restore.se > 0 ? restore.se : FALLBACK_VOLUME);
+      setBgmVolume(bgm > 0 ? bgm : FALLBACK_VOLUME);
+      setSeVolume(se > 0 ? se : FALLBACK_VOLUME);
     } else {
       try {
         localStorage.setItem(

--- a/frontend/src/features/top/components/HowToPlayModal.tsx
+++ b/frontend/src/features/top/components/HowToPlayModal.tsx
@@ -3,28 +3,44 @@
 import type { JSX, ReactNode } from 'react';
 import Image from 'next/image';
 
-/** 他画面と揃えた強調テキスト（黒フチ＋ローズ） */
-function AccentText({ children }: { children: ReactNode }) {
+const TEXT_OUTLINE = {
+  textShadow:
+    '-2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000',
+} as const;
+
+/** 黄背景ステッカー（結果画面の一言タイトルに近い、読みやすい強調） */
+function StickerAccent({ children }: { children: ReactNode }) {
   return (
-    <span
-      className="font-black text-rose-500"
-      style={{
-        textShadow:
-          '-2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000',
-      }}
-    >
+    <span className="inline-block rounded-md border-2 border-black bg-[#ffe175] px-2 py-0.5 font-black text-[#0e7490] shadow-[2px_2px_0_0_#000]">
       {children}
     </span>
   );
 }
 
-/** マーカー風の黄色ハイライト */
-function HighlightMarker({ className }: { className?: string }) {
+/** 数字など単体の強調（ローズ＋黒フチ） */
+function AccentText({ children }: { children: ReactNode }) {
   return (
-    <div
-      className={`absolute rounded-full bg-[#f1cf44] opacity-40 [-z-10] ${className ?? ''}`}
-      aria-hidden
-    />
+    <span className="font-black text-rose-500" style={TEXT_OUTLINE}>
+      {children}
+    </span>
+  );
+}
+
+/**
+ * 下から少しだけ隠して強調（3枚目用）。
+ * 黄色バーが文字の下半分をかぶせ、見える部分が目立つ。
+ */
+function PeekEmphasis({ children }: { children: ReactNode }) {
+  return (
+    <span className="relative mx-0.5 inline-block align-baseline">
+      <span className="relative z-10 font-black text-rose-500" style={TEXT_OUTLINE}>
+        {children}
+      </span>
+      <span
+        className="pointer-events-none absolute -bottom-1 left-[-0.12em] right-[-0.12em] z-20 h-[0.52em] rounded-sm border-2 border-black bg-[#f1cf44] shadow-[2px_2px_0_0_#000]"
+        aria-hidden
+      />
+    </span>
   );
 }
 
@@ -98,13 +114,10 @@ export const howToPlaySlides: JSX.Element[] = [
     <h2 className="mb-1 text-5xl font-black tracking-wide text-gray-900 sm:text-6xl">
       Real Youとは？
     </h2>
-    <div className="relative mb-2 text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
-      <span className="relative z-10">
-        <AccentText>「本当のあなた」</AccentText>
-        が分かる、新しい性格診断アプリ。
-      </span>
-      <HighlightMarker className="left-1/2 top-1/2 h-7 w-[min(555px,90%)] -translate-x-1/2 -translate-y-1/2" />
-    </div>
+    <p className="mb-2 text-center text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
+      <StickerAccent>「本当のあなた」</StickerAccent>
+      が分かる、新しい性格診断アプリ。
+    </p>
     <div className="mt-5 space-y-1 text-base font-bold leading-relaxed text-gray-800">
       <p>直感のままにプレイするだけ。</p>
       <p>あなたらしさが、自然とあらわれます。</p>
@@ -149,11 +162,10 @@ export const howToPlaySlides: JSX.Element[] = [
       className="absolute bottom-4 left-4 w-28"
     />
 
-    <h2 className="relative mb-1 text-4xl font-black tracking-wide text-gray-900 sm:text-5xl">
+    <h2 className="mb-1 text-4xl font-black tracking-wide text-gray-900 sm:text-5xl">
       プレイ時間は約
       <AccentText>5</AccentText>
       分！
-      <HighlightMarker className="right-[17.5%] top-1/3 h-15 w-[175px] -translate-x-1/2 -translate-y-1/4" />
     </h2>
     <p className="mb-5 text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
       ゲームでサクッと、診断完了！
@@ -233,11 +245,10 @@ export const howToPlaySlides: JSX.Element[] = [
       className="absolute bottom-12 left-18 w-25"
     />
 
-    <h2 className="relative text-3xl font-black leading-relaxed tracking-wide text-gray-900 sm:text-4xl">
+    <h2 className="text-3xl font-black leading-relaxed tracking-wide text-gray-900 sm:text-4xl">
       さあ！
-      <AccentText>「本当の自分」</AccentText>
+      <PeekEmphasis>「本当の自分」</PeekEmphasis>
       に会いに行こう！
-      <HighlightMarker className="left-[38%] top-1/2 h-15 w-[300px] -translate-x-1/2 -translate-y-1/2" />
     </h2>
   </div>,
 ];

--- a/frontend/src/features/top/components/HowToPlayModal.tsx
+++ b/frontend/src/features/top/components/HowToPlayModal.tsx
@@ -22,7 +22,9 @@ function EmphasisText({
 
 /** 数字など単体の強調 */
 function AccentText({ children }: { children: ReactNode }) {
-  return <span className="text-[1.15em] font-black text-rose-500">{children}</span>;
+  return (
+    <span className="text-[1.15em] font-black text-rose-500">{children}</span>
+  );
 }
 
 export const howToPlaySlides: JSX.Element[] = [

--- a/frontend/src/features/top/components/HowToPlayModal.tsx
+++ b/frontend/src/features/top/components/HowToPlayModal.tsx
@@ -1,16 +1,41 @@
 'use client';
 
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
 import Image from 'next/image';
 
+/** 他画面と揃えた強調テキスト（黒フチ＋ローズ） */
+function AccentText({ children }: { children: ReactNode }) {
+  return (
+    <span
+      className="font-black text-rose-500"
+      style={{
+        textShadow:
+          '-2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** マーカー風の黄色ハイライト */
+function HighlightMarker({ className }: { className?: string }) {
+  return (
+    <div
+      className={`absolute rounded-full bg-[#f1cf44] opacity-40 [-z-10] ${className ?? ''}`}
+      aria-hidden
+    />
+  );
+}
+
 export const howToPlaySlides: JSX.Element[] = [
-  <div key="page1" className="flex flex-col items-center mt-0">
+  <div key="page1" className="mt-0 flex flex-col items-center">
     <Image
       src="/images/fukidashi.png"
       alt=""
       width={1000}
       height={1000}
-      className="pointer-events-none absolute inset-4 m-auto w-auto max-h-[90%] object-contain -z-10"
+      className="pointer-events-none absolute inset-4 -z-10 m-auto max-h-[90%] w-auto object-contain"
     />
 
     <Image
@@ -70,29 +95,29 @@ export const howToPlaySlides: JSX.Element[] = [
       className="absolute bottom-20 left-20 w-25"
     />
 
-    <h2 className="mb-1 text-7xl font-bold leading-relaxed">Real Youとは？</h2>
-    <div className="mb-2 text-2xl leading-relaxed relative">
+    <h2 className="mb-1 text-5xl font-black tracking-wide text-gray-900 sm:text-6xl">
+      Real Youとは？
+    </h2>
+    <div className="relative mb-2 text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
       <span className="relative z-10">
-        <span className="text-blue-500 font-extrabold  [-webkit-text-stroke:1px_#000] [-webkit-text-fill-color:#ff00ff]">
-          「本当のあなた」
-        </span>
+        <AccentText>「本当のあなた」</AccentText>
         が分かる、新しい性格診断アプリ。
       </span>
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-7 w-[555px] bg-yellow-500 rounded-full opacity-30 [-z-10]" />
+      <HighlightMarker className="left-1/2 top-1/2 h-7 w-[min(555px,90%)] -translate-x-1/2 -translate-y-1/2" />
     </div>
-    <div className="space-y-1 text-base font-bold leading-relaxed text-[#111] mt-5">
+    <div className="mt-5 space-y-1 text-base font-bold leading-relaxed text-gray-800">
       <p>直感のままにプレイするだけ。</p>
       <p>あなたらしさが、自然とあらわれます。</p>
     </div>
   </div>,
 
-  <div key="page2" className="flex flex-col items-center mt-4">
+  <div key="page2" className="mt-4 flex flex-col items-center">
     <Image
       src="/images/fukidashi.png"
       alt=""
       width={1000}
       height={1000}
-      className="pointer-events-none absolute inset-4 m-auto w-auto max-h-[90%] object-contain -z-10"
+      className="pointer-events-none absolute inset-4 -z-10 m-auto max-h-[90%] w-auto object-contain"
     />
 
     <Image
@@ -107,7 +132,7 @@ export const howToPlaySlides: JSX.Element[] = [
       alt=""
       width={92}
       height={92}
-      className="absolute top-1 left-5 w-30 rotate-[-25deg] "
+      className="absolute top-1 left-5 w-30 rotate-[-25deg]"
     />
     <Image
       src="/images/PC.png"
@@ -124,18 +149,16 @@ export const howToPlaySlides: JSX.Element[] = [
       className="absolute bottom-4 left-4 w-28"
     />
 
-    <h2 className="mb-1 text-6xl font-bold leading-relaxed">
+    <h2 className="relative mb-1 text-4xl font-black tracking-wide text-gray-900 sm:text-5xl">
       プレイ時間は約
-      <span className="text-blue-500 font-extrabold  [-webkit-text-stroke:2px_#000] [-webkit-text-fill-color:#ff00ff]">
-        5
-      </span>
+      <AccentText>5</AccentText>
       分！
-      <div className="absolute right-[17.5%] top-1/3 -translate-x-1/2 -translate-y-1/4 h-15 w-[175px] bg-yellow-500 rounded-full opacity-30 [-z-10]" />
+      <HighlightMarker className="right-[17.5%] top-1/3 h-15 w-[175px] -translate-x-1/2 -translate-y-1/4" />
     </h2>
-    <p className="mb-5 text-2xl leading-relaxed">
+    <p className="mb-5 text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
       ゲームでサクッと、診断完了！
     </p>
-    <div className="space-y-1 text-base leading-relaxed text-[#111] text-left text-gray-600">
+    <div className="space-y-1 text-left text-base font-bold leading-relaxed text-gray-800">
       <p>※PCでのプレイをおすすめします</p>
       <p>※ゲーム中、BGMや効果音が流れます</p>
     </div>
@@ -150,7 +173,7 @@ export const howToPlaySlides: JSX.Element[] = [
       alt=""
       width={1000}
       height={1000}
-      className="pointer-events-none absolute inset-4 m-auto w-auto max-h-[90%] object-contain -z-10"
+      className="pointer-events-none absolute inset-4 -z-10 m-auto max-h-[90%] w-auto object-contain"
     />
 
     <Image
@@ -210,13 +233,11 @@ export const howToPlaySlides: JSX.Element[] = [
       className="absolute bottom-12 left-18 w-25"
     />
 
-    <h2 className="text-5xl font-bold leading-relaxed">
+    <h2 className="relative text-3xl font-black leading-relaxed tracking-wide text-gray-900 sm:text-4xl">
       さあ！
-      <span className="text-yellow-500 font-extrabold [-webkit-text-stroke:2px_#000] [-webkit-text-fill-color:#ff00ff]">
-        「本当の自分」
-      </span>
+      <AccentText>「本当の自分」</AccentText>
       に会いに行こう！
+      <HighlightMarker className="left-[38%] top-1/2 h-15 w-[300px] -translate-x-1/2 -translate-y-1/2" />
     </h2>
-    <div className="absolute left-[38%] top-1/2 -translate-x-1/2 -translate-y-1/2 h-15 w-[300px] bg-yellow-500 rounded-full opacity-30 [-z-10]" />
   </div>,
 ];

--- a/frontend/src/features/top/components/HowToPlayModal.tsx
+++ b/frontend/src/features/top/components/HowToPlayModal.tsx
@@ -3,45 +3,26 @@
 import type { JSX, ReactNode } from 'react';
 import Image from 'next/image';
 
-const TEXT_OUTLINE = {
-  textShadow:
-    '-2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000',
-} as const;
-
-/** 黄背景ステッカー（結果画面の一言タイトルに近い、読みやすい強調） */
-function StickerAccent({ children }: { children: ReactNode }) {
+/** 背景なしで文字サイズだけ大きくして強調 */
+function EmphasisText({
+  children,
+  size = 'md',
+}: {
+  children: ReactNode;
+  size?: 'md' | 'lg';
+}) {
+  const sizeClass =
+    size === 'lg'
+      ? 'text-[1.45em] sm:text-[1.55em]'
+      : 'text-[1.3em] sm:text-[1.35em]';
   return (
-    <span className="inline-block rounded-md border-2 border-black bg-[#ffe175] px-2 py-0.5 font-black text-[#0e7490] shadow-[2px_2px_0_0_#000]">
-      {children}
-    </span>
+    <span className={`font-black text-rose-500 ${sizeClass}`}>{children}</span>
   );
 }
 
-/** 数字など単体の強調（ローズ＋黒フチ） */
+/** 数字など単体の強調 */
 function AccentText({ children }: { children: ReactNode }) {
-  return (
-    <span className="font-black text-rose-500" style={TEXT_OUTLINE}>
-      {children}
-    </span>
-  );
-}
-
-/**
- * 下から少しだけ隠して強調（3枚目用）。
- * 黄色バーが文字の下半分をかぶせ、見える部分が目立つ。
- */
-function PeekEmphasis({ children }: { children: ReactNode }) {
-  return (
-    <span className="relative mx-0.5 inline-block align-baseline">
-      <span className="relative z-10 font-black text-rose-500" style={TEXT_OUTLINE}>
-        {children}
-      </span>
-      <span
-        className="pointer-events-none absolute -bottom-1 left-[-0.12em] right-[-0.12em] z-20 h-[0.52em] rounded-sm border-2 border-black bg-[#f1cf44] shadow-[2px_2px_0_0_#000]"
-        aria-hidden
-      />
-    </span>
-  );
+  return <span className="text-[1.15em] font-black text-rose-500">{children}</span>;
 }
 
 export const howToPlaySlides: JSX.Element[] = [
@@ -115,7 +96,7 @@ export const howToPlaySlides: JSX.Element[] = [
       Real Youとは？
     </h2>
     <p className="mb-2 text-center text-xl font-bold leading-relaxed text-gray-800 sm:text-2xl">
-      <StickerAccent>「本当のあなた」</StickerAccent>
+      <EmphasisText>「本当のあなた」</EmphasisText>
       が分かる、新しい性格診断アプリ。
     </p>
     <div className="mt-5 space-y-1 text-base font-bold leading-relaxed text-gray-800">
@@ -247,7 +228,7 @@ export const howToPlaySlides: JSX.Element[] = [
 
     <h2 className="text-3xl font-black leading-relaxed tracking-wide text-gray-900 sm:text-4xl">
       さあ！
-      <PeekEmphasis>「本当の自分」</PeekEmphasis>
+      <EmphasisText size="lg">「本当の自分」</EmphasisText>
       に会いに行こう！
     </h2>
   </div>,

--- a/frontend/src/features/top/components/TopMenu.tsx
+++ b/frontend/src/features/top/components/TopMenu.tsx
@@ -1,176 +1,108 @@
 'use client';
 
-import { Volume2, VolumeX, HelpCircle, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { useAudioSettings } from '@/features/audio/hooks/useAudioSettings';
-import HowToPlayModal from './HowToPlayModal';
-
-interface TopMenuProps {
-  /** メニューを閉じるコールバック */
-  onClose: () => void;
-}
-
-/** ミュート解除時に復元する音量の退避先（localStorage キー） */
-const MUTE_BACKUP_KEY = 'realyou_premute_volumes';
-/** 退避値が無い場合に復元するデフォルト音量 */
-const FALLBACK_VOLUME = 50;
+import { HelpCircle, Volume2 } from 'lucide-react';
+import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
+import SlideModal from '@/components/common/SlideModal';
+import { useSe } from '@/components/audio/useSe';
+import SparklesExplosion from './SparklesExplosion';
+import VolumeModal from './VolumeModal';
 
 /**
- * トップページのメニューモーダル。
- * 音量設定（BGM/SE）と遊び方の確認ができる。
+ * トップ画面のインタラクティブ部分（スタート / あそびかた / おとボタン・爆発演出・
+ * あそびかた / 音量モーダル）。クリック操作と状態を持つためここだけ Client Component。
+ * 静的な背景・ロゴ・装飾は page.tsx（Server Component）側が描画する。
  */
-export default function TopMenu({ onClose }: TopMenuProps) {
-  const { bgmVolume, seVolume, setBgmVolume, setSeVolume, isLoaded } =
-    useAudioSettings();
+export default function TopMenu() {
+  const router = useRouter();
+  const playSe = useSe();
+  const [showExplosion, setShowExplosion] = useState(false);
   const [showHowToPlay, setShowHowToPlay] = useState(false);
+  const [showVolume, setShowVolume] = useState(false);
 
-  // BGM・SE がどちらも 0 のときをミュート状態とみなす
-  const muted = isLoaded && bgmVolume === 0 && seVolume === 0;
+  const handleStartClick = () => {
+    setShowExplosion(true);
+    playSe('start');
 
-  /**
-   * 即ミュート切り替え。
-   * - ミュート時：現在の音量を localStorage に退避してから両方 0 にする
-   * - 解除時：退避値（無ければ既定値）へ復元する
-   * 退避先を localStorage にすることで、モーダルを閉じ直しても復元できる。
-   */
-  const toggleMute = () => {
-    if (muted) {
-      let restore = { bgm: FALLBACK_VOLUME, se: FALLBACK_VOLUME };
-      try {
-        const raw = localStorage.getItem(MUTE_BACKUP_KEY);
-        if (raw) {
-          const parsed = JSON.parse(raw) as { bgm?: number; se?: number };
-          restore = {
-            bgm: typeof parsed.bgm === 'number' ? parsed.bgm : FALLBACK_VOLUME,
-            se: typeof parsed.se === 'number' ? parsed.se : FALLBACK_VOLUME,
-          };
-        }
-      } catch {
-        // 読み込み失敗時は既定値で復元
-      }
-      setBgmVolume(restore.bgm > 0 ? restore.bgm : FALLBACK_VOLUME);
-      setSeVolume(restore.se > 0 ? restore.se : FALLBACK_VOLUME);
-    } else {
-      try {
-        localStorage.setItem(
-          MUTE_BACKUP_KEY,
-          JSON.stringify({ bgm: bgmVolume, se: seVolume })
-        );
-      } catch {
-        // 退避失敗しても 0 にはする
-      }
-      setBgmVolume(0);
-      setSeVolume(0);
-    }
+    setTimeout(() => {
+      router.push('/games/terms');
+    }, 800);
+
+    setTimeout(() => {
+      setShowExplosion(false);
+    }, 800);
+  };
+
+  const openHowToPlay = () => {
+    playSe('buttonClick');
+    setShowHowToPlay(true);
+  };
+
+  const openVolume = () => {
+    playSe('buttonClick');
+    setShowVolume(true);
   };
 
   return (
     <>
-      <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-        onClick={onClose}
-      >
-        <div
-          className="relative w-full max-w-md rounded-3xl border-4 border-black bg-white p-6 shadow-[8px_8px_0_0_#000]"
-          onClick={(e) => e.stopPropagation()}
+      <div className="relative flex flex-col items-center gap-4">
+        {/* スタート（主役の rose pill） */}
+        <button
+          type="button"
+          onClick={handleStartClick}
+          className="w-[80vw] max-w-xs min-w-[200px] rounded-full border-4 border-gray-800 bg-gradient-to-br from-rose-400 to-rose-500 py-4 text-[28px] font-black text-white shadow-[0_7px_0_#1f2937] transition-transform hover:-translate-y-0.5 active:translate-y-[5px] active:shadow-[0_2px_0_#1f2937]"
         >
-          {/* 閉じるボタン */}
+          スタート ▶
+        </button>
+
+        {/* あそびかた / おと（丸アイコン＋ラベル） */}
+        <div className="flex gap-7">
           <button
-            onClick={onClose}
-            className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full border-2 border-black bg-white transition hover:bg-gray-100"
-            aria-label="閉じる"
+            type="button"
+            onClick={openHowToPlay}
+            aria-label="あそびかた"
+            className="flex flex-col items-center gap-1.5"
           >
-            <X className="h-5 w-5" />
+            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#f1cf44] text-gray-900 shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
+              <HelpCircle size={28} strokeWidth={2.25} aria-hidden />
+            </span>
+            <span className="rounded-full border-2 border-gray-800 bg-[#fff8dc] px-3 py-0.5 text-[13px] font-extrabold tracking-wide text-gray-800">
+              あそびかた
+            </span>
           </button>
 
-          {/* タイトル */}
-          <h2 className="mb-6 text-center text-2xl font-black tracking-wide">
-            メニュー
-          </h2>
-
-          {/* 音量設定セクション */}
-          <div className="mb-6">
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <h3 className="flex items-center gap-2 text-lg font-bold">
-                <Volume2 className="h-5 w-5" />
-                音量設定
-              </h3>
-
-              {/* 即ミュートトグル */}
-              <button
-                onClick={toggleMute}
-                disabled={!isLoaded}
-                aria-pressed={muted}
-                className={`flex items-center gap-1.5 rounded-full border-2 border-black px-3 py-1 text-sm font-black shadow-[2px_2px_0_0_#000] transition active:translate-x-[1px] active:translate-y-[1px] active:shadow-none disabled:cursor-not-allowed disabled:opacity-50 ${
-                  muted
-                    ? 'bg-red-400 text-white'
-                    : 'bg-white text-black hover:bg-gray-100'
-                }`}
-              >
-                {muted ? (
-                  <VolumeX className="h-4 w-4" />
-                ) : (
-                  <Volume2 className="h-4 w-4" />
-                )}
-                {muted ? 'ミュート中' : 'ミュート'}
-              </button>
-            </div>
-
-            {/* BGM音量 */}
-            <div className="mb-4">
-              <label className="mb-1 block text-sm font-bold text-gray-700">
-                BGM
-              </label>
-              <div className="flex items-center gap-3">
-                <VolumeX className="h-4 w-4 flex-shrink-0 text-gray-400" />
-                <input
-                  type="range"
-                  min="0"
-                  max="100"
-                  value={bgmVolume}
-                  onChange={(e) => setBgmVolume(Number(e.target.value))}
-                  disabled={!isLoaded}
-                  className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-200 accent-black"
-                />
-                <Volume2 className="h-4 w-4 flex-shrink-0 text-gray-600" />
-              </div>
-            </div>
-
-            {/* SE音量 */}
-            <div className="mb-2">
-              <label className="mb-1 block text-sm font-bold text-gray-700">
-                効果音
-              </label>
-              <div className="flex items-center gap-3">
-                <VolumeX className="h-4 w-4 flex-shrink-0 text-gray-400" />
-                <input
-                  type="range"
-                  min="0"
-                  max="100"
-                  value={seVolume}
-                  onChange={(e) => setSeVolume(Number(e.target.value))}
-                  disabled={!isLoaded}
-                  className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-200 accent-black"
-                />
-                <Volume2 className="h-4 w-4 flex-shrink-0 text-gray-600" />
-              </div>
-            </div>
-          </div>
-
-          {/* 遊び方ボタン */}
           <button
-            onClick={() => setShowHowToPlay(true)}
-            className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-black bg-yellow-300 px-4 py-3 font-bold transition hover:bg-yellow-400"
+            type="button"
+            onClick={openVolume}
+            aria-label="おと"
+            className="flex flex-col items-center gap-1.5"
           >
-            <HelpCircle className="h-5 w-5" />
-            遊び方
+            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#FFD77B] text-gray-800 shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
+              <Volume2 size={28} strokeWidth={2.5} aria-hidden />
+            </span>
+            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
+              おと
+            </span>
           </button>
         </div>
+
+        {showExplosion && <SparklesExplosion />}
       </div>
 
-      {showHowToPlay && (
-        <HowToPlayModal onClose={() => setShowHowToPlay(false)} />
-      )}
+      <SlideModal
+        open={showHowToPlay}
+        onComplete={() => setShowHowToPlay(false)}
+        completeLabel="完了！"
+        ariaLabel="あそびかた 説明"
+        classNames={{
+          card: 'relative bg-white overflow-hidden [&>*]:relative [&>*]:z-10',
+        }}
+      >
+        {howToPlaySlides}
+      </SlideModal>
+
+      <VolumeModal open={showVolume} onClose={() => setShowVolume(false)} />
     </>
   );
 }

--- a/frontend/src/features/top/components/TopMenu.tsx
+++ b/frontend/src/features/top/components/TopMenu.tsx
@@ -64,10 +64,10 @@ export default function TopMenu() {
             aria-label="あそびかた"
             className="flex flex-col items-center gap-1.5"
           >
-            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#f1cf44] text-gray-900 shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
-              <HelpCircle size={28} strokeWidth={2.25} aria-hidden />
+            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#8EE3FA] text-white shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
+              <HelpCircle size={28} strokeWidth={2.5} aria-hidden />
             </span>
-            <span className="rounded-full border-2 border-gray-800 bg-[#fff8dc] px-3 py-0.5 text-[13px] font-extrabold tracking-wide text-gray-800">
+            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
               あそびかた
             </span>
           </button>

--- a/frontend/src/features/top/components/TopMenu.tsx
+++ b/frontend/src/features/top/components/TopMenu.tsx
@@ -1,110 +1,176 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { Volume2, VolumeX, HelpCircle, X } from 'lucide-react';
 import { useState } from 'react';
-import { HelpCircle, Volume2 } from 'lucide-react';
-import { howToPlaySlides } from '@/features/top/components/HowToPlayModal';
-import SlideModal from '@/components/common/SlideModal';
-import { useSe } from '@/components/audio/useSe';
-import SparklesExplosion from './SparklesExplosion';
-import VolumeModal from './VolumeModal';
+import { useAudioSettings } from '@/features/audio/hooks/useAudioSettings';
+import HowToPlayModal from './HowToPlayModal';
+
+interface TopMenuProps {
+  /** メニューを閉じるコールバック */
+  onClose: () => void;
+}
+
+/** ミュート解除時に復元する音量の退避先（localStorage キー） */
+const MUTE_BACKUP_KEY = 'realyou_premute_volumes';
+/** 退避値が無い場合に復元するデフォルト音量 */
+const FALLBACK_VOLUME = 50;
 
 /**
- * トップ画面のインタラクティブ部分（スタート / あそびかた / おとボタン・爆発演出・
- * あそびかた / 音量モーダル）。クリック操作と状態を持つためここだけ Client Component。
- * 静的な背景・ロゴ・装飾は page.tsx（Server Component）側が描画する。
+ * トップページのメニューモーダル。
+ * 音量設定（BGM/SE）と遊び方の確認ができる。
  */
-export default function TopMenu() {
-  const router = useRouter();
-  const playSe = useSe();
-  const [showExplosion, setShowExplosion] = useState(false);
+export default function TopMenu({ onClose }: TopMenuProps) {
+  const { bgmVolume, seVolume, setBgmVolume, setSeVolume, isLoaded } =
+    useAudioSettings();
   const [showHowToPlay, setShowHowToPlay] = useState(false);
-  const [showVolume, setShowVolume] = useState(false);
 
-  const handleStartClick = () => {
-    setShowExplosion(true);
-    playSe('start');
+  // BGM・SE がどちらも 0 のときをミュート状態とみなす
+  const muted = isLoaded && bgmVolume === 0 && seVolume === 0;
 
-    setTimeout(() => {
-      router.push('/games/terms');
-    }, 800);
-
-    setTimeout(() => {
-      setShowExplosion(false);
-    }, 800);
-  };
-
-  const openHowToPlay = () => {
-    playSe('buttonClick');
-    setShowHowToPlay(true);
-  };
-
-  const openVolume = () => {
-    playSe('buttonClick');
-    setShowVolume(true);
+  /**
+   * 即ミュート切り替え。
+   * - ミュート時：現在の音量を localStorage に退避してから両方 0 にする
+   * - 解除時：退避値（無ければ既定値）へ復元する
+   * 退避先を localStorage にすることで、モーダルを閉じ直しても復元できる。
+   */
+  const toggleMute = () => {
+    if (muted) {
+      let restore = { bgm: FALLBACK_VOLUME, se: FALLBACK_VOLUME };
+      try {
+        const raw = localStorage.getItem(MUTE_BACKUP_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw) as { bgm?: number; se?: number };
+          restore = {
+            bgm: typeof parsed.bgm === 'number' ? parsed.bgm : FALLBACK_VOLUME,
+            se: typeof parsed.se === 'number' ? parsed.se : FALLBACK_VOLUME,
+          };
+        }
+      } catch {
+        // 読み込み失敗時は既定値で復元
+      }
+      setBgmVolume(restore.bgm > 0 ? restore.bgm : FALLBACK_VOLUME);
+      setSeVolume(restore.se > 0 ? restore.se : FALLBACK_VOLUME);
+    } else {
+      try {
+        localStorage.setItem(
+          MUTE_BACKUP_KEY,
+          JSON.stringify({ bgm: bgmVolume, se: seVolume })
+        );
+      } catch {
+        // 退避失敗しても 0 にはする
+      }
+      setBgmVolume(0);
+      setSeVolume(0);
+    }
   };
 
   return (
     <>
-      <div className="relative flex flex-col items-center gap-4">
-        {/* スタート（主役の rose pill） */}
-        <button
-          type="button"
-          onClick={handleStartClick}
-          className="w-[80vw] max-w-xs min-w-[200px] rounded-full border-4 border-gray-800 bg-gradient-to-br from-rose-400 to-rose-500 py-4 text-[28px] font-black text-white shadow-[0_7px_0_#1f2937] transition-transform hover:-translate-y-0.5 active:translate-y-[5px] active:shadow-[0_2px_0_#1f2937]"
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        onClick={onClose}
+      >
+        <div
+          className="relative w-full max-w-md rounded-3xl border-4 border-black bg-white p-6 shadow-[8px_8px_0_0_#000]"
+          onClick={(e) => e.stopPropagation()}
         >
-          スタート ▶
-        </button>
-
-        {/* あそびかた / おと（丸アイコン＋ラベル） */}
-        <div className="flex gap-7">
+          {/* 閉じるボタン */}
           <button
-            type="button"
-            onClick={openHowToPlay}
-            aria-label="あそびかた"
-            className="flex flex-col items-center gap-1.5"
+            onClick={onClose}
+            className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full border-2 border-black bg-white transition hover:bg-gray-100"
+            aria-label="閉じる"
           >
-            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#8EE3FA] text-white shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
-              <HelpCircle size={28} strokeWidth={2.5} aria-hidden />
-            </span>
-            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
-              あそびかた
-            </span>
+            <X className="h-5 w-5" />
           </button>
 
+          {/* タイトル */}
+          <h2 className="mb-6 text-center text-2xl font-black tracking-wide">
+            メニュー
+          </h2>
+
+          {/* 音量設定セクション */}
+          <div className="mb-6">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="flex items-center gap-2 text-lg font-bold">
+                <Volume2 className="h-5 w-5" />
+                音量設定
+              </h3>
+
+              {/* 即ミュートトグル */}
+              <button
+                onClick={toggleMute}
+                disabled={!isLoaded}
+                aria-pressed={muted}
+                className={`flex items-center gap-1.5 rounded-full border-2 border-black px-3 py-1 text-sm font-black shadow-[2px_2px_0_0_#000] transition active:translate-x-[1px] active:translate-y-[1px] active:shadow-none disabled:cursor-not-allowed disabled:opacity-50 ${
+                  muted
+                    ? 'bg-red-400 text-white'
+                    : 'bg-white text-black hover:bg-gray-100'
+                }`}
+              >
+                {muted ? (
+                  <VolumeX className="h-4 w-4" />
+                ) : (
+                  <Volume2 className="h-4 w-4" />
+                )}
+                {muted ? 'ミュート中' : 'ミュート'}
+              </button>
+            </div>
+
+            {/* BGM音量 */}
+            <div className="mb-4">
+              <label className="mb-1 block text-sm font-bold text-gray-700">
+                BGM
+              </label>
+              <div className="flex items-center gap-3">
+                <VolumeX className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={bgmVolume}
+                  onChange={(e) => setBgmVolume(Number(e.target.value))}
+                  disabled={!isLoaded}
+                  className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-200 accent-black"
+                />
+                <Volume2 className="h-4 w-4 flex-shrink-0 text-gray-600" />
+              </div>
+            </div>
+
+            {/* SE音量 */}
+            <div className="mb-2">
+              <label className="mb-1 block text-sm font-bold text-gray-700">
+                効果音
+              </label>
+              <div className="flex items-center gap-3">
+                <VolumeX className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={seVolume}
+                  onChange={(e) => setSeVolume(Number(e.target.value))}
+                  disabled={!isLoaded}
+                  className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-200 accent-black"
+                />
+                <Volume2 className="h-4 w-4 flex-shrink-0 text-gray-600" />
+              </div>
+            </div>
+          </div>
+
+          {/* 遊び方ボタン */}
           <button
-            type="button"
-            onClick={openVolume}
-            aria-label="おと"
-            className="flex flex-col items-center gap-1.5"
+            onClick={() => setShowHowToPlay(true)}
+            className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-black bg-yellow-300 px-4 py-3 font-bold transition hover:bg-yellow-400"
           >
-            <span className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-gray-800 bg-[#FFD77B] text-gray-800 shadow-[0_5px_0_#1f2937] transition-transform active:translate-y-[3px] active:shadow-[0_2px_0_#1f2937]">
-              <Volume2 size={28} strokeWidth={2.5} aria-hidden />
-            </span>
-            <span className="rounded-full border-2 border-gray-800 bg-white px-2.5 py-px text-[13px] font-black text-gray-900">
-              おと
-            </span>
+            <HelpCircle className="h-5 w-5" />
+            遊び方
           </button>
         </div>
-
-        {showExplosion && <SparklesExplosion />}
       </div>
 
-      {/* SlideModal に children 配列を渡す（SlideModal が children 配列を受け取る実装の前提） */}
-      <SlideModal
-        open={showHowToPlay}
-        onComplete={() => setShowHowToPlay(false)}
-        completeLabel="完了！"
-        ariaLabel="あそびかた 説明"
-        classNames={{
-          // 背景画像をカード内に収める（切れないように contain 指定、真ん中に）
-          card: 'relative bg-white overflow-hidden [&>*]:relative [&>*]:z-10',
-        }}
-      >
-        {howToPlaySlides}
-      </SlideModal>
-
-      <VolumeModal open={showVolume} onClose={() => setShowVolume(false)} />
+      {showHowToPlay && (
+        <HowToPlayModal onClose={() => setShowHowToPlay(false)} />
+      )}
     </>
   );
 }

--- a/frontend/src/features/top/components/VolumeModal.tsx
+++ b/frontend/src/features/top/components/VolumeModal.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
+import { Volume2, VolumeX } from 'lucide-react';
 import { VolumeControl } from '@/components/audio/VolumeControl';
+import { useVolumeMute } from '@/components/audio/useVolumeMute';
 
 type VolumeModalProps = {
   open: boolean;
@@ -13,6 +15,8 @@ type VolumeModalProps = {
  * オーバーレイのクリック / 「とじる」で閉じる。中身は共通の VolumeControl。
  */
 export default function VolumeModal({ open, onClose }: VolumeModalProps) {
+  const { muted, toggleMute } = useVolumeMute();
+
   return (
     <AnimatePresence>
       {open && (
@@ -35,13 +39,32 @@ export default function VolumeModal({ open, onClose }: VolumeModalProps) {
             transition={{ duration: 0.2 }}
             onClick={(e) => e.stopPropagation()}
           >
-            {/* タイトル pill（カード上端にかぶせる） */}
             <div className="absolute -top-6 left-1/2 -translate-x-1/2">
               <div className="rounded-full border-4 border-gray-800 bg-[#FFD77B] px-8 py-2 shadow-[0_4px_0_#1f2937]">
                 <p className="text-xl font-black whitespace-nowrap text-gray-900">
                   おとのせってい
                 </p>
               </div>
+            </div>
+
+            <div className="mb-4 flex items-center justify-end">
+              <button
+                type="button"
+                onClick={toggleMute}
+                aria-pressed={muted}
+                className={`flex items-center gap-1.5 rounded-full border-[3px] border-gray-800 px-3 py-1.5 text-sm font-black shadow-[2px_2px_0_#1f2937] transition-transform hover:-translate-y-0.5 active:translate-y-0 active:shadow-none ${
+                  muted
+                    ? 'bg-rose-400 text-white'
+                    : 'bg-white text-gray-900 hover:bg-gray-50'
+                }`}
+              >
+                {muted ? (
+                  <VolumeX size={16} aria-hidden />
+                ) : (
+                  <Volume2 size={16} aria-hidden />
+                )}
+                {muted ? 'ミュート中' : 'ミュート'}
+              </button>
             </div>
 
             <div className="mb-7">


### PR DESCRIPTION
## Summary

トップ画面の音量設定と「あそびかた」モーダルの UX・見た目を整えた PR です。誤って壊れていた `TopMenu` のビルドエラーも解消しています。

## 変更点

### おとのせってい（音量モーダル）
- 「おと」から開くモーダル右上に **即ミュート** ボタンを追加
- 押下で BGM / SE を同時に 0、解除時はミュート前の音量を `localStorage` から復元（`useVolumeMute` + 既存の jotai atom）
- ミュート中はボタンがローズ系で状態が分かる

### あそびかたボタン（トップ下部）
- アイコンを黄（`#f1cf44`）、ラベルをクリーム背景＋`font-extrabold` に変更し、他ボタンとの差別化と雰囲気を調整

### あそびかたスライド（3枚）
- マゼンタ fill / 黄色マーカー / 黄背景ステッカー / 下線バーを廃止
- 強調は **ローズ色＋文字サイズアップのみ**（1枚目「本当のあなた」、3枚目「本当の自分」はやや大きめ）
- 見出し・本文は `font-black` / `text-gray-800` で他 UI と統一
- 2枚目のずれた黄色ハイライトは削除（「5」だけサイズで強調）

### ビルド修正
- 存在しない `@/features/audio/hooks/useAudioSettings` 参照をやめ、`TopMenu` をスタート / あそびかた / おと構成に復元

## Test plan

- [ ] トップで「おと」→ スライダー調整・即ミュート ON/OFF（リロード後も復元）
- [ ] 「あそびかた」3スライド：強調テキストが背景なしで読みやすいこと
- [ ] 「スタート ▶」からゲーム開始まで問題ないこと
- [ ] `npm run build` が通ること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ボリューム設定画面にミュート切り替えボタンを追加しました。BGM と効果音を一括でミュート/ミュート解除できるようになります。モーダルを閉じずに操作可能です。

* **Style**
  * 「あそびかた」ボタンのアイコンデザインと背景色の見た目を更新しました。
  * チュートリアルスライドのテキスト装飾と全体的な視覚的レイアウトを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Koseeee-27/real-you/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->